### PR TITLE
Fix/100, 98, 78

### DIFF
--- a/src/define-xml/define.json
+++ b/src/define-xml/define.json
@@ -1,0 +1,14638 @@
+{
+  "OID": "MDV.LZZT - NEW.Version1.Design1",
+  "name": "MDV LZZT - NEW",
+  "description": "Data Definitions for LZZT - NEW",
+  "fileOID": "ODM.DEFINE-JSON.LZZT - NEW.Version1.Design1",
+  "creationDateTime": "2026-04-05T22:02:46.565392+00:00",
+  "odmVersion": "1.3.2",
+  "fileType": "Snapshot",
+  "originator": "Define-JSON Processor",
+  "context": "Other",
+  "defineVersion": "2.1.0",
+  "studyOID": "ODM.LZZT - NEW.Version1.Design1",
+  "studyName": "LZZT - NEW",
+  "studyDescription": "Safety and Efficacy of the Xanomeline Transdermal Therapeutic System (TTS) in Patients with Mild to Moderate Alzheimer's Disease",
+  "protocolName": "LZZT - NEW",
+  "itemGroups": [
+    {
+      "OID": "IG.DS",
+      "name": "DS",
+      "description": "Disposition",
+      "domain": "DS",
+      "purpose": "Tabulation",
+      "structure": "One record per disposition status or protocol milestone per subject",
+      "isReferenceData": false,
+      "keySequence": [
+        "__PLACEHOLDER__"
+      ],
+      "standard": "STD.SDTMIG",
+      "observationClass": {
+        "name": "EVENTS"
+      },
+      "items": [
+        {
+          "OID": "IT.DS.STUDYID",
+          "mandatory": true,
+          "name": "STUDYID",
+          "description": "Study Identifier",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.DS.DOMAIN",
+          "mandatory": true,
+          "name": "DOMAIN",
+          "description": "Domain Abbreviation",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.DS.USUBJID",
+          "mandatory": true,
+          "name": "USUBJID",
+          "description": "Unique Subject Identifier",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.DS.DSSEQ",
+          "mandatory": true,
+          "name": "DSSEQ",
+          "description": "Sequence Number",
+          "role": "Identifier",
+          "dataType": "integer",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.DS.DSTERM",
+          "mandatory": true,
+          "name": "DSTERM",
+          "description": "Reported Term for the Disposition Event",
+          "role": "Topic",
+          "dataType": "text",
+          "length": 200,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          }
+        },
+        {
+          "OID": "IT.DS.DSDECOD",
+          "mandatory": true,
+          "name": "DSDECOD",
+          "description": "Standardized Disposition Term",
+          "role": "Synonym Qualifier",
+          "dataType": "text",
+          "length": 200,
+          "origin": {
+            "type": "Assigned",
+            "source": "Sponsor"
+          },
+          "codeList": "CL.NCOMPLT"
+        },
+        {
+          "OID": "IT.DS.DSCAT",
+          "mandatory": false,
+          "name": "DSCAT",
+          "description": "Category for Disposition Event",
+          "role": "Grouping Qualifier",
+          "dataType": "text",
+          "length": 200,
+          "origin": {
+            "type": "Assigned",
+            "source": "Sponsor"
+          },
+          "codeList": "CL.DSCAT"
+        },
+        {
+          "OID": "IT.DS.DSSCAT",
+          "mandatory": false,
+          "name": "DSSCAT",
+          "description": "Subcategory for Disposition Event",
+          "role": "Grouping Qualifier",
+          "dataType": "text",
+          "length": 200,
+          "origin": {
+            "type": "Assigned",
+            "source": "Sponsor"
+          },
+          "codeList": "CL.DSSCAT"
+        },
+        {
+          "OID": "IT.DS.DSSTDTC",
+          "mandatory": false,
+          "name": "DSSTDTC",
+          "description": "Start Date/Time of Disposition Event",
+          "role": "Timing",
+          "dataType": "datetime",
+          "length": null,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          }
+        },
+        {
+          "OID": "IT.DS.DSSTDY",
+          "mandatory": false,
+          "name": "DSSTDY",
+          "description": "Study Day of Start of Disposition Event",
+          "role": "Timing",
+          "dataType": "integer",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        }
+      ]
+    },
+    {
+      "OID": "IG.DM",
+      "name": "DM",
+      "description": "Demographics",
+      "domain": "DM",
+      "purpose": "Tabulation",
+      "structure": "One record per subject",
+      "isReferenceData": false,
+      "keySequence": [
+        "__PLACEHOLDER__"
+      ],
+      "standard": "STD.SDTMIG",
+      "observationClass": {
+        "name": "SPECIAL-PURPOSE"
+      },
+      "items": [
+        {
+          "OID": "IT.DM.STUDYID",
+          "mandatory": true,
+          "name": "STUDYID",
+          "description": "Study Identifier",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.DM.DOMAIN",
+          "mandatory": true,
+          "name": "DOMAIN",
+          "description": "Domain Abbreviation",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.DM.USUBJID",
+          "mandatory": true,
+          "name": "USUBJID",
+          "description": "Unique Subject Identifier",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.DM.SUBJID",
+          "mandatory": true,
+          "name": "SUBJID",
+          "description": "Subject Identifier for the Study",
+          "role": "Topic",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.DM.RFSTDTC",
+          "mandatory": false,
+          "name": "RFSTDTC",
+          "description": "Subject Reference Start Date/Time",
+          "role": "Record Qualifier",
+          "dataType": "datetime",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.DM.RFENDTC",
+          "mandatory": false,
+          "name": "RFENDTC",
+          "description": "Subject Reference End Date/Time",
+          "role": "Record Qualifier",
+          "dataType": "datetime",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.DM.RFXSTDTC",
+          "mandatory": false,
+          "name": "RFXSTDTC",
+          "description": "Date/Time of First Study Treatment",
+          "role": "Record Qualifier",
+          "dataType": "datetime",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.DM.RFXENDTC",
+          "mandatory": false,
+          "name": "RFXENDTC",
+          "description": "Date/Time of Last Study Treatment",
+          "role": "Record Qualifier",
+          "dataType": "datetime",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.DM.RFICDTC",
+          "mandatory": false,
+          "name": "RFICDTC",
+          "description": "Date/Time of Informed Consent",
+          "role": "Record Qualifier",
+          "dataType": "datetime",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.DM.RFPENDTC",
+          "mandatory": false,
+          "name": "RFPENDTC",
+          "description": "Date/Time of End of Participation",
+          "role": "Record Qualifier",
+          "dataType": "datetime",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.DM.DTHDTC",
+          "mandatory": false,
+          "name": "DTHDTC",
+          "description": "Date/Time of Death",
+          "role": "Record Qualifier",
+          "dataType": "datetime",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.DM.DTHFL",
+          "mandatory": false,
+          "name": "DTHFL",
+          "description": "Subject Death Flag",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.NY"
+        },
+        {
+          "OID": "IT.DM.SITEID",
+          "mandatory": true,
+          "name": "SITEID",
+          "description": "Study Site Identifier",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.DM.AGE",
+          "mandatory": false,
+          "name": "AGE",
+          "description": "Age",
+          "role": "Record Qualifier",
+          "dataType": "float",
+          "length": 6,
+          "displayFormat": "3.2",
+          "significantDigits": 2,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          }
+        },
+        {
+          "OID": "IT.DM.AGEU",
+          "mandatory": false,
+          "name": "AGEU",
+          "description": "Age Units",
+          "role": "Variable Qualifier",
+          "dataType": "text",
+          "length": 20,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          },
+          "codeList": "CL.AGEU"
+        },
+        {
+          "OID": "IT.DM.SEX",
+          "mandatory": true,
+          "name": "SEX",
+          "description": "Sex",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": 100,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          },
+          "codeList": "CL.SEX"
+        },
+        {
+          "OID": "IT.DM.RACE",
+          "mandatory": false,
+          "name": "RACE",
+          "description": "Race",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": 100,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          },
+          "codeList": "CL.RACE"
+        },
+        {
+          "OID": "IT.DM.ETHNIC",
+          "mandatory": false,
+          "name": "ETHNIC",
+          "description": "Ethnicity",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": 100,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          },
+          "codeList": "CL.ETHNIC"
+        },
+        {
+          "OID": "IT.DM.ARMCD",
+          "mandatory": false,
+          "name": "ARMCD",
+          "description": "Planned Arm Code",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.DM.ARM",
+          "mandatory": false,
+          "name": "ARM",
+          "description": "Description of Planned Arm",
+          "role": "Synonym Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.DM.ACTARMCD",
+          "mandatory": false,
+          "name": "ACTARMCD",
+          "description": "Actual Arm Code",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.DM.ACTARM",
+          "mandatory": false,
+          "name": "ACTARM",
+          "description": "Description of Actual Arm",
+          "role": "Synonym Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.DM.ARMNRS",
+          "mandatory": false,
+          "name": "ARMNRS",
+          "description": "Reason Arm and/or Actual Arm is Null",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.ARMNULRS"
+        },
+        {
+          "OID": "IT.DM.ACTARMUD",
+          "mandatory": false,
+          "name": "ACTARMUD",
+          "description": "Description of Unplanned Actual Arm",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.DM.COUNTRY",
+          "mandatory": true,
+          "name": "COUNTRY",
+          "description": "Country",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.DM.DMDTC",
+          "mandatory": false,
+          "name": "DMDTC",
+          "description": "Date/Time of Collection",
+          "role": "Timing",
+          "dataType": "datetime",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        }
+      ]
+    },
+    {
+      "OID": "IG.SC",
+      "name": "SC",
+      "description": "Subject Characteristics",
+      "domain": "SC",
+      "purpose": "Tabulation",
+      "structure": "One record per characteristic per visit per subject.",
+      "isReferenceData": false,
+      "keySequence": [
+        "__PLACEHOLDER__"
+      ],
+      "standard": "STD.SDTMIG",
+      "observationClass": {
+        "name": "FINDINGS"
+      },
+      "items": [
+        {
+          "OID": "IT.SC.STUDYID",
+          "mandatory": true,
+          "name": "STUDYID",
+          "description": "Study Identifier",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.SC.DOMAIN",
+          "mandatory": true,
+          "name": "DOMAIN",
+          "description": "Domain Abbreviation",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.SC.USUBJID",
+          "mandatory": true,
+          "name": "USUBJID",
+          "description": "Unique Subject Identifier",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.SC.SCSEQ",
+          "mandatory": true,
+          "name": "SCSEQ",
+          "description": "Sequence Number",
+          "role": "Identifier",
+          "dataType": "integer",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.SC.SCTESTCD",
+          "mandatory": true,
+          "name": "SCTESTCD",
+          "description": "Subject Characteristic Short Name",
+          "role": "Topic",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.SCTESTCD"
+        },
+        {
+          "OID": "IT.SC.SCTEST",
+          "mandatory": true,
+          "name": "SCTEST",
+          "description": "Subject Characteristic",
+          "role": "Synonym Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.SCTEST"
+        },
+        {
+          "OID": "IT.SC.SCORRES",
+          "mandatory": false,
+          "name": "SCORRES",
+          "description": "Result or Finding in Original Units",
+          "role": "Result Qualifier",
+          "dataType": "text",
+          "length": 100,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          }
+        },
+        {
+          "OID": "IT.SC.SCORRESU",
+          "mandatory": false,
+          "name": "SCORRESU",
+          "description": "Original Units",
+          "role": "Variable Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.UNIT"
+        },
+        {
+          "OID": "IT.SC.SCSTRESC",
+          "mandatory": false,
+          "name": "SCSTRESC",
+          "description": "Character Result/Finding in Std Format",
+          "role": "Result Qualifier",
+          "dataType": "text",
+          "length": 100,
+          "origin": {
+            "type": "Assigned",
+            "source": "Sponsor"
+          }
+        },
+        {
+          "OID": "IT.SC.SCSTRESN",
+          "mandatory": false,
+          "name": "SCSTRESN",
+          "description": "Numeric Result/Finding in Standard Units",
+          "role": "Result Qualifier",
+          "dataType": "text",
+          "length": 100,
+          "origin": {
+            "type": "Assigned",
+            "source": "Sponsor"
+          }
+        },
+        {
+          "OID": "IT.SC.SCSTRESU",
+          "mandatory": false,
+          "name": "SCSTRESU",
+          "description": "Standard Units",
+          "role": "Variable Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.UNIT"
+        },
+        {
+          "OID": "IT.SC.SCDTC",
+          "mandatory": false,
+          "name": "SCDTC",
+          "description": "Date/Time of Collection",
+          "role": "Timing",
+          "dataType": "datetime",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        }
+      ],
+      "slices": [
+        {
+          "OID": "VL.SC.SCORRES",
+          "name": "VL_SC_SCORRES",
+          "type": "ValueList",
+          "wasDerivedFrom": "IT.SC.SCORRES",
+          "items": [
+            {
+              "OID": "IT.SC.SCORRES.EDULEVEL",
+              "mandatory": false,
+              "name": "SCORRES",
+              "dataType": "float",
+              "length": 4,
+              "displayFormat": "3.1",
+              "significantDigits": 1,
+              "origin": {
+                "type": "Collected",
+                "source": "Investigator"
+              },
+              "applicableWhen": [
+                "WC.SC.48924878"
+              ]
+            },
+            {
+              "OID": "IT.SC.SCORRES.EDUYRNUM",
+              "mandatory": false,
+              "name": "SCORRES",
+              "dataType": "float",
+              "length": 4,
+              "displayFormat": "3.1",
+              "significantDigits": 1,
+              "origin": {
+                "type": "Collected",
+                "source": "Investigator"
+              },
+              "applicableWhen": [
+                "WC.SC.e7173a71"
+              ]
+            }
+          ]
+        },
+        {
+          "OID": "VL.SC.SCORRESU",
+          "name": "VL_SC_SCORRESU",
+          "type": "ValueList",
+          "wasDerivedFrom": "IT.SC.SCORRESU",
+          "items": [
+            {
+              "OID": "IT.SC.SCORRESU.EDUYRNUM",
+              "mandatory": false,
+              "name": "SCORRESU",
+              "dataType": "text",
+              "applicableWhen": [
+                "WC.SC.5fc4562e"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "OID": "IG.MH",
+      "name": "MH",
+      "description": "Medical History",
+      "domain": "MH",
+      "purpose": "Tabulation",
+      "structure": "One record per medical history event per subject",
+      "isReferenceData": false,
+      "keySequence": [
+        "__PLACEHOLDER__"
+      ],
+      "standard": "STD.SDTMIG",
+      "observationClass": {
+        "name": "EVENTS"
+      },
+      "items": [
+        {
+          "OID": "IT.MH.STUDYID",
+          "mandatory": true,
+          "name": "STUDYID",
+          "description": "Study Identifier",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.MH.DOMAIN",
+          "mandatory": true,
+          "name": "DOMAIN",
+          "description": "Domain Abbreviation",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.MH.USUBJID",
+          "mandatory": true,
+          "name": "USUBJID",
+          "description": "Unique Subject Identifier",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.MH.MHSEQ",
+          "mandatory": true,
+          "name": "MHSEQ",
+          "description": "Sequence Number",
+          "role": "Identifier",
+          "dataType": "integer",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.MH.MHTERM",
+          "mandatory": true,
+          "name": "MHTERM",
+          "description": "Reported Term for the Medical History",
+          "role": "Topic",
+          "dataType": "text",
+          "length": 200,
+          "origin": {
+            "type": "Assigned",
+            "source": "Sponsor"
+          }
+        },
+        {
+          "OID": "IT.MH.MHDECOD",
+          "mandatory": false,
+          "name": "MHDECOD",
+          "description": "Dictionary-Derived Term",
+          "role": "Synonym Qualifier",
+          "dataType": "text",
+          "length": 200,
+          "origin": {
+            "type": "Assigned",
+            "source": "Sponsor"
+          }
+        },
+        {
+          "OID": "IT.MH.MHPRESP",
+          "mandatory": false,
+          "name": "MHPRESP",
+          "description": "Medical History Event Pre-Specified",
+          "role": "Variable Qualifier",
+          "dataType": "text",
+          "length": 1,
+          "origin": {
+            "type": "Assigned",
+            "source": "Sponsor"
+          },
+          "codeList": "CL.NY"
+        },
+        {
+          "OID": "IT.MH.MHOCCUR",
+          "mandatory": false,
+          "name": "MHOCCUR",
+          "description": "Medical History Occurrence",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": 1,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          },
+          "codeList": "CL.NY"
+        },
+        {
+          "OID": "IT.MH.MHENRF",
+          "mandatory": false,
+          "name": "MHENRF",
+          "description": "End Relative to Reference Period",
+          "role": "Timing",
+          "dataType": "text",
+          "length": 20,
+          "origin": {
+            "type": "Assigned",
+            "source": "Sponsor"
+          },
+          "codeList": "CL.STENRF"
+        },
+        {
+          "OID": "IT.MH.MHENRTPT",
+          "mandatory": false,
+          "name": "MHENRTPT",
+          "description": "End Relative to Reference Time Point",
+          "role": "Timing",
+          "dataType": "text",
+          "length": 20,
+          "origin": {
+            "type": "Assigned",
+            "source": "Sponsor"
+          },
+          "codeList": "CL.STENRF"
+        },
+        {
+          "OID": "IT.MH.MHENTPT",
+          "mandatory": false,
+          "name": "MHENTPT",
+          "description": "End Reference Time Point",
+          "role": "Timing",
+          "dataType": "text",
+          "length": 20,
+          "origin": {
+            "type": "Assigned",
+            "source": "Sponsor"
+          }
+        }
+      ]
+    },
+    {
+      "OID": "IG.SU",
+      "name": "SU",
+      "description": "Substance Use",
+      "domain": "SU",
+      "purpose": "Tabulation",
+      "structure": "One record per substance type per reported occurrence per subject",
+      "isReferenceData": false,
+      "keySequence": [
+        "__PLACEHOLDER__"
+      ],
+      "standard": "STD.SDTMIG",
+      "observationClass": {
+        "name": "INTERVENTIONS"
+      },
+      "items": [
+        {
+          "OID": "IT.SU.STUDYID",
+          "mandatory": true,
+          "name": "STUDYID",
+          "description": "Study Identifier",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.SU.DOMAIN",
+          "mandatory": true,
+          "name": "DOMAIN",
+          "description": "Domain Abbreviation",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.SU.USUBJID",
+          "mandatory": true,
+          "name": "USUBJID",
+          "description": "Unique Subject Identifier",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.SU.SUSEQ",
+          "mandatory": true,
+          "name": "SUSEQ",
+          "description": "Sequence Number",
+          "role": "Identifier",
+          "dataType": "integer",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.SU.SUTRT",
+          "mandatory": true,
+          "name": "SUTRT",
+          "description": "Reported Name of Substance",
+          "role": "Topic",
+          "dataType": "text",
+          "length": 200,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          }
+        },
+        {
+          "OID": "IT.SU.SUCAT",
+          "mandatory": false,
+          "name": "SUCAT",
+          "description": "Category for Substance Use",
+          "role": "Grouping Qualifier",
+          "dataType": "text",
+          "length": 200,
+          "origin": {
+            "type": "Assigned",
+            "source": "Sponsor"
+          }
+        },
+        {
+          "OID": "IT.SU.SUSCAT",
+          "mandatory": false,
+          "name": "SUSCAT",
+          "description": "Subcategory for Substance Use",
+          "role": "Grouping Qualifier",
+          "dataType": "text",
+          "length": 200,
+          "origin": {
+            "type": "Assigned",
+            "source": "Sponsor"
+          }
+        },
+        {
+          "OID": "IT.SU.SUPRESP",
+          "mandatory": false,
+          "name": "SUPRESP",
+          "description": "SU Pre-Specified",
+          "role": "Variable Qualifier",
+          "dataType": "text",
+          "length": 1,
+          "origin": {
+            "type": "Assigned",
+            "source": "Sponsor"
+          },
+          "codeList": "CL.NY"
+        },
+        {
+          "OID": "IT.SU.SUOCCUR",
+          "mandatory": false,
+          "name": "SUOCCUR",
+          "description": "SU Occurrence",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": 1,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          },
+          "codeList": "CL.NY"
+        },
+        {
+          "OID": "IT.SU.SUDOSE",
+          "mandatory": false,
+          "name": "SUDOSE",
+          "description": "Substance Use Consumption",
+          "role": "Record Qualifier",
+          "dataType": "float",
+          "length": 12,
+          "displayFormat": "12.4",
+          "significantDigits": 4,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          }
+        },
+        {
+          "OID": "IT.SU.SUDOSTXT",
+          "mandatory": false,
+          "name": "SUDOSTXT",
+          "description": "Substance Use Consumption Text",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": 40,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          }
+        },
+        {
+          "OID": "IT.SU.SUDOSU",
+          "mandatory": false,
+          "name": "SUDOSU",
+          "description": "Consumption Units",
+          "role": "Variable Qualifier",
+          "dataType": "text",
+          "length": 40,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          },
+          "codeList": "CL.UNIT"
+        },
+        {
+          "OID": "IT.SU.SUDOSFRQ",
+          "mandatory": false,
+          "name": "SUDOSFRQ",
+          "description": "Use Frequency Per Interval",
+          "role": "Variable Qualifier",
+          "dataType": "text",
+          "length": 40,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          },
+          "codeList": "CL.FREQ"
+        },
+        {
+          "OID": "IT.SU.SUSTDTC",
+          "mandatory": false,
+          "name": "SUSTDTC",
+          "description": "Start Date/Time of Substance Use",
+          "role": "Timing",
+          "dataType": "datetime",
+          "length": null,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          }
+        },
+        {
+          "OID": "IT.SU.SUENDTC",
+          "mandatory": false,
+          "name": "SUENDTC",
+          "description": "End Date/Time of Substance Use",
+          "role": "Timing",
+          "dataType": "datetime",
+          "length": null,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          }
+        },
+        {
+          "OID": "IT.SU.SUDUR",
+          "mandatory": false,
+          "name": "SUDUR",
+          "description": "Duration of Substance Use",
+          "role": "Timing",
+          "dataType": "durationDatetime",
+          "length": null,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          }
+        },
+        {
+          "OID": "IT.SU.SUSTRF",
+          "mandatory": false,
+          "name": "SUSTRF",
+          "description": "Start Relative to Reference Period",
+          "role": "Timing",
+          "dataType": "text",
+          "length": 20,
+          "origin": {
+            "type": "Assigned",
+            "source": "Sponsor"
+          },
+          "codeList": "CL.STENRF"
+        },
+        {
+          "OID": "IT.SU.SUENRF",
+          "mandatory": false,
+          "name": "SUENRF",
+          "description": "End Relative to Reference Period",
+          "role": "Timing",
+          "dataType": "text",
+          "length": 20,
+          "origin": {
+            "type": "Assigned",
+            "source": "Sponsor"
+          },
+          "codeList": "CL.STENRF"
+        },
+        {
+          "OID": "IT.SU.SUSTRTPT",
+          "mandatory": false,
+          "name": "SUSTRTPT",
+          "description": "Start Relative to Reference Time Point",
+          "role": "Timing",
+          "dataType": "text",
+          "length": 20,
+          "origin": {
+            "type": "Assigned",
+            "source": "Sponsor"
+          },
+          "codeList": "CL.STENRF"
+        },
+        {
+          "OID": "IT.SU.SUSTTPT",
+          "mandatory": false,
+          "name": "SUSTTPT",
+          "description": "Start Reference Time Point",
+          "role": "Timing",
+          "dataType": "text",
+          "length": 20,
+          "origin": {
+            "type": "Assigned",
+            "source": "Sponsor"
+          }
+        },
+        {
+          "OID": "IT.SU.SUENRTPT",
+          "mandatory": false,
+          "name": "SUENRTPT",
+          "description": "End Relative to Reference Time Point",
+          "role": "Timing",
+          "dataType": "text",
+          "length": 20,
+          "origin": {
+            "type": "Assigned",
+            "source": "Sponsor"
+          },
+          "codeList": "CL.STENRF"
+        },
+        {
+          "OID": "IT.SU.SUENTPT",
+          "mandatory": false,
+          "name": "SUENTPT",
+          "description": "End Reference Time Point",
+          "role": "Timing",
+          "dataType": "text",
+          "length": 20,
+          "origin": {
+            "type": "Assigned",
+            "source": "Sponsor"
+          }
+        }
+      ]
+    },
+    {
+      "OID": "IG.PR",
+      "name": "PR",
+      "description": "Procedures",
+      "domain": "PR",
+      "purpose": "Tabulation",
+      "structure": "One record per recorded procedure per occurrence per subject",
+      "isReferenceData": false,
+      "keySequence": [
+        "__PLACEHOLDER__"
+      ],
+      "standard": "STD.SDTMIG",
+      "observationClass": {
+        "name": "INTERVENTIONS"
+      },
+      "items": [
+        {
+          "OID": "IT.PR.STUDYID",
+          "mandatory": true,
+          "name": "STUDYID",
+          "description": "Study Identifier",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.PR.DOMAIN",
+          "mandatory": true,
+          "name": "DOMAIN",
+          "description": "Domain Abbreviation",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.PR.USUBJID",
+          "mandatory": true,
+          "name": "USUBJID",
+          "description": "Unique Subject Identifier",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.PR.PRSEQ",
+          "mandatory": true,
+          "name": "PRSEQ",
+          "description": "Sequence Number",
+          "role": "Identifier",
+          "dataType": "integer",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.PR.PRTRT",
+          "mandatory": true,
+          "name": "PRTRT",
+          "description": "Reported Name of Procedure",
+          "role": "Topic",
+          "dataType": "text",
+          "length": 200,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          }
+        },
+        {
+          "OID": "IT.PR.PRDECOD",
+          "mandatory": false,
+          "name": "PRDECOD",
+          "description": "Standardized Procedure Name",
+          "role": "Synonym Qualifier",
+          "dataType": "text",
+          "length": 200,
+          "origin": {
+            "type": "Assigned",
+            "source": "Sponsor"
+          },
+          "codeList": "CL.PROCEDUR"
+        },
+        {
+          "OID": "IT.PR.PRCAT",
+          "mandatory": false,
+          "name": "PRCAT",
+          "description": "Category",
+          "role": "Grouping Qualifier",
+          "dataType": "text",
+          "length": 200,
+          "origin": {
+            "type": "Assigned",
+            "source": "Sponsor"
+          }
+        },
+        {
+          "OID": "IT.PR.PRSCAT",
+          "mandatory": false,
+          "name": "PRSCAT",
+          "description": "Subcategory",
+          "role": "Grouping Qualifier",
+          "dataType": "text",
+          "length": 200,
+          "origin": {
+            "type": "Assigned",
+            "source": "Sponsor"
+          }
+        },
+        {
+          "OID": "IT.PR.PRPRESP",
+          "mandatory": false,
+          "name": "PRPRESP",
+          "description": "Pre-specified",
+          "role": "Variable Qualifier",
+          "dataType": "text",
+          "length": 1,
+          "origin": {
+            "type": "Assigned",
+            "source": "Sponsor"
+          },
+          "codeList": "CL.NY"
+        },
+        {
+          "OID": "IT.PR.PROCCUR",
+          "mandatory": false,
+          "name": "PROCCUR",
+          "description": "Occurrence",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": 1,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          },
+          "codeList": "CL.NY"
+        },
+        {
+          "OID": "IT.PR.PRLOC",
+          "mandatory": false,
+          "name": "PRLOC",
+          "description": "Location of Procedure",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": 200,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          },
+          "codeList": "CL.LOC"
+        },
+        {
+          "OID": "IT.PR.PRSTDTC",
+          "mandatory": false,
+          "name": "PRSTDTC",
+          "description": "Start Date/Time of Procedure",
+          "role": "Timing",
+          "dataType": "datetime",
+          "length": null,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          }
+        },
+        {
+          "OID": "IT.PR.PRENDTC",
+          "mandatory": false,
+          "name": "PRENDTC",
+          "description": "End Date/Time of Procedure",
+          "role": "Timing",
+          "dataType": "datetime",
+          "length": null,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          }
+        }
+      ]
+    },
+    {
+      "OID": "IG.VS",
+      "name": "VS",
+      "description": "Vital Signs",
+      "domain": "VS",
+      "purpose": "Tabulation",
+      "structure": "One record per vital sign measurement per time point per visit per subject",
+      "isReferenceData": false,
+      "keySequence": [
+        "__PLACEHOLDER__"
+      ],
+      "standard": "STD.SDTMIG",
+      "observationClass": {
+        "name": "FINDINGS"
+      },
+      "items": [
+        {
+          "OID": "IT.VS.STUDYID",
+          "mandatory": true,
+          "name": "STUDYID",
+          "description": "Study Identifier",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.VS.DOMAIN",
+          "mandatory": true,
+          "name": "DOMAIN",
+          "description": "Domain Abbreviation",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.VS.USUBJID",
+          "mandatory": true,
+          "name": "USUBJID",
+          "description": "Unique Subject Identifier",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.VS.VSSEQ",
+          "mandatory": true,
+          "name": "VSSEQ",
+          "description": "Sequence Number",
+          "role": "Identifier",
+          "dataType": "integer",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.VS.VSTESTCD",
+          "mandatory": true,
+          "name": "VSTESTCD",
+          "description": "Vital Signs Test Short Name",
+          "role": "Topic",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.VSTESTCD"
+        },
+        {
+          "OID": "IT.VS.VSTEST",
+          "mandatory": true,
+          "name": "VSTEST",
+          "description": "Vital Signs Test Name",
+          "role": "Synonym Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.VSTEST"
+        },
+        {
+          "OID": "IT.VS.VSPOS",
+          "mandatory": false,
+          "name": "VSPOS",
+          "description": "Vital Signs Position of Subject",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.POSITION"
+        },
+        {
+          "OID": "IT.VS.VSORRES",
+          "mandatory": false,
+          "name": "VSORRES",
+          "description": "Result or Finding in Original Units",
+          "role": "Result Qualifier",
+          "dataType": "float",
+          "length": 8,
+          "displayFormat": "8.3",
+          "significantDigits": 3,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          }
+        },
+        {
+          "OID": "IT.VS.VSORRESU",
+          "mandatory": false,
+          "name": "VSORRESU",
+          "description": "Original Units",
+          "role": "Variable Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.VSRESU"
+        },
+        {
+          "OID": "IT.VS.VSSTRESC",
+          "mandatory": false,
+          "name": "VSSTRESC",
+          "description": "Character Result/Finding in Std Format",
+          "role": "Result Qualifier",
+          "dataType": "float",
+          "length": 8,
+          "displayFormat": "8.3",
+          "significantDigits": 3,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.VS.VSSTRESN",
+          "mandatory": false,
+          "name": "VSSTRESN",
+          "description": "Numeric Result/Finding in Standard Units",
+          "role": "Result Qualifier",
+          "dataType": "float",
+          "length": 8,
+          "displayFormat": "8.3",
+          "significantDigits": 3,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.VS.VSSTRESU",
+          "mandatory": false,
+          "name": "VSSTRESU",
+          "description": "Standard Units",
+          "role": "Variable Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.VSRESU"
+        },
+        {
+          "OID": "IT.VS.VSLOC",
+          "mandatory": false,
+          "name": "VSLOC",
+          "description": "Location of Vital Signs Measurement",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.LOC"
+        },
+        {
+          "OID": "IT.VS.VSLAT",
+          "mandatory": false,
+          "name": "VSLAT",
+          "description": "Laterality",
+          "role": "Result Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.LAT"
+        },
+        {
+          "OID": "IT.VS.VSLOBXFL",
+          "mandatory": false,
+          "name": "VSLOBXFL",
+          "description": "Last Observation Before Exposure Flag",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.NY"
+        },
+        {
+          "OID": "IT.VS.VISITNUM",
+          "mandatory": false,
+          "name": "VISITNUM",
+          "description": "Visit Number",
+          "role": "Timing",
+          "dataType": "integer",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.VS.VSDTC",
+          "mandatory": false,
+          "name": "VSDTC",
+          "description": "Date/Time of Measurements",
+          "role": "Timing",
+          "dataType": "datetime",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        }
+      ],
+      "slices": [
+        {
+          "OID": "VL.VS.VSORRES",
+          "name": "VL_VS_VSORRES",
+          "type": "ValueList",
+          "wasDerivedFrom": "IT.VS.VSORRES",
+          "items": [
+            {
+              "OID": "IT.VS.VSORRES.TEMP",
+              "mandatory": false,
+              "name": "VSORRES",
+              "dataType": "float",
+              "length": 8,
+              "displayFormat": "8.3",
+              "significantDigits": 3,
+              "origin": {
+                "type": "Collected",
+                "source": "Investigator"
+              },
+              "applicableWhen": [
+                "WC.VS.df8e6ed8"
+              ]
+            },
+            {
+              "OID": "IT.VS.VSORRES.WEIGHT",
+              "mandatory": false,
+              "name": "VSORRES",
+              "dataType": "float",
+              "length": 8,
+              "displayFormat": "8.3",
+              "significantDigits": 3,
+              "origin": {
+                "type": "Collected",
+                "source": "Investigator"
+              },
+              "applicableWhen": [
+                "WC.VS.362bc1cf"
+              ]
+            },
+            {
+              "OID": "IT.VS.VSORRES.HEIGHT",
+              "mandatory": false,
+              "name": "VSORRES",
+              "dataType": "float",
+              "length": 8,
+              "displayFormat": "8.3",
+              "significantDigits": 3,
+              "origin": {
+                "type": "Collected",
+                "source": "Investigator"
+              },
+              "applicableWhen": [
+                "WC.VS.22da90ca"
+              ]
+            },
+            {
+              "OID": "IT.VS.VSORRES.PULSE",
+              "mandatory": false,
+              "name": "VSORRES",
+              "dataType": "integer",
+              "length": 3,
+              "origin": {
+                "type": "Collected",
+                "source": "Investigator"
+              },
+              "applicableWhen": [
+                "WC.VS.90269389"
+              ]
+            },
+            {
+              "OID": "IT.VS.VSORRES.RESP",
+              "mandatory": false,
+              "name": "VSORRES",
+              "dataType": "integer",
+              "length": 3,
+              "origin": {
+                "type": "Collected",
+                "source": "Investigator"
+              },
+              "applicableWhen": [
+                "WC.VS.02e0f161"
+              ]
+            },
+            {
+              "OID": "IT.VS.VSORRES.BMI",
+              "mandatory": false,
+              "name": "VSORRES",
+              "dataType": "float",
+              "length": 8,
+              "displayFormat": "8.3",
+              "origin": {
+                "type": "Derived",
+                "source": "Sponsor"
+              },
+              "applicableWhen": [
+                "WC.VS.ba9d17a7"
+              ]
+            },
+            {
+              "OID": "IT.VS.VSORRES.SYSBP",
+              "mandatory": false,
+              "name": "VSORRES",
+              "dataType": "integer",
+              "length": 3,
+              "origin": {
+                "type": "Collected",
+                "source": "Investigator"
+              },
+              "applicableWhen": [
+                "WC.VS.037b6848"
+              ]
+            },
+            {
+              "OID": "IT.VS.VSORRES.DIABP",
+              "mandatory": false,
+              "name": "VSORRES",
+              "dataType": "integer",
+              "length": 3,
+              "origin": {
+                "type": "Collected",
+                "source": "Investigator"
+              },
+              "applicableWhen": [
+                "WC.VS.fe755a11"
+              ]
+            },
+            {
+              "OID": "IT.VS.VSORRES.HR",
+              "mandatory": false,
+              "name": "VSORRES",
+              "dataType": "integer",
+              "length": 3,
+              "origin": {
+                "type": "Collected",
+                "source": "Investigator"
+              },
+              "applicableWhen": [
+                "WC.VS.324e0cc0"
+              ]
+            }
+          ]
+        },
+        {
+          "OID": "VL.VS.VSORRESU",
+          "name": "VL_VS_VSORRESU",
+          "type": "ValueList",
+          "wasDerivedFrom": "IT.VS.VSORRESU",
+          "items": [
+            {
+              "OID": "IT.VS.VSORRESU.TEMP",
+              "mandatory": false,
+              "name": "VSORRESU",
+              "dataType": "text",
+              "applicableWhen": [
+                "WC.VS.dea56915"
+              ]
+            },
+            {
+              "OID": "IT.VS.VSORRESU.WEIGHT",
+              "mandatory": false,
+              "name": "VSORRESU",
+              "dataType": "text",
+              "applicableWhen": [
+                "WC.VS.ef959fbb"
+              ]
+            },
+            {
+              "OID": "IT.VS.VSORRESU.HEIGHT",
+              "mandatory": false,
+              "name": "VSORRESU",
+              "dataType": "text",
+              "applicableWhen": [
+                "WC.VS.97262f9f"
+              ]
+            },
+            {
+              "OID": "IT.VS.VSORRESU.PULSE",
+              "mandatory": false,
+              "name": "VSORRESU",
+              "dataType": "text",
+              "applicableWhen": [
+                "WC.VS.2fad3005"
+              ]
+            },
+            {
+              "OID": "IT.VS.VSORRESU.RESP",
+              "mandatory": false,
+              "name": "VSORRESU",
+              "dataType": "text",
+              "applicableWhen": [
+                "WC.VS.f296848d"
+              ]
+            },
+            {
+              "OID": "IT.VS.VSORRESU.BMI",
+              "mandatory": false,
+              "name": "VSORRESU",
+              "dataType": "text",
+              "applicableWhen": [
+                "WC.VS.ca4251ba"
+              ]
+            },
+            {
+              "OID": "IT.VS.VSORRESU.SYSBP",
+              "mandatory": false,
+              "name": "VSORRESU",
+              "dataType": "text",
+              "applicableWhen": [
+                "WC.VS.301c7ee3"
+              ]
+            },
+            {
+              "OID": "IT.VS.VSORRESU.DIABP",
+              "mandatory": false,
+              "name": "VSORRESU",
+              "dataType": "text",
+              "applicableWhen": [
+                "WC.VS.714dfc07"
+              ]
+            },
+            {
+              "OID": "IT.VS.VSORRESU.HR",
+              "mandatory": false,
+              "name": "VSORRESU",
+              "dataType": "text",
+              "applicableWhen": [
+                "WC.VS.5a9c1ab0"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "OID": "IG.EG",
+      "name": "EG",
+      "description": "ECG Test Results",
+      "domain": "EG",
+      "purpose": "Tabulation",
+      "structure": "One record per ECG observation per replicate per time point or one record per ECG observation per beat per visit per subject",
+      "isReferenceData": false,
+      "keySequence": [
+        "__PLACEHOLDER__"
+      ],
+      "standard": "STD.SDTMIG",
+      "observationClass": {
+        "name": "FINDINGS"
+      },
+      "items": [
+        {
+          "OID": "IT.EG.STUDYID",
+          "mandatory": true,
+          "name": "STUDYID",
+          "description": "Study Identifier",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.EG.DOMAIN",
+          "mandatory": true,
+          "name": "DOMAIN",
+          "description": "Domain Abbreviation",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.EG.USUBJID",
+          "mandatory": true,
+          "name": "USUBJID",
+          "description": "Unique Subject Identifier",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.EG.EGSEQ",
+          "mandatory": true,
+          "name": "EGSEQ",
+          "description": "Sequence Number",
+          "role": "Identifier",
+          "dataType": "integer",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.EG.EGTESTCD",
+          "mandatory": true,
+          "name": "EGTESTCD",
+          "description": "ECG Test or Examination Short Name",
+          "role": "Topic",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.EGTESTCD"
+        },
+        {
+          "OID": "IT.EG.EGTEST",
+          "mandatory": true,
+          "name": "EGTEST",
+          "description": "ECG Test or Examination Name",
+          "role": "Synonym Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.EGTEST"
+        },
+        {
+          "OID": "IT.EG.EGCAT",
+          "mandatory": false,
+          "name": "EGCAT",
+          "description": "Category for ECG",
+          "role": "Grouping Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.EG.EGPOS",
+          "mandatory": false,
+          "name": "EGPOS",
+          "description": "ECG Position of Subject",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.POSITION"
+        },
+        {
+          "OID": "IT.EG.EGORRES",
+          "mandatory": false,
+          "name": "EGORRES",
+          "description": "Result or Finding in Original Units",
+          "role": "Result Qualifier",
+          "dataType": "text",
+          "length": 20,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.EG.EGORRESU",
+          "mandatory": false,
+          "name": "EGORRESU",
+          "description": "Original Units",
+          "role": "Variable Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.UNIT"
+        },
+        {
+          "OID": "IT.EG.EGSTRESC",
+          "mandatory": false,
+          "name": "EGSTRESC",
+          "description": "Character Result/Finding in Std Format",
+          "role": "Result Qualifier",
+          "dataType": "text",
+          "length": 20,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.EGSTRESC"
+        },
+        {
+          "OID": "IT.EG.EGSTRESN",
+          "mandatory": false,
+          "name": "EGSTRESN",
+          "description": "Numeric Result/Finding in Standard Units",
+          "role": "Result Qualifier",
+          "dataType": "float",
+          "length": 8,
+          "displayFormat": "8.3",
+          "significantDigits": 3,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.EG.EGSTRESU",
+          "mandatory": false,
+          "name": "EGSTRESU",
+          "description": "Standard Units",
+          "role": "Variable Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.UNIT"
+        },
+        {
+          "OID": "IT.EG.EGMETHOD",
+          "mandatory": false,
+          "name": "EGMETHOD",
+          "description": "Method of Test or Examination",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.EGMETHOD"
+        },
+        {
+          "OID": "IT.EG.EGLOBXFL",
+          "mandatory": false,
+          "name": "EGLOBXFL",
+          "description": "Last Observation Before Exposure Flag",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.NY"
+        },
+        {
+          "OID": "IT.EG.EGEVAL",
+          "mandatory": false,
+          "name": "EGEVAL",
+          "description": "Evaluator",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.EVAL"
+        },
+        {
+          "OID": "IT.EG.EGCLSIG",
+          "mandatory": false,
+          "name": "EGCLSIG",
+          "description": "Clinically Significant, Collected",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.NY"
+        },
+        {
+          "OID": "IT.EG.VISITNUM",
+          "mandatory": false,
+          "name": "VISITNUM",
+          "description": "Visit Number",
+          "role": "Timing",
+          "dataType": "integer",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.EG.EGDTC",
+          "mandatory": false,
+          "name": "EGDTC",
+          "description": "Date/Time of ECG",
+          "role": "Timing",
+          "dataType": "datetime",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        }
+      ],
+      "slices": [
+        {
+          "OID": "VL.EG.EGORRES",
+          "name": "VL_EG_EGORRES",
+          "type": "ValueList",
+          "wasDerivedFrom": "IT.EG.EGORRES",
+          "items": [
+            {
+              "OID": "IT.EG.EGORRES.INTP",
+              "mandatory": false,
+              "name": "EGORRES",
+              "dataType": "text",
+              "length": 20,
+              "applicableWhen": [
+                "WC.EG.f60b99cb"
+              ]
+            },
+            {
+              "OID": "IT.EG.EGORRES.AVCOND",
+              "mandatory": false,
+              "name": "EGORRES",
+              "dataType": "text",
+              "length": 8,
+              "displayFormat": "8.3",
+              "significantDigits": 3,
+              "applicableWhen": [
+                "WC.EG.d30401ba"
+              ]
+            },
+            {
+              "OID": "IT.EG.EGORRES.AXISVOLT",
+              "mandatory": false,
+              "name": "EGORRES",
+              "dataType": "text",
+              "length": 8,
+              "displayFormat": "8.3",
+              "significantDigits": 3,
+              "applicableWhen": [
+                "WC.EG.0764363d"
+              ]
+            },
+            {
+              "OID": "IT.EG.EGORRES.CHYPTENL",
+              "mandatory": false,
+              "name": "EGORRES",
+              "dataType": "text",
+              "length": 8,
+              "displayFormat": "8.3",
+              "significantDigits": 3,
+              "applicableWhen": [
+                "WC.EG.c7ca2c0d"
+              ]
+            },
+            {
+              "OID": "IT.EG.EGORRES.TECHQUAL",
+              "mandatory": false,
+              "name": "EGORRES",
+              "dataType": "text",
+              "length": 200,
+              "applicableWhen": [
+                "WC.EG.0110957e"
+              ]
+            },
+            {
+              "OID": "IT.EG.EGORRES.IVTIACD",
+              "mandatory": false,
+              "name": "EGORRES",
+              "dataType": "text",
+              "length": 8,
+              "displayFormat": "8.3",
+              "significantDigits": 3,
+              "applicableWhen": [
+                "WC.EG.7a2cbb17"
+              ]
+            },
+            {
+              "OID": "IT.EG.EGORRES.PACEMAKR",
+              "mandatory": false,
+              "name": "EGORRES",
+              "dataType": "text",
+              "length": 8,
+              "displayFormat": "8.3",
+              "significantDigits": 3,
+              "applicableWhen": [
+                "WC.EG.c82f004b"
+              ]
+            },
+            {
+              "OID": "IT.EG.EGORRES.RHYNOS",
+              "mandatory": false,
+              "name": "EGORRES",
+              "dataType": "text",
+              "length": 8,
+              "displayFormat": "8.3",
+              "significantDigits": 3,
+              "applicableWhen": [
+                "WC.EG.aaf51dd5"
+              ]
+            },
+            {
+              "OID": "IT.EG.EGORRES.SNRARRY",
+              "mandatory": false,
+              "name": "EGORRES",
+              "dataType": "text",
+              "length": 8,
+              "displayFormat": "8.3",
+              "significantDigits": 3,
+              "applicableWhen": [
+                "WC.EG.0a478649"
+              ]
+            },
+            {
+              "OID": "IT.EG.EGORRES.SPRARRY",
+              "mandatory": false,
+              "name": "EGORRES",
+              "dataType": "text",
+              "length": 8,
+              "displayFormat": "8.3",
+              "significantDigits": 3,
+              "applicableWhen": [
+                "WC.EG.44c12ce4"
+              ]
+            },
+            {
+              "OID": "IT.EG.EGORRES.SPRTARRY",
+              "mandatory": false,
+              "name": "EGORRES",
+              "dataType": "text",
+              "length": 8,
+              "displayFormat": "8.3",
+              "significantDigits": 3,
+              "applicableWhen": [
+                "WC.EG.7c9fb72d"
+              ]
+            },
+            {
+              "OID": "IT.EG.EGORRES.VTARRY",
+              "mandatory": false,
+              "name": "EGORRES",
+              "dataType": "text",
+              "length": 8,
+              "displayFormat": "8.3",
+              "significantDigits": 3,
+              "applicableWhen": [
+                "WC.EG.3a146a53"
+              ]
+            },
+            {
+              "OID": "IT.EG.EGORRES.VTTARRY",
+              "mandatory": false,
+              "name": "EGORRES",
+              "dataType": "text",
+              "length": 8,
+              "displayFormat": "8.3",
+              "significantDigits": 3,
+              "applicableWhen": [
+                "WC.EG.5571a969"
+              ]
+            },
+            {
+              "OID": "IT.EG.EGORRES.PRAG",
+              "mandatory": false,
+              "name": "EGORRES",
+              "dataType": "text",
+              "length": 8,
+              "displayFormat": "8.3",
+              "significantDigits": 3,
+              "applicableWhen": [
+                "WC.EG.13a9fd00"
+              ]
+            },
+            {
+              "OID": "IT.EG.EGORRES.QRSAG",
+              "mandatory": false,
+              "name": "EGORRES",
+              "dataType": "text",
+              "length": 8,
+              "displayFormat": "8.3",
+              "significantDigits": 3,
+              "applicableWhen": [
+                "WC.EG.72304c3a"
+              ]
+            },
+            {
+              "OID": "IT.EG.EGORRES.QTAG",
+              "mandatory": false,
+              "name": "EGORRES",
+              "dataType": "text",
+              "length": 8,
+              "displayFormat": "8.3",
+              "significantDigits": 3,
+              "applicableWhen": [
+                "WC.EG.6f155b1d"
+              ]
+            },
+            {
+              "OID": "IT.EG.EGORRES.QTCBAG",
+              "mandatory": false,
+              "name": "EGORRES",
+              "dataType": "text",
+              "length": 8,
+              "displayFormat": "8.3",
+              "significantDigits": 3,
+              "applicableWhen": [
+                "WC.EG.dff815c6"
+              ]
+            },
+            {
+              "OID": "IT.EG.EGORRES.QTCFAG",
+              "mandatory": false,
+              "name": "EGORRES",
+              "dataType": "text",
+              "length": 8,
+              "displayFormat": "8.3",
+              "significantDigits": 3,
+              "applicableWhen": [
+                "WC.EG.e967e1e7"
+              ]
+            },
+            {
+              "OID": "IT.EG.EGORRES.RRAG",
+              "mandatory": false,
+              "name": "EGORRES",
+              "dataType": "text",
+              "length": 8,
+              "displayFormat": "8.3",
+              "significantDigits": 3,
+              "applicableWhen": [
+                "WC.EG.64f26102"
+              ]
+            },
+            {
+              "OID": "IT.EG.EGORRES.EGHRMN",
+              "mandatory": false,
+              "name": "EGORRES",
+              "dataType": "text",
+              "length": 8,
+              "displayFormat": "8.3",
+              "significantDigits": 3,
+              "applicableWhen": [
+                "WC.EG.2ecbdce2"
+              ]
+            },
+            {
+              "OID": "IT.EG.EGORRES.QRS_AXIS",
+              "mandatory": false,
+              "name": "EGORRES",
+              "dataType": "text",
+              "length": 8,
+              "displayFormat": "8.3",
+              "significantDigits": 3,
+              "applicableWhen": [
+                "WC.EG.9ce29aa6"
+              ]
+            }
+          ]
+        },
+        {
+          "OID": "VL.EG.EGORRESU",
+          "name": "VL_EG_EGORRESU",
+          "type": "ValueList",
+          "wasDerivedFrom": "IT.EG.EGORRESU",
+          "items": [
+            {
+              "OID": "IT.EG.EGORRESU.PRAG",
+              "mandatory": false,
+              "name": "EGORRESU",
+              "dataType": "text",
+              "applicableWhen": [
+                "WC.EG.cec16291"
+              ]
+            },
+            {
+              "OID": "IT.EG.EGORRESU.QRSAG",
+              "mandatory": false,
+              "name": "EGORRESU",
+              "dataType": "text",
+              "applicableWhen": [
+                "WC.EG.5a1ab0f5"
+              ]
+            },
+            {
+              "OID": "IT.EG.EGORRESU.QTAG",
+              "mandatory": false,
+              "name": "EGORRESU",
+              "dataType": "text",
+              "applicableWhen": [
+                "WC.EG.ddb86367"
+              ]
+            },
+            {
+              "OID": "IT.EG.EGORRESU.QTCBAG",
+              "mandatory": false,
+              "name": "EGORRESU",
+              "dataType": "text",
+              "applicableWhen": [
+                "WC.EG.e847517c"
+              ]
+            },
+            {
+              "OID": "IT.EG.EGORRESU.QTCFAG",
+              "mandatory": false,
+              "name": "EGORRESU",
+              "dataType": "text",
+              "applicableWhen": [
+                "WC.EG.7f463007"
+              ]
+            },
+            {
+              "OID": "IT.EG.EGORRESU.RRAG",
+              "mandatory": false,
+              "name": "EGORRESU",
+              "dataType": "text",
+              "applicableWhen": [
+                "WC.EG.3d1ba9c3"
+              ]
+            },
+            {
+              "OID": "IT.EG.EGORRESU.EGHRMN",
+              "mandatory": false,
+              "name": "EGORRESU",
+              "dataType": "text",
+              "applicableWhen": [
+                "WC.EG.a40eb46d"
+              ]
+            },
+            {
+              "OID": "IT.EG.EGORRESU.QRS_AXIS",
+              "mandatory": false,
+              "name": "EGORRESU",
+              "dataType": "text",
+              "applicableWhen": [
+                "WC.EG.02ebb46f"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "OID": "IG.CM",
+      "name": "CM",
+      "description": "Concomitant/Prior Medications",
+      "domain": "CM",
+      "purpose": "Tabulation",
+      "structure": "One record per recorded intervention occurrence or constant-dosing interval per subject",
+      "isReferenceData": false,
+      "keySequence": [
+        "__PLACEHOLDER__"
+      ],
+      "standard": "STD.SDTMIG",
+      "observationClass": {
+        "name": "INTERVENTIONS"
+      },
+      "items": [
+        {
+          "OID": "IT.CM.STUDYID",
+          "mandatory": true,
+          "name": "STUDYID",
+          "description": "Study Identifier",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.CM.DOMAIN",
+          "mandatory": true,
+          "name": "DOMAIN",
+          "description": "Domain Abbreviation",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.CM.USUBJID",
+          "mandatory": true,
+          "name": "USUBJID",
+          "description": "Unique Subject Identifier",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.CM.CMSEQ",
+          "mandatory": true,
+          "name": "CMSEQ",
+          "description": "Sequence Number",
+          "role": "Identifier",
+          "dataType": "integer",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.CM.CMTRT",
+          "mandatory": true,
+          "name": "CMTRT",
+          "description": "Reported Name of Drug, Med, or Therapy",
+          "role": "Topic",
+          "dataType": "text",
+          "length": 200,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          }
+        },
+        {
+          "OID": "IT.CM.CMDECOD",
+          "mandatory": false,
+          "name": "CMDECOD",
+          "description": "Standardized Medication Name",
+          "role": "Synonym Qualifier",
+          "dataType": "text",
+          "length": 200,
+          "origin": {
+            "type": "Assigned",
+            "source": "Sponsor"
+          }
+        },
+        {
+          "OID": "IT.CM.CMCAT",
+          "mandatory": false,
+          "name": "CMCAT",
+          "description": "Category for Medication",
+          "role": "Grouping Qualifier",
+          "dataType": "text",
+          "length": 200,
+          "origin": {
+            "type": "Assigned",
+            "source": "Sponsor"
+          }
+        },
+        {
+          "OID": "IT.CM.CMSCAT",
+          "mandatory": false,
+          "name": "CMSCAT",
+          "description": "Subcategory for Medication",
+          "role": "Grouping Qualifier",
+          "dataType": "text",
+          "length": 200,
+          "origin": {
+            "type": "Assigned",
+            "source": "Sponsor"
+          }
+        },
+        {
+          "OID": "IT.CM.CMPRESP",
+          "mandatory": false,
+          "name": "CMPRESP",
+          "description": "CM Pre-specified",
+          "role": "Variable Qualifier",
+          "dataType": "text",
+          "length": 1,
+          "origin": {
+            "type": "Assigned",
+            "source": "Sponsor"
+          },
+          "codeList": "CL.NY"
+        },
+        {
+          "OID": "IT.CM.CMOCCUR",
+          "mandatory": false,
+          "name": "CMOCCUR",
+          "description": "CM Occurrence",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": 1,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          },
+          "codeList": "CL.NY"
+        },
+        {
+          "OID": "IT.CM.CMINDC",
+          "mandatory": false,
+          "name": "CMINDC",
+          "description": "Indication",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": 200,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          }
+        },
+        {
+          "OID": "IT.CM.CMDOSE",
+          "mandatory": false,
+          "name": "CMDOSE",
+          "description": "Dose per Administration",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": 40,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          }
+        },
+        {
+          "OID": "IT.CM.CMDOSU",
+          "mandatory": false,
+          "name": "CMDOSU",
+          "description": "Dose Units",
+          "role": "Variable Qualifier",
+          "dataType": "text",
+          "length": 40,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          },
+          "codeList": "CL.UNIT"
+        },
+        {
+          "OID": "IT.CM.CMDOSFRM",
+          "mandatory": false,
+          "name": "CMDOSFRM",
+          "description": "Dose Form",
+          "role": "Variable Qualifier",
+          "dataType": "text",
+          "length": 40,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          },
+          "codeList": "CL.FRM"
+        },
+        {
+          "OID": "IT.CM.CMROUTE",
+          "mandatory": false,
+          "name": "CMROUTE",
+          "description": "Route of Administration",
+          "role": "Variable Qualifier",
+          "dataType": "text",
+          "length": 200,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          },
+          "codeList": "CL.ROUTE"
+        },
+        {
+          "OID": "IT.CM.CMSTDTC",
+          "mandatory": false,
+          "name": "CMSTDTC",
+          "description": "Start Date/Time of Medication",
+          "role": "Timing",
+          "dataType": "datetime",
+          "length": null,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          }
+        },
+        {
+          "OID": "IT.CM.CMENDTC",
+          "mandatory": false,
+          "name": "CMENDTC",
+          "description": "End Date/Time of Medication",
+          "role": "Timing",
+          "dataType": "datetime",
+          "length": null,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          }
+        }
+      ]
+    },
+    {
+      "OID": "IG.LB",
+      "name": "LB",
+      "description": "Laboratory Test Results",
+      "domain": "LB",
+      "purpose": "Tabulation",
+      "structure": "One record per lab test per time point per visit per subject",
+      "isReferenceData": false,
+      "keySequence": [
+        "__PLACEHOLDER__"
+      ],
+      "standard": "STD.SDTMIG",
+      "observationClass": {
+        "name": "FINDINGS"
+      },
+      "items": [
+        {
+          "OID": "IT.LB.STUDYID",
+          "mandatory": true,
+          "name": "STUDYID",
+          "description": "Study Identifier",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.LB.DOMAIN",
+          "mandatory": true,
+          "name": "DOMAIN",
+          "description": "Domain Abbreviation",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.LB.USUBJID",
+          "mandatory": true,
+          "name": "USUBJID",
+          "description": "Unique Subject Identifier",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.LB.LBSEQ",
+          "mandatory": true,
+          "name": "LBSEQ",
+          "description": "Sequence Number",
+          "role": "Identifier",
+          "dataType": "integer",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.LB.LBTESTCD",
+          "mandatory": true,
+          "name": "LBTESTCD",
+          "description": "Lab Test or Examination Short Name",
+          "role": "Topic",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.LBTESTCD"
+        },
+        {
+          "OID": "IT.LB.LBTEST",
+          "mandatory": true,
+          "name": "LBTEST",
+          "description": "Lab Test or Examination Name",
+          "role": "Synonym Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.LBTEST"
+        },
+        {
+          "OID": "IT.LB.LBCAT",
+          "mandatory": false,
+          "name": "LBCAT",
+          "description": "Category for Lab Test",
+          "role": "Grouping Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.LB.LBORRES",
+          "mandatory": false,
+          "name": "LBORRES",
+          "description": "Result or Finding in Original Units",
+          "role": "Result Qualifier",
+          "dataType": "float",
+          "length": 12,
+          "displayFormat": "12.4",
+          "significantDigits": 4,
+          "origin": {
+            "type": "Collected",
+            "source": "Vendor"
+          }
+        },
+        {
+          "OID": "IT.LB.LBORRESU",
+          "mandatory": false,
+          "name": "LBORRESU",
+          "description": "Original Units",
+          "role": "Variable Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.UNIT"
+        },
+        {
+          "OID": "IT.LB.LBORNRLO",
+          "mandatory": false,
+          "name": "LBORNRLO",
+          "description": "Reference Range Lower Limit in Orig Unit",
+          "role": "Variable Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.LB.LBORNRHI",
+          "mandatory": false,
+          "name": "LBORNRHI",
+          "description": "Reference Range Upper Limit in Orig Unit",
+          "role": "Variable Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.LB.LBSTRESC",
+          "mandatory": false,
+          "name": "LBSTRESC",
+          "description": "Character Result/Finding in Std Format",
+          "role": "Result Qualifier",
+          "dataType": "float",
+          "length": 12,
+          "displayFormat": "12.4",
+          "significantDigits": 4,
+          "origin": {
+            "type": "Collected",
+            "source": "Vendor"
+          },
+          "codeList": "CL.LBSTRESC"
+        },
+        {
+          "OID": "IT.LB.LBSTRESN",
+          "mandatory": false,
+          "name": "LBSTRESN",
+          "description": "Numeric Result/Finding in Standard Units",
+          "role": "Result Qualifier",
+          "dataType": "float",
+          "length": 12,
+          "displayFormat": "12.4",
+          "significantDigits": 4,
+          "origin": {
+            "type": "Collected",
+            "source": "Vendor"
+          }
+        },
+        {
+          "OID": "IT.LB.LBSTRESU",
+          "mandatory": false,
+          "name": "LBSTRESU",
+          "description": "Standard Units",
+          "role": "Variable Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.UNIT"
+        },
+        {
+          "OID": "IT.LB.LBSTNRLO",
+          "mandatory": false,
+          "name": "LBSTNRLO",
+          "description": "Reference Range Lower Limit-Std Units",
+          "role": "Variable Qualifier",
+          "dataType": "integer",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.LB.LBSTNRHI",
+          "mandatory": false,
+          "name": "LBSTNRHI",
+          "description": "Reference Range Upper Limit-Std Units",
+          "role": "Variable Qualifier",
+          "dataType": "integer",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.LB.LBNRIND",
+          "mandatory": false,
+          "name": "LBNRIND",
+          "description": "Reference Range Indicator",
+          "role": "Variable Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.NRIND"
+        },
+        {
+          "OID": "IT.LB.LBSPEC",
+          "mandatory": false,
+          "name": "LBSPEC",
+          "description": "Specimen Type",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.SPECTYPE"
+        },
+        {
+          "OID": "IT.LB.LBMETHOD",
+          "mandatory": false,
+          "name": "LBMETHOD",
+          "description": "Method of Test or Examination",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.METHOD"
+        },
+        {
+          "OID": "IT.LB.LBLOBXFL",
+          "mandatory": false,
+          "name": "LBLOBXFL",
+          "description": "Last Observation Before Exposure Flag",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.NY"
+        },
+        {
+          "OID": "IT.LB.LBFAST",
+          "mandatory": false,
+          "name": "LBFAST",
+          "description": "Fasting Status",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.NY"
+        },
+        {
+          "OID": "IT.LB.VISITNUM",
+          "mandatory": false,
+          "name": "VISITNUM",
+          "description": "Visit Number",
+          "role": "Timing",
+          "dataType": "integer",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.LB.LBDTC",
+          "mandatory": false,
+          "name": "LBDTC",
+          "description": "Date/Time of Specimen Collection",
+          "role": "Timing",
+          "dataType": "datetime",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        }
+      ],
+      "slices": [
+        {
+          "OID": "VL.LB.LBORRES",
+          "name": "VL_LB_LBORRES",
+          "type": "ValueList",
+          "wasDerivedFrom": "IT.LB.LBORRES",
+          "items": [
+            {
+              "OID": "IT.LB.LBORRES.HGB",
+              "mandatory": false,
+              "name": "LBORRES",
+              "dataType": "float",
+              "length": 12,
+              "displayFormat": "12.4",
+              "significantDigits": 4,
+              "origin": {
+                "type": "Collected",
+                "source": "Vendor"
+              },
+              "applicableWhen": [
+                "WC.LB.c192b07f"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRES.HCT",
+              "mandatory": false,
+              "name": "LBORRES",
+              "dataType": "float",
+              "length": 12,
+              "displayFormat": "12.4",
+              "significantDigits": 4,
+              "origin": {
+                "type": "Collected",
+                "source": "Vendor"
+              },
+              "applicableWhen": [
+                "WC.LB.82b97100"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRES.RBC",
+              "mandatory": false,
+              "name": "LBORRES",
+              "dataType": "float",
+              "length": 12,
+              "displayFormat": "12.4",
+              "significantDigits": 4,
+              "origin": {
+                "type": "Collected",
+                "source": "Vendor"
+              },
+              "applicableWhen": [
+                "WC.LB.87582e25"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRES.MCH",
+              "mandatory": false,
+              "name": "LBORRES",
+              "dataType": "float",
+              "length": 12,
+              "displayFormat": "12.4",
+              "significantDigits": 4,
+              "origin": {
+                "type": "Collected",
+                "source": "Vendor"
+              },
+              "applicableWhen": [
+                "WC.LB.95f4de22"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRES.MCHC",
+              "mandatory": false,
+              "name": "LBORRES",
+              "dataType": "float",
+              "length": 12,
+              "displayFormat": "12.4",
+              "significantDigits": 4,
+              "origin": {
+                "type": "Collected",
+                "source": "Vendor"
+              },
+              "applicableWhen": [
+                "WC.LB.92bd1f17"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRES.MCV",
+              "mandatory": false,
+              "name": "LBORRES",
+              "dataType": "float",
+              "length": 12,
+              "displayFormat": "12.4",
+              "significantDigits": 4,
+              "origin": {
+                "type": "Collected",
+                "source": "Vendor"
+              },
+              "applicableWhen": [
+                "WC.LB.24c0e2bc"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRES.WBC",
+              "mandatory": false,
+              "name": "LBORRES",
+              "dataType": "float",
+              "length": 12,
+              "displayFormat": "12.4",
+              "significantDigits": 4,
+              "origin": {
+                "type": "Collected",
+                "source": "Vendor"
+              },
+              "applicableWhen": [
+                "WC.LB.351df44b"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRES.NEUTSG",
+              "mandatory": false,
+              "name": "LBORRES",
+              "dataType": "float",
+              "length": 12,
+              "displayFormat": "12.4",
+              "significantDigits": 4,
+              "origin": {
+                "type": "Collected",
+                "source": "Vendor"
+              },
+              "applicableWhen": [
+                "WC.LB.5f2a0bab"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRES.NEUTB",
+              "mandatory": false,
+              "name": "LBORRES",
+              "dataType": "float",
+              "length": 12,
+              "displayFormat": "12.4",
+              "significantDigits": 4,
+              "origin": {
+                "type": "Collected",
+                "source": "Vendor"
+              },
+              "applicableWhen": [
+                "WC.LB.eea0ae49"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRES.NEUT",
+              "mandatory": false,
+              "name": "LBORRES",
+              "dataType": "float",
+              "length": 12,
+              "displayFormat": "12.4",
+              "significantDigits": 4,
+              "origin": {
+                "type": "Collected",
+                "source": "Vendor"
+              },
+              "applicableWhen": [
+                "WC.LB.550c7a01"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRES.MONO",
+              "mandatory": false,
+              "name": "LBORRES",
+              "dataType": "float",
+              "length": 12,
+              "displayFormat": "12.4",
+              "significantDigits": 4,
+              "origin": {
+                "type": "Collected",
+                "source": "Vendor"
+              },
+              "applicableWhen": [
+                "WC.LB.de4c119b"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRES.EOS",
+              "mandatory": false,
+              "name": "LBORRES",
+              "dataType": "float",
+              "length": 12,
+              "displayFormat": "12.4",
+              "significantDigits": 4,
+              "origin": {
+                "type": "Collected",
+                "source": "Vendor"
+              },
+              "applicableWhen": [
+                "WC.LB.a5684311"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRES.BASO",
+              "mandatory": false,
+              "name": "LBORRES",
+              "dataType": "float",
+              "length": 12,
+              "displayFormat": "12.4",
+              "significantDigits": 4,
+              "origin": {
+                "type": "Collected",
+                "source": "Vendor"
+              },
+              "applicableWhen": [
+                "WC.LB.7b86c15b"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRES.PLAT",
+              "mandatory": false,
+              "name": "LBORRES",
+              "dataType": "float",
+              "length": 12,
+              "displayFormat": "12.4",
+              "significantDigits": 4,
+              "origin": {
+                "type": "Collected",
+                "source": "Vendor"
+              },
+              "applicableWhen": [
+                "WC.LB.3a9d73e1"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRES.MICROCY",
+              "mandatory": false,
+              "name": "LBORRES",
+              "dataType": "text",
+              "length": 200,
+              "origin": {
+                "type": "Collected",
+                "source": "Vendor"
+              },
+              "applicableWhen": [
+                "WC.LB.ddc3319f"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRES.MACROCY",
+              "mandatory": false,
+              "name": "LBORRES",
+              "dataType": "text",
+              "length": 200,
+              "origin": {
+                "type": "Collected",
+                "source": "Vendor"
+              },
+              "applicableWhen": [
+                "WC.LB.116f85e4"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRES.ANISO",
+              "mandatory": false,
+              "name": "LBORRES",
+              "dataType": "text",
+              "length": 200,
+              "origin": {
+                "type": "Collected",
+                "source": "Vendor"
+              },
+              "applicableWhen": [
+                "WC.LB.84ceb0ad"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRES.POIKILO",
+              "mandatory": false,
+              "name": "LBORRES",
+              "dataType": "text",
+              "length": 200,
+              "origin": {
+                "type": "Collected",
+                "source": "Vendor"
+              },
+              "applicableWhen": [
+                "WC.LB.b622c728"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRES.POLYCHR",
+              "mandatory": false,
+              "name": "LBORRES",
+              "dataType": "text",
+              "length": 200,
+              "origin": {
+                "type": "Collected",
+                "source": "Vendor"
+              },
+              "applicableWhen": [
+                "WC.LB.87b1b367"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRES.ALT",
+              "mandatory": false,
+              "name": "LBORRES",
+              "dataType": "float",
+              "length": 12,
+              "displayFormat": "12.4",
+              "significantDigits": 4,
+              "origin": {
+                "type": "Collected",
+                "source": "Vendor"
+              },
+              "applicableWhen": [
+                "WC.LB.5412b298"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRES.ALB",
+              "mandatory": false,
+              "name": "LBORRES",
+              "dataType": "text",
+              "length": 200,
+              "significantDigits": 4,
+              "origin": {
+                "type": "Collected",
+                "source": "Vendor"
+              },
+              "applicableWhen": [
+                "WC.LB.e42a3c09"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRES.ALP",
+              "mandatory": false,
+              "name": "LBORRES",
+              "dataType": "float",
+              "length": 12,
+              "displayFormat": "12.4",
+              "significantDigits": 4,
+              "origin": {
+                "type": "Collected",
+                "source": "Vendor"
+              },
+              "applicableWhen": [
+                "WC.LB.cdac7fcc"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRES.AST",
+              "mandatory": false,
+              "name": "LBORRES",
+              "dataType": "float",
+              "length": 12,
+              "displayFormat": "12.4",
+              "significantDigits": 4,
+              "origin": {
+                "type": "Collected",
+                "source": "Vendor"
+              },
+              "applicableWhen": [
+                "WC.LB.b9d7ddba"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRES.CREAT",
+              "mandatory": false,
+              "name": "LBORRES",
+              "dataType": "float",
+              "length": 12,
+              "displayFormat": "12.4",
+              "significantDigits": 4,
+              "origin": {
+                "type": "Collected",
+                "source": "Vendor"
+              },
+              "applicableWhen": [
+                "WC.LB.969c1a6d"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRES.K",
+              "mandatory": false,
+              "name": "LBORRES",
+              "dataType": "float",
+              "length": 12,
+              "displayFormat": "12.4",
+              "significantDigits": 4,
+              "origin": {
+                "type": "Collected",
+                "source": "Vendor"
+              },
+              "applicableWhen": [
+                "WC.LB.7ce691fd"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRES.SODIUM",
+              "mandatory": false,
+              "name": "LBORRES",
+              "dataType": "float",
+              "length": 12,
+              "displayFormat": "12.4",
+              "significantDigits": 4,
+              "origin": {
+                "type": "Collected",
+                "source": "Vendor"
+              },
+              "applicableWhen": [
+                "WC.LB.88601b52"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRES.UREAN",
+              "mandatory": false,
+              "name": "LBORRES",
+              "dataType": "float",
+              "length": 12,
+              "displayFormat": "12.4",
+              "significantDigits": 4,
+              "origin": {
+                "type": "Collected",
+                "source": "Vendor"
+              },
+              "applicableWhen": [
+                "WC.LB.42392cd1"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRES.BICARB",
+              "mandatory": false,
+              "name": "LBORRES",
+              "dataType": "float",
+              "length": 12,
+              "displayFormat": "12.4",
+              "significantDigits": 4,
+              "origin": {
+                "type": "Collected",
+                "source": "Vendor"
+              },
+              "applicableWhen": [
+                "WC.LB.9279ec22"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRES.CL",
+              "mandatory": false,
+              "name": "LBORRES",
+              "dataType": "float",
+              "length": 12,
+              "displayFormat": "12.4",
+              "significantDigits": 4,
+              "origin": {
+                "type": "Collected",
+                "source": "Vendor"
+              },
+              "applicableWhen": [
+                "WC.LB.8b779a3b"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRES.BILI",
+              "mandatory": false,
+              "name": "LBORRES",
+              "dataType": "text",
+              "length": 200,
+              "significantDigits": 4,
+              "origin": {
+                "type": "Collected",
+                "source": "Vendor"
+              },
+              "applicableWhen": [
+                "WC.LB.cfe14422"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRES.GGT",
+              "mandatory": false,
+              "name": "LBORRES",
+              "dataType": "float",
+              "length": 12,
+              "displayFormat": "12.4",
+              "significantDigits": 4,
+              "origin": {
+                "type": "Collected",
+                "source": "Vendor"
+              },
+              "applicableWhen": [
+                "WC.LB.8285c765"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRES.URATE",
+              "mandatory": false,
+              "name": "LBORRES",
+              "dataType": "float",
+              "length": 12,
+              "displayFormat": "12.4",
+              "significantDigits": 4,
+              "origin": {
+                "type": "Collected",
+                "source": "Vendor"
+              },
+              "applicableWhen": [
+                "WC.LB.37c7b4ba"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRES.PHOS",
+              "mandatory": false,
+              "name": "LBORRES",
+              "dataType": "float",
+              "length": 12,
+              "displayFormat": "12.4",
+              "significantDigits": 4,
+              "origin": {
+                "type": "Collected",
+                "source": "Vendor"
+              },
+              "applicableWhen": [
+                "WC.LB.e4e81dc5"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRES.CA",
+              "mandatory": false,
+              "name": "LBORRES",
+              "dataType": "float",
+              "length": 12,
+              "displayFormat": "12.4",
+              "significantDigits": 4,
+              "origin": {
+                "type": "Collected",
+                "source": "Vendor"
+              },
+              "applicableWhen": [
+                "WC.LB.470def9b"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRES.GLUC",
+              "mandatory": false,
+              "name": "LBORRES",
+              "dataType": "text",
+              "length": 200,
+              "applicableWhen": [
+                "WC.LB.c891c160"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRES.PROT",
+              "mandatory": false,
+              "name": "LBORRES",
+              "dataType": "text",
+              "length": 200,
+              "significantDigits": 4,
+              "origin": {
+                "type": "Collected",
+                "source": "Vendor"
+              },
+              "applicableWhen": [
+                "WC.LB.abcfd20c"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRES.CHOL",
+              "mandatory": false,
+              "name": "LBORRES",
+              "dataType": "float",
+              "length": 12,
+              "displayFormat": "12.4",
+              "significantDigits": 4,
+              "origin": {
+                "type": "Collected",
+                "source": "Vendor"
+              },
+              "applicableWhen": [
+                "WC.LB.5a1bca67"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRES.T3UP",
+              "mandatory": false,
+              "name": "LBORRES",
+              "dataType": "float",
+              "length": 12,
+              "displayFormat": "12.4",
+              "significantDigits": 4,
+              "origin": {
+                "type": "Collected",
+                "source": "Vendor"
+              },
+              "applicableWhen": [
+                "WC.LB.4226ee02"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRES.T3",
+              "mandatory": false,
+              "name": "LBORRES",
+              "dataType": "float",
+              "length": 12,
+              "displayFormat": "12.4",
+              "significantDigits": 4,
+              "origin": {
+                "type": "Collected",
+                "source": "Vendor"
+              },
+              "applicableWhen": [
+                "WC.LB.df33e99e"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRES.T4FR",
+              "mandatory": false,
+              "name": "LBORRES",
+              "dataType": "float",
+              "length": 12,
+              "displayFormat": "12.4",
+              "significantDigits": 4,
+              "origin": {
+                "type": "Collected",
+                "source": "Vendor"
+              },
+              "applicableWhen": [
+                "WC.LB.30f3d8b3"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRES.T4FRIDX",
+              "mandatory": false,
+              "name": "LBORRES",
+              "dataType": "float",
+              "length": 12,
+              "displayFormat": "12.4",
+              "significantDigits": 4,
+              "origin": {
+                "type": "Collected",
+                "source": "Vendor"
+              },
+              "applicableWhen": [
+                "WC.LB.f59f4529"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRES.TSH",
+              "mandatory": false,
+              "name": "LBORRES",
+              "dataType": "float",
+              "length": 12,
+              "displayFormat": "12.4",
+              "significantDigits": 4,
+              "origin": {
+                "type": "Collected",
+                "source": "Vendor"
+              },
+              "applicableWhen": [
+                "WC.LB.c54221c6"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRES.VITB9",
+              "mandatory": false,
+              "name": "LBORRES",
+              "dataType": "float",
+              "length": 12,
+              "displayFormat": "12.4",
+              "significantDigits": 4,
+              "origin": {
+                "type": "Collected",
+                "source": "Vendor"
+              },
+              "applicableWhen": [
+                "WC.LB.cb02cad8"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRES.VITB12",
+              "mandatory": false,
+              "name": "LBORRES",
+              "dataType": "float",
+              "length": 12,
+              "displayFormat": "12.4",
+              "significantDigits": 4,
+              "origin": {
+                "type": "Collected",
+                "source": "Vendor"
+              },
+              "applicableWhen": [
+                "WC.LB.d0f49556"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRES.COLOR",
+              "mandatory": false,
+              "name": "LBORRES",
+              "dataType": "text",
+              "length": 200,
+              "origin": {
+                "type": "Collected",
+                "source": "Vendor"
+              },
+              "applicableWhen": [
+                "WC.LB.4987b41e"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRES.SPGRAV",
+              "mandatory": false,
+              "name": "LBORRES",
+              "dataType": "float",
+              "length": 12,
+              "displayFormat": "12.4",
+              "significantDigits": 4,
+              "origin": {
+                "type": "Collected",
+                "source": "Vendor"
+              },
+              "applicableWhen": [
+                "WC.LB.cbf789d8"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRES.KETONES",
+              "mandatory": false,
+              "name": "LBORRES",
+              "dataType": "text",
+              "length": 200,
+              "significantDigits": 4,
+              "origin": {
+                "type": "Collected",
+                "source": "Vendor"
+              },
+              "applicableWhen": [
+                "WC.LB.3239d7a3"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRES.UROBIL",
+              "mandatory": false,
+              "name": "LBORRES",
+              "dataType": "float",
+              "length": 12,
+              "displayFormat": "12.4",
+              "significantDigits": 4,
+              "origin": {
+                "type": "Collected",
+                "source": "Vendor"
+              },
+              "applicableWhen": [
+                "WC.LB.59366afe"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRES.OCCBLD",
+              "mandatory": false,
+              "name": "LBORRES",
+              "dataType": "text",
+              "length": 200,
+              "significantDigits": 4,
+              "origin": {
+                "type": "Collected",
+                "source": "Vendor"
+              },
+              "applicableWhen": [
+                "WC.LB.3adc4566"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRES.NITRITE",
+              "mandatory": false,
+              "name": "LBORRES",
+              "dataType": "text",
+              "length": 200,
+              "significantDigits": 4,
+              "origin": {
+                "type": "Collected",
+                "source": "Vendor"
+              },
+              "applicableWhen": [
+                "WC.LB.59074de1"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRES.HBA1C",
+              "mandatory": false,
+              "name": "LBORRES",
+              "dataType": "float",
+              "length": 12,
+              "displayFormat": "12.4",
+              "significantDigits": 4,
+              "origin": {
+                "type": "Collected",
+                "source": "Vendor"
+              },
+              "applicableWhen": [
+                "WC.LB.c1765eee"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRES.HBA1CHGB",
+              "mandatory": false,
+              "name": "LBORRES",
+              "dataType": "float",
+              "length": 12,
+              "displayFormat": "12.4",
+              "significantDigits": 4,
+              "origin": {
+                "type": "Collected",
+                "source": "Vendor"
+              },
+              "applicableWhen": [
+                "WC.LB.dd459ec6"
+              ]
+            }
+          ]
+        },
+        {
+          "OID": "VL.LB.LBORRESU",
+          "name": "VL_LB_LBORRESU",
+          "type": "ValueList",
+          "wasDerivedFrom": "IT.LB.LBORRESU",
+          "items": [
+            {
+              "OID": "IT.LB.LBORRESU.HGB",
+              "mandatory": false,
+              "name": "LBORRESU",
+              "dataType": "text",
+              "applicableWhen": [
+                "WC.LB.e9a1c33d"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRESU.HCT",
+              "mandatory": false,
+              "name": "LBORRESU",
+              "dataType": "text",
+              "applicableWhen": [
+                "WC.LB.7f0975c7"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRESU.RBC",
+              "mandatory": false,
+              "name": "LBORRESU",
+              "dataType": "text",
+              "applicableWhen": [
+                "WC.LB.f7f1de35"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRESU.MCH",
+              "mandatory": false,
+              "name": "LBORRESU",
+              "dataType": "text",
+              "applicableWhen": [
+                "WC.LB.c32acb17"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRESU.MCHC",
+              "mandatory": false,
+              "name": "LBORRESU",
+              "dataType": "text",
+              "applicableWhen": [
+                "WC.LB.eb7f048a"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRESU.MCV",
+              "mandatory": false,
+              "name": "LBORRESU",
+              "dataType": "text",
+              "applicableWhen": [
+                "WC.LB.e881d4b5"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRESU.WBC",
+              "mandatory": false,
+              "name": "LBORRESU",
+              "dataType": "text",
+              "applicableWhen": [
+                "WC.LB.41785be6"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRESU.NEUTSG",
+              "mandatory": false,
+              "name": "LBORRESU",
+              "dataType": "text",
+              "applicableWhen": [
+                "WC.LB.a68e5eaa"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRESU.NEUTB",
+              "mandatory": false,
+              "name": "LBORRESU",
+              "dataType": "text",
+              "applicableWhen": [
+                "WC.LB.aad6dbd6"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRESU.NEUT",
+              "mandatory": false,
+              "name": "LBORRESU",
+              "dataType": "text",
+              "applicableWhen": [
+                "WC.LB.d13d6578"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRESU.MONO",
+              "mandatory": false,
+              "name": "LBORRESU",
+              "dataType": "text",
+              "applicableWhen": [
+                "WC.LB.00e6d228"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRESU.EOS",
+              "mandatory": false,
+              "name": "LBORRESU",
+              "dataType": "text",
+              "applicableWhen": [
+                "WC.LB.ef654de1"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRESU.BASO",
+              "mandatory": false,
+              "name": "LBORRESU",
+              "dataType": "text",
+              "applicableWhen": [
+                "WC.LB.b6fa6e8d"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRESU.PLAT",
+              "mandatory": false,
+              "name": "LBORRESU",
+              "dataType": "text",
+              "applicableWhen": [
+                "WC.LB.90eedf3b"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRESU.ALT",
+              "mandatory": false,
+              "name": "LBORRESU",
+              "dataType": "text",
+              "applicableWhen": [
+                "WC.LB.8914eb45"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRESU.ALP",
+              "mandatory": false,
+              "name": "LBORRESU",
+              "dataType": "text",
+              "applicableWhen": [
+                "WC.LB.6660e11c"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRESU.AST",
+              "mandatory": false,
+              "name": "LBORRESU",
+              "dataType": "text",
+              "applicableWhen": [
+                "WC.LB.37e389df"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRESU.CREAT",
+              "mandatory": false,
+              "name": "LBORRESU",
+              "dataType": "text",
+              "applicableWhen": [
+                "WC.LB.549f5ae4"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRESU.K",
+              "mandatory": false,
+              "name": "LBORRESU",
+              "dataType": "text",
+              "applicableWhen": [
+                "WC.LB.ee634517"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRESU.SODIUM",
+              "mandatory": false,
+              "name": "LBORRESU",
+              "dataType": "text",
+              "applicableWhen": [
+                "WC.LB.07a8daa1"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRESU.UREAN",
+              "mandatory": false,
+              "name": "LBORRESU",
+              "dataType": "text",
+              "applicableWhen": [
+                "WC.LB.91d1c3d5"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRESU.BICARB",
+              "mandatory": false,
+              "name": "LBORRESU",
+              "dataType": "text",
+              "applicableWhen": [
+                "WC.LB.9df0845c"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRESU.CL",
+              "mandatory": false,
+              "name": "LBORRESU",
+              "dataType": "text",
+              "applicableWhen": [
+                "WC.LB.cc8b6004"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRESU.GGT",
+              "mandatory": false,
+              "name": "LBORRESU",
+              "dataType": "text",
+              "applicableWhen": [
+                "WC.LB.3c564f36"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRESU.URATE",
+              "mandatory": false,
+              "name": "LBORRESU",
+              "dataType": "text",
+              "applicableWhen": [
+                "WC.LB.13fbb1a5"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRESU.PHOS",
+              "mandatory": false,
+              "name": "LBORRESU",
+              "dataType": "text",
+              "applicableWhen": [
+                "WC.LB.3749493c"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRESU.CA",
+              "mandatory": false,
+              "name": "LBORRESU",
+              "dataType": "text",
+              "applicableWhen": [
+                "WC.LB.38f9f39d"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRESU.CHOL",
+              "mandatory": false,
+              "name": "LBORRESU",
+              "dataType": "text",
+              "applicableWhen": [
+                "WC.LB.516f3664"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRESU.T3UP",
+              "mandatory": false,
+              "name": "LBORRESU",
+              "dataType": "text",
+              "applicableWhen": [
+                "WC.LB.dcbcbe57"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRESU.T3",
+              "mandatory": false,
+              "name": "LBORRESU",
+              "dataType": "text",
+              "applicableWhen": [
+                "WC.LB.b7b215a1"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRESU.T4FR",
+              "mandatory": false,
+              "name": "LBORRESU",
+              "dataType": "text",
+              "applicableWhen": [
+                "WC.LB.0f071538"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRESU.T4FRIDX",
+              "mandatory": false,
+              "name": "LBORRESU",
+              "dataType": "text",
+              "applicableWhen": [
+                "WC.LB.258e657c"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRESU.TSH",
+              "mandatory": false,
+              "name": "LBORRESU",
+              "dataType": "text",
+              "applicableWhen": [
+                "WC.LB.d675561c"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRESU.VITB9",
+              "mandatory": false,
+              "name": "LBORRESU",
+              "dataType": "text",
+              "applicableWhen": [
+                "WC.LB.e81938d6"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRESU.VITB12",
+              "mandatory": false,
+              "name": "LBORRESU",
+              "dataType": "text",
+              "applicableWhen": [
+                "WC.LB.54dda2d1"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRESU.UROBIL",
+              "mandatory": false,
+              "name": "LBORRESU",
+              "dataType": "text",
+              "applicableWhen": [
+                "WC.LB.e6a434ec"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRESU.HBA1C",
+              "mandatory": false,
+              "name": "LBORRESU",
+              "dataType": "text",
+              "applicableWhen": [
+                "WC.LB.9e9118c8"
+              ]
+            },
+            {
+              "OID": "IT.LB.LBORRESU.HBA1CHGB",
+              "mandatory": false,
+              "name": "LBORRESU",
+              "dataType": "text",
+              "applicableWhen": [
+                "WC.LB.8644d9ca"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "OID": "IG.MB",
+      "name": "MB",
+      "description": "Microbiology Specimen",
+      "domain": "MB",
+      "purpose": "Tabulation",
+      "structure": "One record per microbiology specimen finding per time point per visit per subject",
+      "isReferenceData": false,
+      "keySequence": [
+        "__PLACEHOLDER__"
+      ],
+      "standard": "STD.SDTMIG",
+      "observationClass": {
+        "name": "FINDINGS"
+      },
+      "items": [
+        {
+          "OID": "IT.MB.STUDYID",
+          "mandatory": true,
+          "name": "STUDYID",
+          "description": "Study Identifier",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.MB.DOMAIN",
+          "mandatory": true,
+          "name": "DOMAIN",
+          "description": "Domain Abbreviation",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.MB.USUBJID",
+          "mandatory": true,
+          "name": "USUBJID",
+          "description": "Unique Subject Identifier",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.MB.MBSEQ",
+          "mandatory": true,
+          "name": "MBSEQ",
+          "description": "Sequence Number",
+          "role": "Identifier",
+          "dataType": "integer",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.MB.MBTESTCD",
+          "mandatory": true,
+          "name": "MBTESTCD",
+          "description": "Microbiology Test or Finding Short Name",
+          "role": "Topic",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.MBTESTCD"
+        },
+        {
+          "OID": "IT.MB.MBTEST",
+          "mandatory": true,
+          "name": "MBTEST",
+          "description": "Microbiology Test or Finding Name",
+          "role": "Synonym Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.MBTEST"
+        },
+        {
+          "OID": "IT.MB.MBTSTDTL",
+          "mandatory": false,
+          "name": "MBTSTDTL",
+          "description": "Measurement, Test or Examination Detail",
+          "role": "Variable Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.MBFTSDTL"
+        },
+        {
+          "OID": "IT.MB.MBORRES",
+          "mandatory": false,
+          "name": "MBORRES",
+          "description": "Result or Finding in Original Units",
+          "role": "Result Qualifier",
+          "dataType": "text",
+          "length": 20,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.MB.MBSTRESC",
+          "mandatory": false,
+          "name": "MBSTRESC",
+          "description": "Result or Finding in Standard Format",
+          "role": "Result Qualifier",
+          "dataType": "text",
+          "length": 20,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.MB.MBSPEC",
+          "mandatory": false,
+          "name": "MBSPEC",
+          "description": "Specimen Material Type",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.SPECTYPE"
+        },
+        {
+          "OID": "IT.MB.MBMETHOD",
+          "mandatory": false,
+          "name": "MBMETHOD",
+          "description": "Method of Test or Examination",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.METHOD"
+        },
+        {
+          "OID": "IT.MB.VISITNUM",
+          "mandatory": false,
+          "name": "VISITNUM",
+          "description": "Visit Number",
+          "role": "Timing",
+          "dataType": "integer",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.MB.MBDTC",
+          "mandatory": false,
+          "name": "MBDTC",
+          "description": "Date/Time of Collection",
+          "role": "Timing",
+          "dataType": "datetime",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        }
+      ],
+      "slices": [
+        {
+          "OID": "VL.MB.MBORRES",
+          "name": "VL_MB_MBORRES",
+          "type": "ValueList",
+          "wasDerivedFrom": "IT.MB.MBORRES",
+          "items": [
+            {
+              "OID": "IT.MB.MBORRES.TPLAB",
+              "mandatory": false,
+              "name": "MBORRES",
+              "dataType": "text",
+              "length": 20,
+              "applicableWhen": [
+                "WC.MB.49773274"
+              ]
+            },
+            {
+              "OID": "IT.MB.MBORRES.TPADNA",
+              "mandatory": false,
+              "name": "MBORRES",
+              "dataType": "text",
+              "length": 20,
+              "applicableWhen": [
+                "WC.MB.e698c5a2"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "OID": "IG.EC",
+      "name": "EC",
+      "description": "Exposure as Collected",
+      "domain": "EC",
+      "purpose": "Tabulation",
+      "structure": "One record per protocol-specified study treatment, collected-dosing interval, per subject, per mood",
+      "isReferenceData": false,
+      "keySequence": [
+        "__PLACEHOLDER__"
+      ],
+      "standard": "STD.SDTMIG",
+      "observationClass": {
+        "name": "INTERVENTIONS"
+      },
+      "items": [
+        {
+          "OID": "IT.EC.STUDYID",
+          "mandatory": true,
+          "name": "STUDYID",
+          "description": "Study Identifier",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.EC.DOMAIN",
+          "mandatory": true,
+          "name": "DOMAIN",
+          "description": "Domain Abbreviation",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.EC.USUBJID",
+          "mandatory": true,
+          "name": "USUBJID",
+          "description": "Unique Subject Identifier",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.EC.ECSEQ",
+          "mandatory": true,
+          "name": "ECSEQ",
+          "description": "Sequence Number",
+          "role": "Identifier",
+          "dataType": "integer",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.EC.ECREFID",
+          "mandatory": false,
+          "name": "ECREFID",
+          "description": "Reference ID",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          }
+        },
+        {
+          "OID": "IT.EC.ECTRT",
+          "mandatory": true,
+          "name": "ECTRT",
+          "description": "Name of Treatment",
+          "role": "Topic",
+          "dataType": "text",
+          "length": 200,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          }
+        },
+        {
+          "OID": "IT.EC.ECDOSE",
+          "mandatory": false,
+          "name": "ECDOSE",
+          "description": "Dose",
+          "role": "Record Qualifier",
+          "dataType": "integer",
+          "length": 20,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          }
+        },
+        {
+          "OID": "IT.EC.ECDOSTXT",
+          "mandatory": false,
+          "name": "ECDOSTXT",
+          "description": "Dose Description",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": 100,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          }
+        },
+        {
+          "OID": "IT.EC.ECDOSU",
+          "mandatory": false,
+          "name": "ECDOSU",
+          "description": "Dose Units",
+          "role": "Variable Qualifier",
+          "dataType": "text",
+          "length": 200,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          },
+          "codeList": "CL.UNIT"
+        },
+        {
+          "OID": "IT.EC.ECDOSFRM",
+          "mandatory": false,
+          "name": "ECDOSFRM",
+          "description": "Dose Form",
+          "role": "Variable Qualifier",
+          "dataType": "text",
+          "length": 200,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          },
+          "codeList": "CL.FRM"
+        },
+        {
+          "OID": "IT.EC.ECDOSFRQ",
+          "mandatory": false,
+          "name": "ECDOSFRQ",
+          "description": "Dosing Frequency per Interval",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": 200,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          },
+          "codeList": "CL.FREQ"
+        },
+        {
+          "OID": "IT.EC.ECDOSRGM",
+          "mandatory": false,
+          "name": "ECDOSRGM",
+          "description": "Intended Dose Regimen",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          }
+        },
+        {
+          "OID": "IT.EC.ECROUTE",
+          "mandatory": false,
+          "name": "ECROUTE",
+          "description": "Route of Administration",
+          "role": "Variable Qualifier",
+          "dataType": "text",
+          "length": 200,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          },
+          "codeList": "CL.ROUTE"
+        },
+        {
+          "OID": "IT.EC.ECLOC",
+          "mandatory": false,
+          "name": "ECLOC",
+          "description": "Location of Dose Administration",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": 200,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          },
+          "codeList": "CL.LOC"
+        },
+        {
+          "OID": "IT.EC.ECLAT",
+          "mandatory": false,
+          "name": "ECLAT",
+          "description": "Laterality",
+          "role": "Variable Qualifier",
+          "dataType": "text",
+          "length": 200,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          },
+          "codeList": "CL.LAT"
+        },
+        {
+          "OID": "IT.EC.ECDIR",
+          "mandatory": false,
+          "name": "ECDIR",
+          "description": "Directionality",
+          "role": "Variable Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          },
+          "codeList": "CL.DIR"
+        },
+        {
+          "OID": "IT.EC.ECSTDTC",
+          "mandatory": false,
+          "name": "ECSTDTC",
+          "description": "Start Date/Time of Treatment",
+          "role": "Timing",
+          "dataType": "datetime",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.EC.ECENDTC",
+          "mandatory": false,
+          "name": "ECENDTC",
+          "description": "End Date/Time of Treatment",
+          "role": "Timing",
+          "dataType": "datetime",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        }
+      ]
+    },
+    {
+      "OID": "IG.AE",
+      "name": "AE",
+      "description": "Adverse Events",
+      "domain": "AE",
+      "purpose": "Tabulation",
+      "structure": "One record per adverse event per subject",
+      "isReferenceData": false,
+      "keySequence": [
+        "__PLACEHOLDER__"
+      ],
+      "standard": "STD.SDTMIG",
+      "observationClass": {
+        "name": "EVENTS"
+      },
+      "items": [
+        {
+          "OID": "IT.AE.STUDYID",
+          "mandatory": true,
+          "name": "STUDYID",
+          "description": "Study Identifier",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.AE.DOMAIN",
+          "mandatory": true,
+          "name": "DOMAIN",
+          "description": "Domain Abbreviation",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.AE.USUBJID",
+          "mandatory": true,
+          "name": "USUBJID",
+          "description": "Unique Subject Identifier",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.AE.AESEQ",
+          "mandatory": true,
+          "name": "AESEQ",
+          "description": "Sequence Number",
+          "role": "Identifier",
+          "dataType": "integer",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.AE.AETERM",
+          "mandatory": true,
+          "name": "AETERM",
+          "description": "Reported Term for the Adverse Event",
+          "role": "Topic",
+          "dataType": "text",
+          "length": 200,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          }
+        },
+        {
+          "OID": "IT.AE.AELLT",
+          "mandatory": false,
+          "name": "AELLT",
+          "description": "Lowest Level Term",
+          "role": "Variable Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.AE.AELLTCD",
+          "mandatory": false,
+          "name": "AELLTCD",
+          "description": "Lowest Level Term Code",
+          "role": "Variable Qualifier",
+          "dataType": "integer",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.AE.AEDECOD",
+          "mandatory": true,
+          "name": "AEDECOD",
+          "description": "Dictionary-Derived Term",
+          "role": "Synonym Qualifier",
+          "dataType": "text",
+          "length": 200,
+          "origin": {
+            "type": "Assigned",
+            "source": "Sponsor"
+          }
+        },
+        {
+          "OID": "IT.AE.AEPTCD",
+          "mandatory": false,
+          "name": "AEPTCD",
+          "description": "Preferred Term Code",
+          "role": "Variable Qualifier",
+          "dataType": "integer",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.AE.AEHLT",
+          "mandatory": false,
+          "name": "AEHLT",
+          "description": "High Level Term",
+          "role": "Variable Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.AE.AEHLTCD",
+          "mandatory": false,
+          "name": "AEHLTCD",
+          "description": "High Level Term Code",
+          "role": "Variable Qualifier",
+          "dataType": "integer",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.AE.AEHLGT",
+          "mandatory": false,
+          "name": "AEHLGT",
+          "description": "High Level Group Term",
+          "role": "Variable Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.AE.AEHLGTCD",
+          "mandatory": false,
+          "name": "AEHLGTCD",
+          "description": "High Level Group Term Code",
+          "role": "Variable Qualifier",
+          "dataType": "integer",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.AE.AECAT",
+          "mandatory": false,
+          "name": "AECAT",
+          "description": "Category for Adverse Event",
+          "role": "Grouping Qualifier",
+          "dataType": "text",
+          "length": 200,
+          "origin": {
+            "type": "Assigned",
+            "source": "Sponsor"
+          }
+        },
+        {
+          "OID": "IT.AE.AESCAT",
+          "mandatory": false,
+          "name": "AESCAT",
+          "description": "Subcategory for Adverse Event",
+          "role": "Grouping Qualifier",
+          "dataType": "text",
+          "length": 200,
+          "origin": {
+            "type": "Assigned",
+            "source": "Sponsor"
+          }
+        },
+        {
+          "OID": "IT.AE.AEPRESP",
+          "mandatory": false,
+          "name": "AEPRESP",
+          "description": "Pre-Specified Adverse Event",
+          "role": "Variable Qualifier",
+          "dataType": "text",
+          "length": 1,
+          "origin": {
+            "type": "Assigned",
+            "source": "Sponsor"
+          },
+          "codeList": "CL.NY"
+        },
+        {
+          "OID": "IT.AE.AEBODSYS",
+          "mandatory": false,
+          "name": "AEBODSYS",
+          "description": "Body System or Organ Class",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.AE.AEBDSYCD",
+          "mandatory": false,
+          "name": "AEBDSYCD",
+          "description": "Body System or Organ Class Code",
+          "role": "Variable Qualifier",
+          "dataType": "integer",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.AE.AESOC",
+          "mandatory": false,
+          "name": "AESOC",
+          "description": "Primary System Organ Class",
+          "role": "Variable Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.AE.AESOCCD",
+          "mandatory": false,
+          "name": "AESOCCD",
+          "description": "Primary System Organ Class Code",
+          "role": "Variable Qualifier",
+          "dataType": "integer",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.AE.AELOC",
+          "mandatory": false,
+          "name": "AELOC",
+          "description": "Location of Event",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": 200,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          },
+          "codeList": "CL.LOC"
+        },
+        {
+          "OID": "IT.AE.AESEV",
+          "mandatory": false,
+          "name": "AESEV",
+          "description": "Severity/Intensity",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": 20,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          },
+          "codeList": "CL.AESEV"
+        },
+        {
+          "OID": "IT.AE.AESER",
+          "mandatory": false,
+          "name": "AESER",
+          "description": "Serious Event",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": 1,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          },
+          "codeList": "CL.NY"
+        },
+        {
+          "OID": "IT.AE.AEACN",
+          "mandatory": false,
+          "name": "AEACN",
+          "description": "Action Taken with Study Treatment",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": 200,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          },
+          "codeList": "CL.ACN"
+        },
+        {
+          "OID": "IT.AE.AEACNOTH",
+          "mandatory": false,
+          "name": "AEACNOTH",
+          "description": "Other Action Taken",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": 200,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          }
+        },
+        {
+          "OID": "IT.AE.AEREL",
+          "mandatory": false,
+          "name": "AEREL",
+          "description": "Causality",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": 200,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          }
+        },
+        {
+          "OID": "IT.AE.AERELNST",
+          "mandatory": false,
+          "name": "AERELNST",
+          "description": "Relationship to Non-Study Treatment",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": 200,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          }
+        },
+        {
+          "OID": "IT.AE.AEPATT",
+          "mandatory": false,
+          "name": "AEPATT",
+          "description": "Pattern of Adverse Event",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": 200,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          }
+        },
+        {
+          "OID": "IT.AE.AEOUT",
+          "mandatory": false,
+          "name": "AEOUT",
+          "description": "Outcome of Adverse Event",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": 200,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          },
+          "codeList": "CL.OUT"
+        },
+        {
+          "OID": "IT.AE.AESCAN",
+          "mandatory": false,
+          "name": "AESCAN",
+          "description": "Involves Cancer",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": 1,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          },
+          "codeList": "CL.NY"
+        },
+        {
+          "OID": "IT.AE.AESCONG",
+          "mandatory": false,
+          "name": "AESCONG",
+          "description": "Congenital Anomaly or Birth Defect",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": 1,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          },
+          "codeList": "CL.NY"
+        },
+        {
+          "OID": "IT.AE.AESDISAB",
+          "mandatory": false,
+          "name": "AESDISAB",
+          "description": "Persist or Signif Disability/Incapacity",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": 1,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          },
+          "codeList": "CL.NY"
+        },
+        {
+          "OID": "IT.AE.AESDTH",
+          "mandatory": false,
+          "name": "AESDTH",
+          "description": "Results in Death",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": 1,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          },
+          "codeList": "CL.NY"
+        },
+        {
+          "OID": "IT.AE.AESHOSP",
+          "mandatory": false,
+          "name": "AESHOSP",
+          "description": "Requires or Prolongs Hospitalization",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": 1,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          },
+          "codeList": "CL.NY"
+        },
+        {
+          "OID": "IT.AE.AESLIFE",
+          "mandatory": false,
+          "name": "AESLIFE",
+          "description": "Is Life Threatening",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": 1,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          },
+          "codeList": "CL.NY"
+        },
+        {
+          "OID": "IT.AE.AESOD",
+          "mandatory": false,
+          "name": "AESOD",
+          "description": "Occurred with Overdose",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": 1,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          },
+          "codeList": "CL.NY"
+        },
+        {
+          "OID": "IT.AE.AESMIE",
+          "mandatory": false,
+          "name": "AESMIE",
+          "description": "Other Medically Important Serious Event",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": 1,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          },
+          "codeList": "CL.NY"
+        },
+        {
+          "OID": "IT.AE.AECONTRT",
+          "mandatory": false,
+          "name": "AECONTRT",
+          "description": "Concomitant or Additional Trtmnt Given",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": 1,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          },
+          "codeList": "CL.NY"
+        },
+        {
+          "OID": "IT.AE.AETOXGR",
+          "mandatory": false,
+          "name": "AETOXGR",
+          "description": "Standard Toxicity Grade",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": 1,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          }
+        },
+        {
+          "OID": "IT.AE.AESTDTC",
+          "mandatory": false,
+          "name": "AESTDTC",
+          "description": "Start Date/Time of Adverse Event",
+          "role": "Timing",
+          "dataType": "datetime",
+          "length": null,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          }
+        },
+        {
+          "OID": "IT.AE.AEENDTC",
+          "mandatory": false,
+          "name": "AEENDTC",
+          "description": "End Date/Time of Adverse Event",
+          "role": "Timing",
+          "dataType": "datetime",
+          "length": null,
+          "origin": {
+            "type": "Collected",
+            "source": "Investigator"
+          }
+        },
+        {
+          "OID": "IT.AE.AEENRF",
+          "mandatory": false,
+          "name": "AEENRF",
+          "description": "End Relative to Reference Period",
+          "role": "Timing",
+          "dataType": "text",
+          "length": 20,
+          "origin": {
+            "type": "Assigned",
+            "source": "Sponsor"
+          },
+          "codeList": "CL.STENRF"
+        },
+        {
+          "OID": "IT.AE.AEENRTPT",
+          "mandatory": false,
+          "name": "AEENRTPT",
+          "description": "End Relative to Reference Time Point",
+          "role": "Timing",
+          "dataType": "text",
+          "length": 20,
+          "origin": {
+            "type": "Assigned",
+            "source": "Sponsor"
+          },
+          "codeList": "CL.STENRF"
+        },
+        {
+          "OID": "IT.AE.AEENTPT",
+          "mandatory": false,
+          "name": "AEENTPT",
+          "description": "End Reference Time Point",
+          "role": "Timing",
+          "dataType": "text",
+          "length": 20,
+          "origin": {
+            "type": "Assigned",
+            "source": "Sponsor"
+          }
+        }
+      ]
+    },
+    {
+      "OID": "IG.TS",
+      "name": "TS",
+      "description": "Trial Summary",
+      "domain": "TS",
+      "purpose": "Tabulation",
+      "structure": "One record per trial summary parameter value",
+      "isReferenceData": true,
+      "keySequence": [
+        "__PLACEHOLDER__"
+      ],
+      "standard": "STD.SDTMIG",
+      "observationClass": {
+        "name": "TRIAL DESIGN"
+      },
+      "items": [
+        {
+          "OID": "IT.TS.STUDYID",
+          "mandatory": true,
+          "name": "STUDYID",
+          "description": "Study Identifier",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.TS.DOMAIN",
+          "mandatory": true,
+          "name": "DOMAIN",
+          "description": "Domain Abbreviation",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.TS.TSSEQ",
+          "mandatory": true,
+          "name": "TSSEQ",
+          "description": "Sequence Number",
+          "role": "Identifier",
+          "dataType": "integer",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.TS.TSPARMCD",
+          "mandatory": true,
+          "name": "TSPARMCD",
+          "description": "Trial Summary Parameter Short Name",
+          "role": "Topic",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.TSPARMCD"
+        },
+        {
+          "OID": "IT.TS.TSPARM",
+          "mandatory": true,
+          "name": "TSPARM",
+          "description": "Trial Summary Parameter",
+          "role": "Synonym Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.TSPARM"
+        },
+        {
+          "OID": "IT.TS.TSVAL",
+          "mandatory": false,
+          "name": "TSVAL",
+          "description": "Parameter Value",
+          "role": "Result Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.TS.TSVALCD",
+          "mandatory": false,
+          "name": "TSVALCD",
+          "description": "Parameter Value Code",
+          "role": "Result Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.TS.TSVCDREF",
+          "mandatory": false,
+          "name": "TSVCDREF",
+          "description": "Name of the Reference Terminology",
+          "role": "Result Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.DICTNAM"
+        },
+        {
+          "OID": "IT.TS.TSVCDVER",
+          "mandatory": false,
+          "name": "TSVCDVER",
+          "description": "Version of the Reference Terminology",
+          "role": "Result Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        }
+      ],
+      "slices": [
+        {
+          "OID": "VL.TS.TSPARMCD",
+          "name": "VL_TS_TSPARMCD",
+          "type": "ValueList",
+          "wasDerivedFrom": "IT.TS.TSPARMCD",
+          "items": [
+            {
+              "OID": "IT.TS.TSPARMCD.ADAPT",
+              "mandatory": false,
+              "name": "TSPARMCD",
+              "dataType": "text",
+              "length": 1,
+              "codeList": "CL.NY",
+              "origin": {
+                "type": "Protocol",
+                "source": "Sponsor"
+              },
+              "applicableWhen": [
+                "WC.TS.08ebd0ce"
+              ]
+            },
+            {
+              "OID": "IT.TS.TSPARMCD.AGEMIN",
+              "mandatory": false,
+              "name": "TSPARMCD",
+              "dataType": "text",
+              "length": 200,
+              "origin": {
+                "type": "Protocol",
+                "source": "Sponsor"
+              },
+              "applicableWhen": [
+                "WC.TS.a7d24f4a"
+              ]
+            },
+            {
+              "OID": "IT.TS.TSPARMCD.AGEMAX",
+              "mandatory": false,
+              "name": "TSPARMCD",
+              "dataType": "text",
+              "length": 200,
+              "origin": {
+                "type": "Protocol",
+                "source": "Sponsor"
+              },
+              "applicableWhen": [
+                "WC.TS.4ac86c98"
+              ]
+            },
+            {
+              "OID": "IT.TS.TSPARMCD.COMPTRT",
+              "mandatory": false,
+              "name": "TSPARMCD",
+              "dataType": "text",
+              "length": 200,
+              "origin": {
+                "type": "Protocol",
+                "source": "Sponsor"
+              },
+              "applicableWhen": [
+                "WC.TS.54cd02f1"
+              ]
+            },
+            {
+              "OID": "IT.TS.TSPARMCD.CRMDUR",
+              "mandatory": false,
+              "name": "TSPARMCD",
+              "dataType": "text",
+              "length": 200,
+              "origin": {
+                "type": "Protocol",
+                "source": "Sponsor"
+              },
+              "applicableWhen": [
+                "WC.TS.f9fa8745"
+              ]
+            },
+            {
+              "OID": "IT.TS.TSPARMCD.DOSE",
+              "mandatory": false,
+              "name": "TSPARMCD",
+              "dataType": "text",
+              "length": 200,
+              "origin": {
+                "type": "Protocol",
+                "source": "Sponsor"
+              },
+              "applicableWhen": [
+                "WC.TS.7fc6c3e6"
+              ]
+            },
+            {
+              "OID": "IT.TS.TSPARMCD.DOSFRQ",
+              "mandatory": false,
+              "name": "TSPARMCD",
+              "dataType": "text",
+              "length": 200,
+              "origin": {
+                "type": "Protocol",
+                "source": "Sponsor"
+              },
+              "applicableWhen": [
+                "WC.TS.5cd14c68"
+              ]
+            },
+            {
+              "OID": "IT.TS.TSPARMCD.DOSU",
+              "mandatory": false,
+              "name": "TSPARMCD",
+              "dataType": "text",
+              "length": 200,
+              "origin": {
+                "type": "Protocol",
+                "source": "Sponsor"
+              },
+              "applicableWhen": [
+                "WC.TS.4053f56c"
+              ]
+            },
+            {
+              "OID": "IT.TS.TSPARMCD.INDIC",
+              "mandatory": false,
+              "name": "TSPARMCD",
+              "dataType": "text",
+              "length": 200,
+              "origin": {
+                "type": "Protocol",
+                "source": "Sponsor"
+              },
+              "applicableWhen": [
+                "WC.TS.9cdae039"
+              ]
+            },
+            {
+              "OID": "IT.TS.TSPARMCD.INTMODEL",
+              "mandatory": false,
+              "name": "TSPARMCD",
+              "dataType": "text",
+              "length": 200,
+              "origin": {
+                "type": "Protocol",
+                "source": "Sponsor"
+              },
+              "applicableWhen": [
+                "WC.TS.2c83b5d9"
+              ]
+            },
+            {
+              "OID": "IT.TS.TSPARMCD.INTTYPE",
+              "mandatory": false,
+              "name": "TSPARMCD",
+              "dataType": "text",
+              "length": 200,
+              "origin": {
+                "type": "Protocol",
+                "source": "Sponsor"
+              },
+              "applicableWhen": [
+                "WC.TS.e3ae16cd"
+              ]
+            },
+            {
+              "OID": "IT.TS.TSPARMCD.NARMS",
+              "mandatory": false,
+              "name": "TSPARMCD",
+              "dataType": "text",
+              "length": 200,
+              "origin": {
+                "type": "Protocol",
+                "source": "Sponsor"
+              },
+              "applicableWhen": [
+                "WC.TS.89c0d243"
+              ]
+            },
+            {
+              "OID": "IT.TS.TSPARMCD.OBJPRIM",
+              "mandatory": false,
+              "name": "TSPARMCD",
+              "dataType": "text",
+              "length": 200,
+              "origin": {
+                "type": "Protocol",
+                "source": "Sponsor"
+              },
+              "applicableWhen": [
+                "WC.TS.7a056c75"
+              ]
+            },
+            {
+              "OID": "IT.TS.TSPARMCD.OBJSEC",
+              "mandatory": false,
+              "name": "TSPARMCD",
+              "dataType": "text",
+              "length": 200,
+              "origin": {
+                "type": "Protocol",
+                "source": "Sponsor"
+              },
+              "applicableWhen": [
+                "WC.TS.36721696"
+              ]
+            },
+            {
+              "OID": "IT.TS.TSPARMCD.OUTMSPRI",
+              "mandatory": false,
+              "name": "TSPARMCD",
+              "dataType": "text",
+              "length": 200,
+              "origin": {
+                "type": "Protocol",
+                "source": "Sponsor"
+              },
+              "applicableWhen": [
+                "WC.TS.d8b84608"
+              ]
+            },
+            {
+              "OID": "IT.TS.TSPARMCD.OUTMSSEC",
+              "mandatory": false,
+              "name": "TSPARMCD",
+              "dataType": "text",
+              "length": 200,
+              "origin": {
+                "type": "Protocol",
+                "source": "Sponsor"
+              },
+              "applicableWhen": [
+                "WC.TS.1d3cd461"
+              ]
+            },
+            {
+              "OID": "IT.TS.TSPARMCD.PLANSUB",
+              "mandatory": false,
+              "name": "TSPARMCD",
+              "dataType": "text",
+              "length": 200,
+              "origin": {
+                "type": "Protocol",
+                "source": "Sponsor"
+              },
+              "applicableWhen": [
+                "WC.TS.3a1c5c3c"
+              ]
+            },
+            {
+              "OID": "IT.TS.TSPARMCD.PTRTDUR",
+              "mandatory": false,
+              "name": "TSPARMCD",
+              "dataType": "text",
+              "length": 200,
+              "origin": {
+                "type": "Protocol",
+                "source": "Sponsor"
+              },
+              "applicableWhen": [
+                "WC.TS.2b2d70bc"
+              ]
+            },
+            {
+              "OID": "IT.TS.TSPARMCD.ROUTE",
+              "mandatory": false,
+              "name": "TSPARMCD",
+              "dataType": "text",
+              "length": 200,
+              "origin": {
+                "type": "Protocol",
+                "source": "Sponsor"
+              },
+              "applicableWhen": [
+                "WC.TS.3c4a8bf2"
+              ]
+            },
+            {
+              "OID": "IT.TS.TSPARMCD.SEXPOP",
+              "mandatory": false,
+              "name": "TSPARMCD",
+              "dataType": "text",
+              "length": 200,
+              "origin": {
+                "type": "Protocol",
+                "source": "Sponsor"
+              },
+              "applicableWhen": [
+                "WC.TS.4f0c74c2"
+              ]
+            },
+            {
+              "OID": "IT.TS.TSPARMCD.SPONSOR",
+              "mandatory": false,
+              "name": "TSPARMCD",
+              "dataType": "text",
+              "length": 200,
+              "origin": {
+                "type": "Protocol",
+                "source": "Sponsor"
+              },
+              "applicableWhen": [
+                "WC.TS.51236927"
+              ]
+            },
+            {
+              "OID": "IT.TS.TSPARMCD.STYPE",
+              "mandatory": false,
+              "name": "TSPARMCD",
+              "dataType": "text",
+              "length": 200,
+              "origin": {
+                "type": "Protocol",
+                "source": "Sponsor"
+              },
+              "applicableWhen": [
+                "WC.TS.f4cb41bb"
+              ]
+            },
+            {
+              "OID": "IT.TS.TSPARMCD.TBLIND",
+              "mandatory": false,
+              "name": "TSPARMCD",
+              "dataType": "text",
+              "length": 200,
+              "origin": {
+                "type": "Protocol",
+                "source": "Sponsor"
+              },
+              "applicableWhen": [
+                "WC.TS.9e101607"
+              ]
+            },
+            {
+              "OID": "IT.TS.TSPARMCD.THERAREA",
+              "mandatory": false,
+              "name": "TSPARMCD",
+              "dataType": "text",
+              "length": 200,
+              "origin": {
+                "type": "Protocol",
+                "source": "Sponsor"
+              },
+              "applicableWhen": [
+                "WC.TS.d8c1ac4c"
+              ]
+            },
+            {
+              "OID": "IT.TS.TSPARMCD.TINDTP",
+              "mandatory": false,
+              "name": "TSPARMCD",
+              "dataType": "text",
+              "length": 200,
+              "origin": {
+                "type": "Protocol",
+                "source": "Sponsor"
+              },
+              "applicableWhen": [
+                "WC.TS.e423672b"
+              ]
+            },
+            {
+              "OID": "IT.TS.TSPARMCD.TITLE",
+              "mandatory": false,
+              "name": "TSPARMCD",
+              "dataType": "text",
+              "length": 200,
+              "origin": {
+                "type": "Protocol",
+                "source": "Sponsor"
+              },
+              "applicableWhen": [
+                "WC.TS.43684533"
+              ]
+            },
+            {
+              "OID": "IT.TS.TSPARMCD.TPHASE",
+              "mandatory": false,
+              "name": "TSPARMCD",
+              "dataType": "text",
+              "length": 200,
+              "origin": {
+                "type": "Protocol",
+                "source": "Sponsor"
+              },
+              "applicableWhen": [
+                "WC.TS.22640600"
+              ]
+            },
+            {
+              "OID": "IT.TS.TSPARMCD.TRT",
+              "mandatory": false,
+              "name": "TSPARMCD",
+              "dataType": "text",
+              "length": 200,
+              "origin": {
+                "type": "Protocol",
+                "source": "Sponsor"
+              },
+              "applicableWhen": [
+                "WC.TS.1948fed3"
+              ]
+            },
+            {
+              "OID": "IT.TS.TSPARMCD.TTYPE",
+              "mandatory": false,
+              "name": "TSPARMCD",
+              "dataType": "text",
+              "length": 200,
+              "origin": {
+                "type": "Protocol",
+                "source": "Sponsor"
+              },
+              "applicableWhen": [
+                "WC.TS.29af0670"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "OID": "IG.TA",
+      "name": "TA",
+      "description": "Trial Arms",
+      "domain": "TA",
+      "purpose": "Tabulation",
+      "structure": "One record per planned Element per Arm",
+      "isReferenceData": true,
+      "keySequence": [
+        "__PLACEHOLDER__"
+      ],
+      "standard": "STD.SDTMIG",
+      "observationClass": {
+        "name": "TRIAL DESIGN"
+      },
+      "items": [
+        {
+          "OID": "IT.TA.STUDYID",
+          "mandatory": true,
+          "name": "STUDYID",
+          "description": "Study Identifier",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.TA.DOMAIN",
+          "mandatory": true,
+          "name": "DOMAIN",
+          "description": "Domain Abbreviation",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.TA.ARMCD",
+          "mandatory": true,
+          "name": "ARMCD",
+          "description": "Planned Arm Code",
+          "role": "Topic",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.ARMCD"
+        },
+        {
+          "OID": "IT.TA.ARM",
+          "mandatory": true,
+          "name": "ARM",
+          "description": "Description of Planned Arm",
+          "role": "Synonym Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.ARM"
+        },
+        {
+          "OID": "IT.TA.TAETORD",
+          "mandatory": true,
+          "name": "TAETORD",
+          "description": "Planned Order of Element within Arm",
+          "role": "Timing",
+          "dataType": "integer",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.TA.ETCD",
+          "mandatory": true,
+          "name": "ETCD",
+          "description": "Element Code",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.ETCD"
+        },
+        {
+          "OID": "IT.TA.ELEMENT",
+          "mandatory": false,
+          "name": "ELEMENT",
+          "description": "Description of Element",
+          "role": "Synonym Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.ELEMENT"
+        },
+        {
+          "OID": "IT.TA.TABRANCH",
+          "mandatory": false,
+          "name": "TABRANCH",
+          "description": "Branch",
+          "role": "Rule",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.TA.TATRANS",
+          "mandatory": false,
+          "name": "TATRANS",
+          "description": "Transition Rule",
+          "role": "Rule",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.TA.EPOCH",
+          "mandatory": true,
+          "name": "EPOCH",
+          "description": "Epoch",
+          "role": "Timing",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.EPOCH"
+        }
+      ]
+    },
+    {
+      "OID": "IG.TE",
+      "name": "TE",
+      "description": "Trial Elements",
+      "domain": "TE",
+      "purpose": "Tabulation",
+      "structure": "One record per planned Element",
+      "isReferenceData": true,
+      "keySequence": [
+        "__PLACEHOLDER__"
+      ],
+      "standard": "STD.SDTMIG",
+      "observationClass": {
+        "name": "TRIAL DESIGN"
+      },
+      "items": [
+        {
+          "OID": "IT.TE.STUDYID",
+          "mandatory": true,
+          "name": "STUDYID",
+          "description": "Study Identifier",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.TE.DOMAIN",
+          "mandatory": true,
+          "name": "DOMAIN",
+          "description": "Domain Abbreviation",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.TE.ETCD",
+          "mandatory": true,
+          "name": "ETCD",
+          "description": "Element Code",
+          "role": "Topic",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.ETCD"
+        },
+        {
+          "OID": "IT.TE.ELEMENT",
+          "mandatory": true,
+          "name": "ELEMENT",
+          "description": "Description of Element",
+          "role": "Synonym Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.ELEMENT"
+        },
+        {
+          "OID": "IT.TE.TESTRL",
+          "mandatory": true,
+          "name": "TESTRL",
+          "description": "Rule for Start of Element",
+          "role": "Rule",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        }
+      ]
+    },
+    {
+      "OID": "IG.TI",
+      "name": "TI",
+      "description": "Trial Inclusion/Exclusion Criteria",
+      "domain": "TI",
+      "purpose": "Tabulation",
+      "structure": "One record per I/E criterion",
+      "isReferenceData": true,
+      "keySequence": [
+        "__PLACEHOLDER__"
+      ],
+      "standard": "STD.SDTMIG",
+      "observationClass": {
+        "name": "TRIAL DESIGN"
+      },
+      "items": [
+        {
+          "OID": "IT.TI.STUDYID",
+          "mandatory": true,
+          "name": "STUDYID",
+          "description": "Study Identifier",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.TI.DOMAIN",
+          "mandatory": true,
+          "name": "DOMAIN",
+          "description": "Domain Abbreviation",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.TI.IETESTCD",
+          "mandatory": true,
+          "name": "IETESTCD",
+          "description": "Incl/Excl Criterion Short Name",
+          "role": "Topic",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.IETESTCD"
+        },
+        {
+          "OID": "IT.TI.IETEST",
+          "mandatory": true,
+          "name": "IETEST",
+          "description": "Inclusion/Exclusion Criterion",
+          "role": "Synonym Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.IETEST"
+        },
+        {
+          "OID": "IT.TI.IECAT",
+          "mandatory": true,
+          "name": "IECAT",
+          "description": "Inclusion/Exclusion Category",
+          "role": "Grouping Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.IECAT"
+        }
+      ]
+    },
+    {
+      "OID": "IG.TV",
+      "name": "TV",
+      "description": "Trial Visits",
+      "domain": "TV",
+      "purpose": "Tabulation",
+      "structure": "One record per planned Visit per Arm",
+      "isReferenceData": true,
+      "keySequence": [
+        "__PLACEHOLDER__"
+      ],
+      "standard": "STD.SDTMIG",
+      "observationClass": {
+        "name": "TRIAL DESIGN"
+      },
+      "items": [
+        {
+          "OID": "IT.TV.STUDYID",
+          "mandatory": true,
+          "name": "STUDYID",
+          "description": "Study Identifier",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.TV.DOMAIN",
+          "mandatory": true,
+          "name": "DOMAIN",
+          "description": "Domain Abbreviation",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.TV.VISITNUM",
+          "mandatory": true,
+          "name": "VISITNUM",
+          "description": "Visit Number",
+          "role": "Topic",
+          "dataType": "integer",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.TV.VISIT",
+          "mandatory": true,
+          "name": "VISIT",
+          "description": "Visit Name",
+          "role": "Synonym Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.TV.VISITDY",
+          "mandatory": false,
+          "name": "VISITDY",
+          "description": "Planned Study Day of Visit",
+          "role": "Timing",
+          "dataType": "integer",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.TV.ARMCD",
+          "mandatory": false,
+          "name": "ARMCD",
+          "description": "Planned Arm Code",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.ARMCD"
+        },
+        {
+          "OID": "IT.TV.ARM",
+          "mandatory": false,
+          "name": "ARM",
+          "description": "Description of Planned Arm",
+          "role": "Synonym Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.ARM"
+        },
+        {
+          "OID": "IT.TV.TVSTRL",
+          "mandatory": true,
+          "name": "TVSTRL",
+          "description": "Visit Start Rule",
+          "role": "Rule",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.TV.TVENRL",
+          "mandatory": false,
+          "name": "TVENRL",
+          "description": "Visit End Rule",
+          "role": "Rule",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        }
+      ]
+    },
+    {
+      "OID": "IG.SV",
+      "name": "SV",
+      "description": "Subject Visits",
+      "domain": "SV",
+      "purpose": "Tabulation",
+      "structure": "One record per actual or planned visit per subject",
+      "isReferenceData": false,
+      "keySequence": [
+        "__PLACEHOLDER__"
+      ],
+      "standard": "STD.SDTMIG",
+      "observationClass": {
+        "name": "SPECIAL-PURPOSE"
+      },
+      "items": [
+        {
+          "OID": "IT.SV.STUDYID",
+          "mandatory": true,
+          "name": "STUDYID",
+          "description": "Study Identifier",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.SV.DOMAIN",
+          "mandatory": true,
+          "name": "DOMAIN",
+          "description": "Domain Abbreviation",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.SV.USUBJID",
+          "mandatory": true,
+          "name": "USUBJID",
+          "description": "Unique Subject Identifier",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.SV.VISITNUM",
+          "mandatory": true,
+          "name": "VISITNUM",
+          "description": "Visit Number",
+          "role": "Topic",
+          "dataType": "integer",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.SV.VISIT",
+          "mandatory": false,
+          "name": "VISIT",
+          "description": "Visit Name",
+          "role": "Synonym Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.SV.SVPRESP",
+          "mandatory": false,
+          "name": "SVPRESP",
+          "description": "Pre-specified",
+          "role": "Variable Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.NY"
+        },
+        {
+          "OID": "IT.SV.SVOCCUR",
+          "mandatory": false,
+          "name": "SVOCCUR",
+          "description": "Occurrence",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.NY"
+        },
+        {
+          "OID": "IT.SV.SVCNTMOD",
+          "mandatory": false,
+          "name": "SVCNTMOD",
+          "description": "Contact Mode",
+          "role": "Record Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.CNTMODE"
+        },
+        {
+          "OID": "IT.SV.SVSTDTC",
+          "mandatory": false,
+          "name": "SVSTDTC",
+          "description": "Start Date/Time of Observation",
+          "role": "Timing",
+          "dataType": "datetime",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.SV.SVENDTC",
+          "mandatory": false,
+          "name": "SVENDTC",
+          "description": "End Date/Time of Observation",
+          "role": "Timing",
+          "dataType": "datetime",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        }
+      ]
+    },
+    {
+      "OID": "IG.IE",
+      "name": "IE",
+      "description": "Inclusion/Exclusion Criteria Not Met",
+      "domain": "IE",
+      "purpose": "Tabulation",
+      "structure": "One record per inclusion/exclusion criterion not met per subject",
+      "isReferenceData": false,
+      "keySequence": [
+        "__PLACEHOLDER__"
+      ],
+      "standard": "STD.SDTMIG",
+      "observationClass": {
+        "name": "FINDINGS"
+      },
+      "items": [
+        {
+          "OID": "IT.IE.STUDYID",
+          "mandatory": true,
+          "name": "STUDYID",
+          "description": "Study Identifier",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.IE.DOMAIN",
+          "mandatory": true,
+          "name": "DOMAIN",
+          "description": "Domain Abbreviation",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.IE.USUBJID",
+          "mandatory": true,
+          "name": "USUBJID",
+          "description": "Unique Subject Identifier",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.IE.IESEQ",
+          "mandatory": true,
+          "name": "IESEQ",
+          "description": "Sequence Number",
+          "role": "Identifier",
+          "dataType": "integer",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.IE.IETESTCD",
+          "mandatory": true,
+          "name": "IETESTCD",
+          "description": "Inclusion/Exclusion Criterion Short Name",
+          "role": "Topic",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.IETESTCD"
+        },
+        {
+          "OID": "IT.IE.IETEST",
+          "mandatory": true,
+          "name": "IETEST",
+          "description": "Inclusion/Exclusion Criterion",
+          "role": "Synonym Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.IETEST"
+        },
+        {
+          "OID": "IT.IE.IECAT",
+          "mandatory": true,
+          "name": "IECAT",
+          "description": "Inclusion/Exclusion Category",
+          "role": "Grouping Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.IECAT"
+        },
+        {
+          "OID": "IT.IE.IEORRES",
+          "mandatory": true,
+          "name": "IEORRES",
+          "description": "I/E Criterion Original Result",
+          "role": "Result Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.NY"
+        },
+        {
+          "OID": "IT.IE.IESTRESC",
+          "mandatory": true,
+          "name": "IESTRESC",
+          "description": "I/E Criterion Result in Std Format",
+          "role": "Result Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.NY"
+        }
+      ],
+      "slices": [
+        {
+          "OID": "VL.IE.IEORRES",
+          "name": "VL_IE_IEORRES",
+          "type": "ValueList",
+          "wasDerivedFrom": "IT.IE.IEORRES",
+          "items": [
+            {
+              "OID": "IT.IE.IEORRES.IN01",
+              "mandatory": false,
+              "name": "IEORRES",
+              "dataType": "text",
+              "length": 1,
+              "origin": {
+                "type": "Collected",
+                "source": "Investigator"
+              },
+              "applicableWhen": [
+                "WC.IE.1d2bb25f"
+              ]
+            },
+            {
+              "OID": "IT.IE.IEORRES.IN02",
+              "mandatory": false,
+              "name": "IEORRES",
+              "dataType": "text",
+              "length": 1,
+              "origin": {
+                "type": "Collected",
+                "source": "Investigator"
+              },
+              "applicableWhen": [
+                "WC.IE.fa688bf3"
+              ]
+            },
+            {
+              "OID": "IT.IE.IEORRES.IN03",
+              "mandatory": false,
+              "name": "IEORRES",
+              "dataType": "text",
+              "length": 1,
+              "origin": {
+                "type": "Collected",
+                "source": "Investigator"
+              },
+              "applicableWhen": [
+                "WC.IE.f276b607"
+              ]
+            },
+            {
+              "OID": "IT.IE.IEORRES.IN04",
+              "mandatory": false,
+              "name": "IEORRES",
+              "dataType": "text",
+              "length": 1,
+              "origin": {
+                "type": "Collected",
+                "source": "Investigator"
+              },
+              "applicableWhen": [
+                "WC.IE.cd528448"
+              ]
+            },
+            {
+              "OID": "IT.IE.IEORRES.IN05",
+              "mandatory": false,
+              "name": "IEORRES",
+              "dataType": "text",
+              "length": 1,
+              "origin": {
+                "type": "Collected",
+                "source": "Investigator"
+              },
+              "applicableWhen": [
+                "WC.IE.c1db3fd3"
+              ]
+            },
+            {
+              "OID": "IT.IE.IEORRES.IN06",
+              "mandatory": false,
+              "name": "IEORRES",
+              "dataType": "text",
+              "length": 1,
+              "origin": {
+                "type": "Collected",
+                "source": "Investigator"
+              },
+              "applicableWhen": [
+                "WC.IE.c2ec614b"
+              ]
+            },
+            {
+              "OID": "IT.IE.IEORRES.IN07",
+              "mandatory": false,
+              "name": "IEORRES",
+              "dataType": "text",
+              "length": 1,
+              "origin": {
+                "type": "Collected",
+                "source": "Investigator"
+              },
+              "applicableWhen": [
+                "WC.IE.2ef341aa"
+              ]
+            },
+            {
+              "OID": "IT.IE.IEORRES.IN08",
+              "mandatory": false,
+              "name": "IEORRES",
+              "dataType": "text",
+              "length": 1,
+              "origin": {
+                "type": "Collected",
+                "source": "Investigator"
+              },
+              "applicableWhen": [
+                "WC.IE.5d85184b"
+              ]
+            },
+            {
+              "OID": "IT.IE.IEORRES.EX01",
+              "mandatory": false,
+              "name": "IEORRES",
+              "dataType": "text",
+              "length": 1,
+              "origin": {
+                "type": "Collected",
+                "source": "Investigator"
+              },
+              "applicableWhen": [
+                "WC.IE.8579104c"
+              ]
+            },
+            {
+              "OID": "IT.IE.IEORRES.EX02",
+              "mandatory": false,
+              "name": "IEORRES",
+              "dataType": "text",
+              "length": 1,
+              "origin": {
+                "type": "Collected",
+                "source": "Investigator"
+              },
+              "applicableWhen": [
+                "WC.IE.74eacc45"
+              ]
+            },
+            {
+              "OID": "IT.IE.IEORRES.EX03",
+              "mandatory": false,
+              "name": "IEORRES",
+              "dataType": "text",
+              "length": 1,
+              "origin": {
+                "type": "Collected",
+                "source": "Investigator"
+              },
+              "applicableWhen": [
+                "WC.IE.ce0e8d09"
+              ]
+            },
+            {
+              "OID": "IT.IE.IEORRES.EX04",
+              "mandatory": false,
+              "name": "IEORRES",
+              "dataType": "text",
+              "length": 1,
+              "origin": {
+                "type": "Collected",
+                "source": "Investigator"
+              },
+              "applicableWhen": [
+                "WC.IE.945bafbd"
+              ]
+            },
+            {
+              "OID": "IT.IE.IEORRES.EX05",
+              "mandatory": false,
+              "name": "IEORRES",
+              "dataType": "text",
+              "length": 1,
+              "origin": {
+                "type": "Collected",
+                "source": "Investigator"
+              },
+              "applicableWhen": [
+                "WC.IE.afbec960"
+              ]
+            },
+            {
+              "OID": "IT.IE.IEORRES.EX06",
+              "mandatory": false,
+              "name": "IEORRES",
+              "dataType": "text",
+              "length": 1,
+              "origin": {
+                "type": "Collected",
+                "source": "Investigator"
+              },
+              "applicableWhen": [
+                "WC.IE.cac0d3f4"
+              ]
+            },
+            {
+              "OID": "IT.IE.IEORRES.EX07",
+              "mandatory": false,
+              "name": "IEORRES",
+              "dataType": "text",
+              "length": 1,
+              "origin": {
+                "type": "Collected",
+                "source": "Investigator"
+              },
+              "applicableWhen": [
+                "WC.IE.cabd9be0"
+              ]
+            },
+            {
+              "OID": "IT.IE.IEORRES.EX08",
+              "mandatory": false,
+              "name": "IEORRES",
+              "dataType": "text",
+              "length": 1,
+              "origin": {
+                "type": "Collected",
+                "source": "Investigator"
+              },
+              "applicableWhen": [
+                "WC.IE.fbae7983"
+              ]
+            },
+            {
+              "OID": "IT.IE.IEORRES.EX09",
+              "mandatory": false,
+              "name": "IEORRES",
+              "dataType": "text",
+              "length": 1,
+              "origin": {
+                "type": "Collected",
+                "source": "Investigator"
+              },
+              "applicableWhen": [
+                "WC.IE.0952c014"
+              ]
+            },
+            {
+              "OID": "IT.IE.IEORRES.EX10",
+              "mandatory": false,
+              "name": "IEORRES",
+              "dataType": "text",
+              "length": 1,
+              "origin": {
+                "type": "Collected",
+                "source": "Investigator"
+              },
+              "applicableWhen": [
+                "WC.IE.5b8b02b2"
+              ]
+            },
+            {
+              "OID": "IT.IE.IEORRES.EX11",
+              "mandatory": false,
+              "name": "IEORRES",
+              "dataType": "text",
+              "length": 1,
+              "origin": {
+                "type": "Collected",
+                "source": "Investigator"
+              },
+              "applicableWhen": [
+                "WC.IE.70a941e7"
+              ]
+            },
+            {
+              "OID": "IT.IE.IEORRES.EX12",
+              "mandatory": false,
+              "name": "IEORRES",
+              "dataType": "text",
+              "length": 1,
+              "origin": {
+                "type": "Collected",
+                "source": "Investigator"
+              },
+              "applicableWhen": [
+                "WC.IE.611f5d7b"
+              ]
+            },
+            {
+              "OID": "IT.IE.IEORRES.EX13",
+              "mandatory": false,
+              "name": "IEORRES",
+              "dataType": "text",
+              "length": 1,
+              "origin": {
+                "type": "Collected",
+                "source": "Investigator"
+              },
+              "applicableWhen": [
+                "WC.IE.8abff918"
+              ]
+            },
+            {
+              "OID": "IT.IE.IEORRES.EX14",
+              "mandatory": false,
+              "name": "IEORRES",
+              "dataType": "text",
+              "length": 1,
+              "origin": {
+                "type": "Collected",
+                "source": "Investigator"
+              },
+              "applicableWhen": [
+                "WC.IE.b089a2a0"
+              ]
+            },
+            {
+              "OID": "IT.IE.IEORRES.EX15",
+              "mandatory": false,
+              "name": "IEORRES",
+              "dataType": "text",
+              "length": 1,
+              "origin": {
+                "type": "Collected",
+                "source": "Investigator"
+              },
+              "applicableWhen": [
+                "WC.IE.39cb2456"
+              ]
+            },
+            {
+              "OID": "IT.IE.IEORRES.EX16",
+              "mandatory": false,
+              "name": "IEORRES",
+              "dataType": "text",
+              "length": 1,
+              "origin": {
+                "type": "Collected",
+                "source": "Investigator"
+              },
+              "applicableWhen": [
+                "WC.IE.2cdb5c18"
+              ]
+            },
+            {
+              "OID": "IT.IE.IEORRES.EX17",
+              "mandatory": false,
+              "name": "IEORRES",
+              "dataType": "text",
+              "length": 1,
+              "origin": {
+                "type": "Collected",
+                "source": "Investigator"
+              },
+              "applicableWhen": [
+                "WC.IE.b415f3a9"
+              ]
+            },
+            {
+              "OID": "IT.IE.IEORRES.EX18",
+              "mandatory": false,
+              "name": "IEORRES",
+              "dataType": "text",
+              "length": 1,
+              "origin": {
+                "type": "Collected",
+                "source": "Investigator"
+              },
+              "applicableWhen": [
+                "WC.IE.5c29f970"
+              ]
+            },
+            {
+              "OID": "IT.IE.IEORRES.EX19",
+              "mandatory": false,
+              "name": "IEORRES",
+              "dataType": "text",
+              "length": 1,
+              "origin": {
+                "type": "Collected",
+                "source": "Investigator"
+              },
+              "applicableWhen": [
+                "WC.IE.9fe9a358"
+              ]
+            },
+            {
+              "OID": "IT.IE.IEORRES.EX20",
+              "mandatory": false,
+              "name": "IEORRES",
+              "dataType": "text",
+              "length": 1,
+              "origin": {
+                "type": "Collected",
+                "source": "Investigator"
+              },
+              "applicableWhen": [
+                "WC.IE.e36b210b"
+              ]
+            },
+            {
+              "OID": "IT.IE.IEORRES.EX21",
+              "mandatory": false,
+              "name": "IEORRES",
+              "dataType": "text",
+              "length": 1,
+              "origin": {
+                "type": "Collected",
+                "source": "Investigator"
+              },
+              "applicableWhen": [
+                "WC.IE.743b4fb5"
+              ]
+            },
+            {
+              "OID": "IT.IE.IEORRES.EX22",
+              "mandatory": false,
+              "name": "IEORRES",
+              "dataType": "text",
+              "length": 1,
+              "origin": {
+                "type": "Collected",
+                "source": "Investigator"
+              },
+              "applicableWhen": [
+                "WC.IE.76a82754"
+              ]
+            },
+            {
+              "OID": "IT.IE.IEORRES.EX23",
+              "mandatory": false,
+              "name": "IEORRES",
+              "dataType": "text",
+              "length": 1,
+              "origin": {
+                "type": "Collected",
+                "source": "Investigator"
+              },
+              "applicableWhen": [
+                "WC.IE.fbeb5a1e"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "OID": "IG.SE",
+      "name": "SE",
+      "description": "Subject Elements",
+      "domain": "SE",
+      "purpose": "Tabulation",
+      "structure": "One record per actual Element per subject",
+      "isReferenceData": false,
+      "keySequence": [
+        "__PLACEHOLDER__"
+      ],
+      "standard": "STD.SDTMIG",
+      "observationClass": {
+        "name": "SPECIAL-PURPOSE"
+      },
+      "items": [
+        {
+          "OID": "IT.SE.STUDYID",
+          "mandatory": true,
+          "name": "STUDYID",
+          "description": "Study Identifier",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.SE.DOMAIN",
+          "mandatory": true,
+          "name": "DOMAIN",
+          "description": "Domain Abbreviation",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.SE.USUBJID",
+          "mandatory": true,
+          "name": "USUBJID",
+          "description": "Unique Subject Identifier",
+          "role": "Identifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.SE.SESEQ",
+          "mandatory": true,
+          "name": "SESEQ",
+          "description": "Sequence Number",
+          "role": "Identifier",
+          "dataType": "integer",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.SE.ETCD",
+          "mandatory": true,
+          "name": "ETCD",
+          "description": "Element Code",
+          "role": "Topic",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.ETCD"
+        },
+        {
+          "OID": "IT.SE.ELEMENT",
+          "mandatory": false,
+          "name": "ELEMENT",
+          "description": "Description of Element",
+          "role": "Synonym Qualifier",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.ELEMENT"
+        },
+        {
+          "OID": "IT.SE.EPOCH",
+          "mandatory": false,
+          "name": "EPOCH",
+          "description": "Epoch",
+          "role": "Timing",
+          "dataType": "text",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          },
+          "codeList": "CL.EPOCH"
+        },
+        {
+          "OID": "IT.SE.SESTDTC",
+          "mandatory": true,
+          "name": "SESTDTC",
+          "description": "Start Date/Time of Element",
+          "role": "Timing",
+          "dataType": "datetime",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        },
+        {
+          "OID": "IT.SE.SEENDTC",
+          "mandatory": false,
+          "name": "SEENDTC",
+          "description": "End Date/Time of Element",
+          "role": "Timing",
+          "dataType": "datetime",
+          "length": null,
+          "origin": {
+            "type": "__PLACEHOLDER__",
+            "source": "__PLACEHOLDER__"
+          }
+        }
+      ]
+    }
+  ],
+  "conditions": [
+    {
+      "OID": "COND.SC.SCTESTCD.78088212",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "EDULEVEL"
+          ],
+          "item": "IT.SC.SCTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.SC.SCTESTCD.7cb4808a",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "EDUYRNUM"
+          ],
+          "item": "IT.SC.SCTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.VS.VSTESTCD.3cd24c45",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "TEMP"
+          ],
+          "item": "IT.VS.VSTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.VS.VSLOC.e14ab3ef",
+      "rangeChecks": [
+        {
+          "comparator": "IN",
+          "checkValues": [
+            "AXILLA",
+            "EAR",
+            "FOREHEAD",
+            "ORAL CAVITY",
+            "RECTUM"
+          ],
+          "item": "IT.VS.VSLOC",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.VS.VSTESTCD.3065ea60",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "WEIGHT"
+          ],
+          "item": "IT.VS.VSTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.VS.VSTESTCD.9c8495d2",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "HEIGHT"
+          ],
+          "item": "IT.VS.VSTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.VS.VSTESTCD.903f5a52",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "PULSE"
+          ],
+          "item": "IT.VS.VSTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.VS.VSPOS.24ef7406",
+      "rangeChecks": [
+        {
+          "comparator": "IN",
+          "checkValues": [
+            "PRONE",
+            "SEMI-RECUMBENT",
+            "SITTING",
+            "STANDING",
+            "SUPINE"
+          ],
+          "item": "IT.VS.VSPOS",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.VS.VSLOC.9b0f4929",
+      "rangeChecks": [
+        {
+          "comparator": "IN",
+          "checkValues": [
+            "BRACHIAL ARTERY",
+            "CAROTID ARTERY",
+            "CEREBRAL ARTERY",
+            "DORSALIS PEDIS ARTERY",
+            "FEMORAL ARTERY",
+            "RADIAL ARTERY"
+          ],
+          "item": "IT.VS.VSLOC",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.VS.VSLAT.934ef850",
+      "rangeChecks": [
+        {
+          "comparator": "IN",
+          "checkValues": [
+            "LEFT",
+            "RIGHT"
+          ],
+          "item": "IT.VS.VSLAT",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.VS.VSTESTCD.4d709ea4",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "RESP"
+          ],
+          "item": "IT.VS.VSTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.VS.VSTESTCD.7ca006e0",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "BMI"
+          ],
+          "item": "IT.VS.VSTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.VS.VSTESTCD.6f8a5002",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "SYSBP"
+          ],
+          "item": "IT.VS.VSTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.VS.VSLOC.7c8b8031",
+      "rangeChecks": [
+        {
+          "comparator": "IN",
+          "checkValues": [
+            "BRACHIAL ARTERY",
+            "CAROTID ARTERY",
+            "DORSALIS PEDIS ARTERY",
+            "FEMORAL ARTERY",
+            "FINGER",
+            "RADIAL ARTERY"
+          ],
+          "item": "IT.VS.VSLOC",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.VS.VSTESTCD.04e7c99e",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "DIABP"
+          ],
+          "item": "IT.VS.VSTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.VS.VSTESTCD.34f13e1b",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "HR"
+          ],
+          "item": "IT.VS.VSTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.EG.EGTESTCD.ebac683e",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "INTP"
+          ],
+          "item": "IT.EG.EGTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.EG.EGEVAL.6c228d92",
+      "rangeChecks": [
+        {
+          "comparator": "IN",
+          "checkValues": [
+            "ADJUDICATION COMMITTEE",
+            "INDEPENDENT ASSESSOR",
+            "INVESTIGATOR",
+            "VENDOR"
+          ],
+          "item": "IT.EG.EGEVAL",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.EG.EGTESTCD.814eb2d7",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "AVCOND"
+          ],
+          "item": "IT.EG.EGTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.EG.EGTESTCD.75ce255c",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "AXISVOLT"
+          ],
+          "item": "IT.EG.EGTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.EG.EGTESTCD.b1863809",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "CHYPTENL"
+          ],
+          "item": "IT.EG.EGTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.EG.EGTESTCD.1eae990e",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "TECHQUAL"
+          ],
+          "item": "IT.EG.EGTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.EG.EGTESTCD.976a645a",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "IVTIACD"
+          ],
+          "item": "IT.EG.EGTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.EG.EGTESTCD.30a97f6d",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "PACEMAKR"
+          ],
+          "item": "IT.EG.EGTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.EG.EGTESTCD.d5fe4df0",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "RHYNOS"
+          ],
+          "item": "IT.EG.EGTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.EG.EGTESTCD.4f569105",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "SNRARRY"
+          ],
+          "item": "IT.EG.EGTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.EG.EGTESTCD.2109c5fb",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "SPRARRY"
+          ],
+          "item": "IT.EG.EGTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.EG.EGTESTCD.d1c2c091",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "SPRTARRY"
+          ],
+          "item": "IT.EG.EGTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.EG.EGTESTCD.07c67769",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "VTARRY"
+          ],
+          "item": "IT.EG.EGTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.EG.EGTESTCD.35652981",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "VTTARRY"
+          ],
+          "item": "IT.EG.EGTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.EG.EGTESTCD.5442d393",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "PRAG"
+          ],
+          "item": "IT.EG.EGTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.EG.EGTESTCD.959d4d44",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "QRSAG"
+          ],
+          "item": "IT.EG.EGTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.EG.EGTESTCD.6da05656",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "QTAG"
+          ],
+          "item": "IT.EG.EGTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.EG.EGTESTCD.920155f1",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "QTCBAG"
+          ],
+          "item": "IT.EG.EGTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.EG.EGTESTCD.aaf0d406",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "QTCFAG"
+          ],
+          "item": "IT.EG.EGTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.EG.EGTESTCD.ba1daa9c",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "RRAG"
+          ],
+          "item": "IT.EG.EGTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.EG.EGTESTCD.5a654be1",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "EGHRMN"
+          ],
+          "item": "IT.EG.EGTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.EG.EGTESTCD.a8fd8ff9",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "QRS_AXIS"
+          ],
+          "item": "IT.EG.EGTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBTESTCD.04aa6f0c",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "HGB"
+          ],
+          "item": "IT.LB.LBTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBSPEC.f6f6df0c",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "BLOOD"
+          ],
+          "item": "IT.LB.LBSPEC",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBMETHOD.ac001fcd",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "DIPSTICK MEASUREMENT METHOD"
+          ],
+          "item": "IT.LB.LBMETHOD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBTESTCD.2596a002",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "HCT"
+          ],
+          "item": "IT.LB.LBTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBTESTCD.f0b51e31",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "RBC"
+          ],
+          "item": "IT.LB.LBTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBTESTCD.ca27fffa",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "MCH"
+          ],
+          "item": "IT.LB.LBTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBSPEC.d1bfd10c",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "ERYTHROCYTES"
+          ],
+          "item": "IT.LB.LBSPEC",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBTESTCD.e647bee9",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "MCHC"
+          ],
+          "item": "IT.LB.LBTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBTESTCD.347788eb",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "MCV"
+          ],
+          "item": "IT.LB.LBTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBTESTCD.d093221c",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "WBC"
+          ],
+          "item": "IT.LB.LBTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBTESTCD.d7f9d982",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "NEUTSG"
+          ],
+          "item": "IT.LB.LBTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBTESTCD.ee1bd4eb",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "NEUTB"
+          ],
+          "item": "IT.LB.LBTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBTESTCD.7949af26",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "NEUT"
+          ],
+          "item": "IT.LB.LBTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBTESTCD.875d3e51",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "MONO"
+          ],
+          "item": "IT.LB.LBTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBTESTCD.67b49e63",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "EOS"
+          ],
+          "item": "IT.LB.LBTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBTESTCD.287c5431",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "BASO"
+          ],
+          "item": "IT.LB.LBTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBTESTCD.e319c1c9",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "PLAT"
+          ],
+          "item": "IT.LB.LBTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBTESTCD.595603b0",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "MICROCY"
+          ],
+          "item": "IT.LB.LBTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBSPEC.e9dcc27d",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "URINE SEDIMENT"
+          ],
+          "item": "IT.LB.LBSPEC",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBTESTCD.4a019cc1",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "MACROCY"
+          ],
+          "item": "IT.LB.LBTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBTESTCD.4c8c90fb",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "ANISO"
+          ],
+          "item": "IT.LB.LBTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBTESTCD.44179c1d",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "POIKILO"
+          ],
+          "item": "IT.LB.LBTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBTESTCD.279ee1d7",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "POLYCHR"
+          ],
+          "item": "IT.LB.LBTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBTESTCD.2cf3f505",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "ALT"
+          ],
+          "item": "IT.LB.LBTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBSPEC.2a0ba9ed",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "SERUM OR PLASMA"
+          ],
+          "item": "IT.LB.LBSPEC",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBTESTCD.65d4f752",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "ALB"
+          ],
+          "item": "IT.LB.LBTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBSPEC.fe2e0fb3",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "URINE"
+          ],
+          "item": "IT.LB.LBSPEC",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBTESTCD.b2d661b6",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "ALP"
+          ],
+          "item": "IT.LB.LBTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBTESTCD.ee16e022",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "AST"
+          ],
+          "item": "IT.LB.LBTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBTESTCD.09d56ffc",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "CREAT"
+          ],
+          "item": "IT.LB.LBTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBTESTCD.5e7b0134",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "K"
+          ],
+          "item": "IT.LB.LBTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBTESTCD.1f6a1d0f",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "SODIUM"
+          ],
+          "item": "IT.LB.LBTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBTESTCD.c95065ae",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "UREAN"
+          ],
+          "item": "IT.LB.LBTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBTESTCD.608ed901",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "BICARB"
+          ],
+          "item": "IT.LB.LBTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBTESTCD.4bda7613",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "CL"
+          ],
+          "item": "IT.LB.LBTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBTESTCD.fb28452f",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "BILI"
+          ],
+          "item": "IT.LB.LBTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBTESTCD.4ea796f7",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "GGT"
+          ],
+          "item": "IT.LB.LBTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBTESTCD.4787c4c4",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "URATE"
+          ],
+          "item": "IT.LB.LBTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBTESTCD.9181afaf",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "PHOS"
+          ],
+          "item": "IT.LB.LBTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBTESTCD.9bb90c0f",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "CA"
+          ],
+          "item": "IT.LB.LBTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBTESTCD.5f3309c8",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "GLUC"
+          ],
+          "item": "IT.LB.LBTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBTESTCD.3705806a",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "PROT"
+          ],
+          "item": "IT.LB.LBTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBTESTCD.546f62a6",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "CHOL"
+          ],
+          "item": "IT.LB.LBTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBTESTCD.662421ca",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "T3UP"
+          ],
+          "item": "IT.LB.LBTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBTESTCD.253a2d2c",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "T3"
+          ],
+          "item": "IT.LB.LBTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBTESTCD.32179136",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "T4FR"
+          ],
+          "item": "IT.LB.LBTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBTESTCD.68013b69",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "T4FRIDX"
+          ],
+          "item": "IT.LB.LBTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBTESTCD.af474d82",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "TSH"
+          ],
+          "item": "IT.LB.LBTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBTESTCD.ee2fb0c8",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "VITB9"
+          ],
+          "item": "IT.LB.LBTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBTESTCD.a07b5dee",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "VITB12"
+          ],
+          "item": "IT.LB.LBTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBTESTCD.797729c2",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "COLOR"
+          ],
+          "item": "IT.LB.LBTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBTESTCD.5613f4c1",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "SPGRAV"
+          ],
+          "item": "IT.LB.LBTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBTESTCD.e6f6bca1",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "KETONES"
+          ],
+          "item": "IT.LB.LBTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBTESTCD.ce5391eb",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "UROBIL"
+          ],
+          "item": "IT.LB.LBTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBTESTCD.d277d8f1",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "OCCBLD"
+          ],
+          "item": "IT.LB.LBTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBSPEC.22e91b54",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "STOOL"
+          ],
+          "item": "IT.LB.LBSPEC",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBTESTCD.b3c8bdba",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "NITRITE"
+          ],
+          "item": "IT.LB.LBTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBTESTCD.1350d454",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "HBA1C"
+          ],
+          "item": "IT.LB.LBTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.LB.LBTESTCD.5717b134",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "HBA1CHGB"
+          ],
+          "item": "IT.LB.LBTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.MB.MBTESTCD.b145c972",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "TPLAB"
+          ],
+          "item": "IT.MB.MBTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.MB.MBTSTDTL.4a168fd0",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "DETECTION"
+          ],
+          "item": "IT.MB.MBTSTDTL",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.MB.MBSPEC.41a5e97b",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "SERUM"
+          ],
+          "item": "IT.MB.MBSPEC",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.MB.MBMETHOD.6348a3e5",
+      "rangeChecks": [
+        {
+          "comparator": "IN",
+          "checkValues": [
+            "FLUORESCENT IMMUNOASSAY",
+            "HEMAGGLUTINATION ASSAY",
+            "CHEMILUMINESCENT MICROPARTICLE IMMUNOASSAY",
+            "POLYMERASE CHAIN REACTION",
+            "IMMUNOBLOT",
+            "RAPID IMMUNOASSAY"
+          ],
+          "item": "IT.MB.MBMETHOD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.MB.MBTESTCD.18cb7208",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "TPADNA"
+          ],
+          "item": "IT.MB.MBTESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.MB.MBSPEC.b395cb00",
+      "rangeChecks": [
+        {
+          "comparator": "IN",
+          "checkValues": [
+            "BLOOD",
+            "CEREBROSPINAL FLUID",
+            "FLUID",
+            "SWABBED MATERIAL",
+            "URINE"
+          ],
+          "item": "IT.MB.MBSPEC",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.MB.MBMETHOD.92bec008",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "LINE PROBE ASSAY"
+          ],
+          "item": "IT.MB.MBMETHOD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.TS.TSPARMCD.8e8bd467",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "ADAPT"
+          ],
+          "item": "IT.TS.TSPARMCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.TS.TSPARMCD.a188954a",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "AGEMIN"
+          ],
+          "item": "IT.TS.TSPARMCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.TS.TSPARMCD.ec5a57e2",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "AGEMAX"
+          ],
+          "item": "IT.TS.TSPARMCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.TS.TSPARMCD.cd7838e7",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "COMPTRT"
+          ],
+          "item": "IT.TS.TSPARMCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.TS.TSPARMCD.ceb735c9",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "CRMDUR"
+          ],
+          "item": "IT.TS.TSPARMCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.TS.TSPARMCD.b47a17a8",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "DOSE"
+          ],
+          "item": "IT.TS.TSPARMCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.TS.TSPARMCD.31172311",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "DOSFRQ"
+          ],
+          "item": "IT.TS.TSPARMCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.TS.TSPARMCD.586a7d9a",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "DOSU"
+          ],
+          "item": "IT.TS.TSPARMCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.TS.TSPARMCD.204aa07d",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "INDIC"
+          ],
+          "item": "IT.TS.TSPARMCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.TS.TSPARMCD.66a1c586",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "INTMODEL"
+          ],
+          "item": "IT.TS.TSPARMCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.TS.TSPARMCD.fd076a8d",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "INTTYPE"
+          ],
+          "item": "IT.TS.TSPARMCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.TS.TSPARMCD.770c1610",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "NARMS"
+          ],
+          "item": "IT.TS.TSPARMCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.TS.TSPARMCD.eb0c9bb2",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "OBJPRIM"
+          ],
+          "item": "IT.TS.TSPARMCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.TS.TSPARMCD.5ca3cd0c",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "OBJSEC"
+          ],
+          "item": "IT.TS.TSPARMCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.TS.TSPARMCD.a724d633",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "OUTMSPRI"
+          ],
+          "item": "IT.TS.TSPARMCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.TS.TSPARMCD.b313e712",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "OUTMSSEC"
+          ],
+          "item": "IT.TS.TSPARMCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.TS.TSPARMCD.116dcbeb",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "PLANSUB"
+          ],
+          "item": "IT.TS.TSPARMCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.TS.TSPARMCD.05d6aaed",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "PTRTDUR"
+          ],
+          "item": "IT.TS.TSPARMCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.TS.TSPARMCD.2254e8e7",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "ROUTE"
+          ],
+          "item": "IT.TS.TSPARMCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.TS.TSPARMCD.501d0db2",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "SEXPOP"
+          ],
+          "item": "IT.TS.TSPARMCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.TS.TSPARMCD.2e2517d1",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "SPONSOR"
+          ],
+          "item": "IT.TS.TSPARMCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.TS.TSPARMCD.5888eb50",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "STYPE"
+          ],
+          "item": "IT.TS.TSPARMCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.TS.TSPARMCD.f1a61db1",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "TBLIND"
+          ],
+          "item": "IT.TS.TSPARMCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.TS.TSPARMCD.688d36b6",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "THERAREA"
+          ],
+          "item": "IT.TS.TSPARMCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.TS.TSPARMCD.80d7d149",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "TINDTP"
+          ],
+          "item": "IT.TS.TSPARMCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.TS.TSPARMCD.52dad99f",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "TITLE"
+          ],
+          "item": "IT.TS.TSPARMCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.TS.TSPARMCD.342e8413",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "TPHASE"
+          ],
+          "item": "IT.TS.TSPARMCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.TS.TSPARMCD.185bd9b1",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "TRT"
+          ],
+          "item": "IT.TS.TSPARMCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.TS.TSPARMCD.91606039",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "TTYPE"
+          ],
+          "item": "IT.TS.TSPARMCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.IE.IETESTCD.02e45534",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "IN01"
+          ],
+          "item": "IT.IE.IETESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.IE.IETESTCD.b98e6bfa",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "IN02"
+          ],
+          "item": "IT.IE.IETESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.IE.IETESTCD.414aa6b7",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "IN03"
+          ],
+          "item": "IT.IE.IETESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.IE.IETESTCD.5600ece7",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "IN04"
+          ],
+          "item": "IT.IE.IETESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.IE.IETESTCD.e62058fb",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "IN05"
+          ],
+          "item": "IT.IE.IETESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.IE.IETESTCD.cae1a567",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "IN06"
+          ],
+          "item": "IT.IE.IETESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.IE.IETESTCD.0b4d25da",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "IN07"
+          ],
+          "item": "IT.IE.IETESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.IE.IETESTCD.dd1bb437",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "IN08"
+          ],
+          "item": "IT.IE.IETESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.IE.IETESTCD.b86f72a6",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "EX01"
+          ],
+          "item": "IT.IE.IETESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.IE.IETESTCD.ee806e62",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "EX02"
+          ],
+          "item": "IT.IE.IETESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.IE.IETESTCD.13b40508",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "EX03"
+          ],
+          "item": "IT.IE.IETESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.IE.IETESTCD.27412cd0",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "EX04"
+          ],
+          "item": "IT.IE.IETESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.IE.IETESTCD.c264aeb4",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "EX05"
+          ],
+          "item": "IT.IE.IETESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.IE.IETESTCD.904b6c2f",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "EX06"
+          ],
+          "item": "IT.IE.IETESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.IE.IETESTCD.29880e8c",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "EX07"
+          ],
+          "item": "IT.IE.IETESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.IE.IETESTCD.7f6091a2",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "EX08"
+          ],
+          "item": "IT.IE.IETESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.IE.IETESTCD.8f18d21b",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "EX09"
+          ],
+          "item": "IT.IE.IETESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.IE.IETESTCD.86209c99",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "EX10"
+          ],
+          "item": "IT.IE.IETESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.IE.IETESTCD.aab5d609",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "EX11"
+          ],
+          "item": "IT.IE.IETESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.IE.IETESTCD.25355161",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "EX12"
+          ],
+          "item": "IT.IE.IETESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.IE.IETESTCD.a38963bd",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "EX13"
+          ],
+          "item": "IT.IE.IETESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.IE.IETESTCD.4f25707e",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "EX14"
+          ],
+          "item": "IT.IE.IETESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.IE.IETESTCD.2a079ede",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "EX15"
+          ],
+          "item": "IT.IE.IETESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.IE.IETESTCD.871b7729",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "EX16"
+          ],
+          "item": "IT.IE.IETESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.IE.IETESTCD.51c4af93",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "EX17"
+          ],
+          "item": "IT.IE.IETESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.IE.IETESTCD.a954a7c8",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "EX18"
+          ],
+          "item": "IT.IE.IETESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.IE.IETESTCD.8f66ca7f",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "EX19"
+          ],
+          "item": "IT.IE.IETESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.IE.IETESTCD.528d2eb0",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "EX20"
+          ],
+          "item": "IT.IE.IETESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.IE.IETESTCD.bd5f1313",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "EX21"
+          ],
+          "item": "IT.IE.IETESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.IE.IETESTCD.01e1c173",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "EX22"
+          ],
+          "item": "IT.IE.IETESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    },
+    {
+      "OID": "COND.IE.IETESTCD.b8e48983",
+      "rangeChecks": [
+        {
+          "comparator": "EQ",
+          "checkValues": [
+            "EX23"
+          ],
+          "item": "IT.IE.IETESTCD",
+          "softHard": "Soft"
+        }
+      ]
+    }
+  ],
+  "whereClauses": [
+    {
+      "OID": "WC.SC.48924878",
+      "conditions": [
+        "COND.SC.SCTESTCD.78088212"
+      ]
+    },
+    {
+      "OID": "WC.SC.e7173a71",
+      "conditions": [
+        "COND.SC.SCTESTCD.7cb4808a"
+      ]
+    },
+    {
+      "OID": "WC.SC.5fc4562e",
+      "conditions": [
+        "COND.SC.SCTESTCD.7cb4808a"
+      ]
+    },
+    {
+      "OID": "WC.VS.df8e6ed8",
+      "conditions": [
+        "COND.VS.VSTESTCD.3cd24c45",
+        "COND.VS.VSLOC.e14ab3ef"
+      ]
+    },
+    {
+      "OID": "WC.VS.362bc1cf",
+      "conditions": [
+        "COND.VS.VSTESTCD.3065ea60"
+      ]
+    },
+    {
+      "OID": "WC.VS.22da90ca",
+      "conditions": [
+        "COND.VS.VSTESTCD.9c8495d2"
+      ]
+    },
+    {
+      "OID": "WC.VS.90269389",
+      "conditions": [
+        "COND.VS.VSTESTCD.903f5a52",
+        "COND.VS.VSPOS.24ef7406",
+        "COND.VS.VSLOC.9b0f4929",
+        "COND.VS.VSLAT.934ef850"
+      ]
+    },
+    {
+      "OID": "WC.VS.02e0f161",
+      "conditions": [
+        "COND.VS.VSTESTCD.4d709ea4"
+      ]
+    },
+    {
+      "OID": "WC.VS.ba9d17a7",
+      "conditions": [
+        "COND.VS.VSTESTCD.7ca006e0"
+      ]
+    },
+    {
+      "OID": "WC.VS.037b6848",
+      "conditions": [
+        "COND.VS.VSTESTCD.6f8a5002",
+        "COND.VS.VSPOS.24ef7406",
+        "COND.VS.VSLOC.7c8b8031",
+        "COND.VS.VSLAT.934ef850"
+      ]
+    },
+    {
+      "OID": "WC.VS.fe755a11",
+      "conditions": [
+        "COND.VS.VSTESTCD.04e7c99e",
+        "COND.VS.VSPOS.24ef7406",
+        "COND.VS.VSLOC.7c8b8031",
+        "COND.VS.VSLAT.934ef850"
+      ]
+    },
+    {
+      "OID": "WC.VS.324e0cc0",
+      "conditions": [
+        "COND.VS.VSTESTCD.34f13e1b",
+        "COND.VS.VSPOS.24ef7406",
+        "COND.VS.VSLOC.9b0f4929",
+        "COND.VS.VSLAT.934ef850"
+      ]
+    },
+    {
+      "OID": "WC.VS.dea56915",
+      "conditions": [
+        "COND.VS.VSTESTCD.3cd24c45",
+        "COND.VS.VSLOC.e14ab3ef"
+      ]
+    },
+    {
+      "OID": "WC.VS.ef959fbb",
+      "conditions": [
+        "COND.VS.VSTESTCD.3065ea60"
+      ]
+    },
+    {
+      "OID": "WC.VS.97262f9f",
+      "conditions": [
+        "COND.VS.VSTESTCD.9c8495d2"
+      ]
+    },
+    {
+      "OID": "WC.VS.2fad3005",
+      "conditions": [
+        "COND.VS.VSTESTCD.903f5a52",
+        "COND.VS.VSPOS.24ef7406",
+        "COND.VS.VSLOC.9b0f4929",
+        "COND.VS.VSLAT.934ef850"
+      ]
+    },
+    {
+      "OID": "WC.VS.f296848d",
+      "conditions": [
+        "COND.VS.VSTESTCD.4d709ea4"
+      ]
+    },
+    {
+      "OID": "WC.VS.ca4251ba",
+      "conditions": [
+        "COND.VS.VSTESTCD.7ca006e0"
+      ]
+    },
+    {
+      "OID": "WC.VS.301c7ee3",
+      "conditions": [
+        "COND.VS.VSTESTCD.6f8a5002",
+        "COND.VS.VSPOS.24ef7406",
+        "COND.VS.VSLOC.7c8b8031",
+        "COND.VS.VSLAT.934ef850"
+      ]
+    },
+    {
+      "OID": "WC.VS.714dfc07",
+      "conditions": [
+        "COND.VS.VSTESTCD.04e7c99e",
+        "COND.VS.VSPOS.24ef7406",
+        "COND.VS.VSLOC.7c8b8031",
+        "COND.VS.VSLAT.934ef850"
+      ]
+    },
+    {
+      "OID": "WC.VS.5a9c1ab0",
+      "conditions": [
+        "COND.VS.VSTESTCD.34f13e1b",
+        "COND.VS.VSPOS.24ef7406",
+        "COND.VS.VSLOC.9b0f4929",
+        "COND.VS.VSLAT.934ef850"
+      ]
+    },
+    {
+      "OID": "WC.EG.f60b99cb",
+      "conditions": [
+        "COND.EG.EGTESTCD.ebac683e",
+        "COND.EG.EGEVAL.6c228d92"
+      ]
+    },
+    {
+      "OID": "WC.EG.d30401ba",
+      "conditions": [
+        "COND.EG.EGTESTCD.814eb2d7",
+        "COND.EG.EGEVAL.6c228d92"
+      ]
+    },
+    {
+      "OID": "WC.EG.0764363d",
+      "conditions": [
+        "COND.EG.EGTESTCD.75ce255c",
+        "COND.EG.EGEVAL.6c228d92"
+      ]
+    },
+    {
+      "OID": "WC.EG.c7ca2c0d",
+      "conditions": [
+        "COND.EG.EGTESTCD.b1863809",
+        "COND.EG.EGEVAL.6c228d92"
+      ]
+    },
+    {
+      "OID": "WC.EG.0110957e",
+      "conditions": [
+        "COND.EG.EGTESTCD.1eae990e",
+        "COND.EG.EGEVAL.6c228d92"
+      ]
+    },
+    {
+      "OID": "WC.EG.7a2cbb17",
+      "conditions": [
+        "COND.EG.EGTESTCD.976a645a",
+        "COND.EG.EGEVAL.6c228d92"
+      ]
+    },
+    {
+      "OID": "WC.EG.c82f004b",
+      "conditions": [
+        "COND.EG.EGTESTCD.30a97f6d",
+        "COND.EG.EGEVAL.6c228d92"
+      ]
+    },
+    {
+      "OID": "WC.EG.aaf51dd5",
+      "conditions": [
+        "COND.EG.EGTESTCD.d5fe4df0",
+        "COND.EG.EGEVAL.6c228d92"
+      ]
+    },
+    {
+      "OID": "WC.EG.0a478649",
+      "conditions": [
+        "COND.EG.EGTESTCD.4f569105",
+        "COND.EG.EGEVAL.6c228d92"
+      ]
+    },
+    {
+      "OID": "WC.EG.44c12ce4",
+      "conditions": [
+        "COND.EG.EGTESTCD.2109c5fb",
+        "COND.EG.EGEVAL.6c228d92"
+      ]
+    },
+    {
+      "OID": "WC.EG.7c9fb72d",
+      "conditions": [
+        "COND.EG.EGTESTCD.d1c2c091",
+        "COND.EG.EGEVAL.6c228d92"
+      ]
+    },
+    {
+      "OID": "WC.EG.3a146a53",
+      "conditions": [
+        "COND.EG.EGTESTCD.07c67769",
+        "COND.EG.EGEVAL.6c228d92"
+      ]
+    },
+    {
+      "OID": "WC.EG.5571a969",
+      "conditions": [
+        "COND.EG.EGTESTCD.35652981",
+        "COND.EG.EGEVAL.6c228d92"
+      ]
+    },
+    {
+      "OID": "WC.EG.13a9fd00",
+      "conditions": [
+        "COND.EG.EGTESTCD.5442d393",
+        "COND.EG.EGEVAL.6c228d92"
+      ]
+    },
+    {
+      "OID": "WC.EG.72304c3a",
+      "conditions": [
+        "COND.EG.EGTESTCD.959d4d44",
+        "COND.EG.EGEVAL.6c228d92"
+      ]
+    },
+    {
+      "OID": "WC.EG.6f155b1d",
+      "conditions": [
+        "COND.EG.EGTESTCD.6da05656",
+        "COND.EG.EGEVAL.6c228d92"
+      ]
+    },
+    {
+      "OID": "WC.EG.dff815c6",
+      "conditions": [
+        "COND.EG.EGTESTCD.920155f1",
+        "COND.EG.EGEVAL.6c228d92"
+      ]
+    },
+    {
+      "OID": "WC.EG.e967e1e7",
+      "conditions": [
+        "COND.EG.EGTESTCD.aaf0d406",
+        "COND.EG.EGEVAL.6c228d92"
+      ]
+    },
+    {
+      "OID": "WC.EG.64f26102",
+      "conditions": [
+        "COND.EG.EGTESTCD.ba1daa9c",
+        "COND.EG.EGEVAL.6c228d92"
+      ]
+    },
+    {
+      "OID": "WC.EG.2ecbdce2",
+      "conditions": [
+        "COND.EG.EGTESTCD.5a654be1",
+        "COND.EG.EGEVAL.6c228d92"
+      ]
+    },
+    {
+      "OID": "WC.EG.9ce29aa6",
+      "conditions": [
+        "COND.EG.EGTESTCD.a8fd8ff9",
+        "COND.EG.EGEVAL.6c228d92"
+      ]
+    },
+    {
+      "OID": "WC.EG.cec16291",
+      "conditions": [
+        "COND.EG.EGTESTCD.5442d393",
+        "COND.EG.EGEVAL.6c228d92"
+      ]
+    },
+    {
+      "OID": "WC.EG.5a1ab0f5",
+      "conditions": [
+        "COND.EG.EGTESTCD.959d4d44",
+        "COND.EG.EGEVAL.6c228d92"
+      ]
+    },
+    {
+      "OID": "WC.EG.ddb86367",
+      "conditions": [
+        "COND.EG.EGTESTCD.6da05656",
+        "COND.EG.EGEVAL.6c228d92"
+      ]
+    },
+    {
+      "OID": "WC.EG.e847517c",
+      "conditions": [
+        "COND.EG.EGTESTCD.920155f1",
+        "COND.EG.EGEVAL.6c228d92"
+      ]
+    },
+    {
+      "OID": "WC.EG.7f463007",
+      "conditions": [
+        "COND.EG.EGTESTCD.aaf0d406",
+        "COND.EG.EGEVAL.6c228d92"
+      ]
+    },
+    {
+      "OID": "WC.EG.3d1ba9c3",
+      "conditions": [
+        "COND.EG.EGTESTCD.ba1daa9c",
+        "COND.EG.EGEVAL.6c228d92"
+      ]
+    },
+    {
+      "OID": "WC.EG.a40eb46d",
+      "conditions": [
+        "COND.EG.EGTESTCD.5a654be1",
+        "COND.EG.EGEVAL.6c228d92"
+      ]
+    },
+    {
+      "OID": "WC.EG.02ebb46f",
+      "conditions": [
+        "COND.EG.EGTESTCD.a8fd8ff9",
+        "COND.EG.EGEVAL.6c228d92"
+      ]
+    },
+    {
+      "OID": "WC.LB.c192b07f",
+      "conditions": [
+        "COND.LB.LBTESTCD.04aa6f0c",
+        "COND.LB.LBSPEC.f6f6df0c",
+        "COND.LB.LBMETHOD.ac001fcd"
+      ]
+    },
+    {
+      "OID": "WC.LB.82b97100",
+      "conditions": [
+        "COND.LB.LBTESTCD.2596a002",
+        "COND.LB.LBSPEC.f6f6df0c"
+      ]
+    },
+    {
+      "OID": "WC.LB.87582e25",
+      "conditions": [
+        "COND.LB.LBTESTCD.f0b51e31",
+        "COND.LB.LBSPEC.f6f6df0c"
+      ]
+    },
+    {
+      "OID": "WC.LB.95f4de22",
+      "conditions": [
+        "COND.LB.LBTESTCD.ca27fffa",
+        "COND.LB.LBSPEC.d1bfd10c"
+      ]
+    },
+    {
+      "OID": "WC.LB.92bd1f17",
+      "conditions": [
+        "COND.LB.LBTESTCD.e647bee9",
+        "COND.LB.LBSPEC.d1bfd10c"
+      ]
+    },
+    {
+      "OID": "WC.LB.24c0e2bc",
+      "conditions": [
+        "COND.LB.LBTESTCD.347788eb",
+        "COND.LB.LBSPEC.d1bfd10c"
+      ]
+    },
+    {
+      "OID": "WC.LB.351df44b",
+      "conditions": [
+        "COND.LB.LBTESTCD.d093221c",
+        "COND.LB.LBSPEC.f6f6df0c"
+      ]
+    },
+    {
+      "OID": "WC.LB.5f2a0bab",
+      "conditions": [
+        "COND.LB.LBTESTCD.d7f9d982",
+        "COND.LB.LBSPEC.f6f6df0c"
+      ]
+    },
+    {
+      "OID": "WC.LB.eea0ae49",
+      "conditions": [
+        "COND.LB.LBTESTCD.ee1bd4eb",
+        "COND.LB.LBSPEC.f6f6df0c"
+      ]
+    },
+    {
+      "OID": "WC.LB.550c7a01",
+      "conditions": [
+        "COND.LB.LBTESTCD.7949af26",
+        "COND.LB.LBSPEC.f6f6df0c"
+      ]
+    },
+    {
+      "OID": "WC.LB.de4c119b",
+      "conditions": [
+        "COND.LB.LBTESTCD.875d3e51",
+        "COND.LB.LBSPEC.f6f6df0c"
+      ]
+    },
+    {
+      "OID": "WC.LB.a5684311",
+      "conditions": [
+        "COND.LB.LBTESTCD.67b49e63",
+        "COND.LB.LBSPEC.f6f6df0c"
+      ]
+    },
+    {
+      "OID": "WC.LB.7b86c15b",
+      "conditions": [
+        "COND.LB.LBTESTCD.287c5431",
+        "COND.LB.LBSPEC.f6f6df0c"
+      ]
+    },
+    {
+      "OID": "WC.LB.3a9d73e1",
+      "conditions": [
+        "COND.LB.LBTESTCD.e319c1c9",
+        "COND.LB.LBSPEC.f6f6df0c"
+      ]
+    },
+    {
+      "OID": "WC.LB.ddc3319f",
+      "conditions": [
+        "COND.LB.LBTESTCD.595603b0",
+        "COND.LB.LBSPEC.e9dcc27d"
+      ]
+    },
+    {
+      "OID": "WC.LB.116f85e4",
+      "conditions": [
+        "COND.LB.LBTESTCD.4a019cc1",
+        "COND.LB.LBSPEC.e9dcc27d"
+      ]
+    },
+    {
+      "OID": "WC.LB.84ceb0ad",
+      "conditions": [
+        "COND.LB.LBTESTCD.4c8c90fb",
+        "COND.LB.LBSPEC.f6f6df0c"
+      ]
+    },
+    {
+      "OID": "WC.LB.b622c728",
+      "conditions": [
+        "COND.LB.LBTESTCD.44179c1d",
+        "COND.LB.LBSPEC.f6f6df0c"
+      ]
+    },
+    {
+      "OID": "WC.LB.87b1b367",
+      "conditions": [
+        "COND.LB.LBTESTCD.279ee1d7",
+        "COND.LB.LBSPEC.f6f6df0c"
+      ]
+    },
+    {
+      "OID": "WC.LB.5412b298",
+      "conditions": [
+        "COND.LB.LBTESTCD.2cf3f505",
+        "COND.LB.LBSPEC.2a0ba9ed"
+      ]
+    },
+    {
+      "OID": "WC.LB.e42a3c09",
+      "conditions": [
+        "COND.LB.LBTESTCD.65d4f752",
+        "COND.LB.LBSPEC.fe2e0fb3"
+      ]
+    },
+    {
+      "OID": "WC.LB.cdac7fcc",
+      "conditions": [
+        "COND.LB.LBTESTCD.b2d661b6",
+        "COND.LB.LBSPEC.2a0ba9ed"
+      ]
+    },
+    {
+      "OID": "WC.LB.b9d7ddba",
+      "conditions": [
+        "COND.LB.LBTESTCD.ee16e022",
+        "COND.LB.LBSPEC.2a0ba9ed"
+      ]
+    },
+    {
+      "OID": "WC.LB.969c1a6d",
+      "conditions": [
+        "COND.LB.LBTESTCD.09d56ffc",
+        "COND.LB.LBSPEC.fe2e0fb3"
+      ]
+    },
+    {
+      "OID": "WC.LB.7ce691fd",
+      "conditions": [
+        "COND.LB.LBTESTCD.5e7b0134",
+        "COND.LB.LBSPEC.fe2e0fb3"
+      ]
+    },
+    {
+      "OID": "WC.LB.88601b52",
+      "conditions": [
+        "COND.LB.LBTESTCD.1f6a1d0f",
+        "COND.LB.LBSPEC.fe2e0fb3"
+      ]
+    },
+    {
+      "OID": "WC.LB.42392cd1",
+      "conditions": [
+        "COND.LB.LBTESTCD.c95065ae",
+        "COND.LB.LBSPEC.2a0ba9ed"
+      ]
+    },
+    {
+      "OID": "WC.LB.9279ec22",
+      "conditions": [
+        "COND.LB.LBTESTCD.608ed901",
+        "COND.LB.LBSPEC.f6f6df0c"
+      ]
+    },
+    {
+      "OID": "WC.LB.8b779a3b",
+      "conditions": [
+        "COND.LB.LBTESTCD.4bda7613",
+        "COND.LB.LBSPEC.2a0ba9ed"
+      ]
+    },
+    {
+      "OID": "WC.LB.cfe14422",
+      "conditions": [
+        "COND.LB.LBTESTCD.fb28452f",
+        "COND.LB.LBSPEC.fe2e0fb3"
+      ]
+    },
+    {
+      "OID": "WC.LB.8285c765",
+      "conditions": [
+        "COND.LB.LBTESTCD.4ea796f7",
+        "COND.LB.LBSPEC.2a0ba9ed"
+      ]
+    },
+    {
+      "OID": "WC.LB.37c7b4ba",
+      "conditions": [
+        "COND.LB.LBTESTCD.4787c4c4",
+        "COND.LB.LBSPEC.2a0ba9ed"
+      ]
+    },
+    {
+      "OID": "WC.LB.e4e81dc5",
+      "conditions": [
+        "COND.LB.LBTESTCD.9181afaf",
+        "COND.LB.LBSPEC.2a0ba9ed"
+      ]
+    },
+    {
+      "OID": "WC.LB.470def9b",
+      "conditions": [
+        "COND.LB.LBTESTCD.9bb90c0f",
+        "COND.LB.LBSPEC.2a0ba9ed"
+      ]
+    },
+    {
+      "OID": "WC.LB.c891c160",
+      "conditions": [
+        "COND.LB.LBTESTCD.5f3309c8",
+        "COND.LB.LBSPEC.fe2e0fb3"
+      ]
+    },
+    {
+      "OID": "WC.LB.abcfd20c",
+      "conditions": [
+        "COND.LB.LBTESTCD.3705806a",
+        "COND.LB.LBSPEC.fe2e0fb3"
+      ]
+    },
+    {
+      "OID": "WC.LB.5a1bca67",
+      "conditions": [
+        "COND.LB.LBTESTCD.546f62a6",
+        "COND.LB.LBSPEC.2a0ba9ed"
+      ]
+    },
+    {
+      "OID": "WC.LB.4226ee02",
+      "conditions": [
+        "COND.LB.LBTESTCD.662421ca",
+        "COND.LB.LBSPEC.2a0ba9ed"
+      ]
+    },
+    {
+      "OID": "WC.LB.df33e99e",
+      "conditions": [
+        "COND.LB.LBTESTCD.253a2d2c",
+        "COND.LB.LBSPEC.2a0ba9ed"
+      ]
+    },
+    {
+      "OID": "WC.LB.30f3d8b3",
+      "conditions": [
+        "COND.LB.LBTESTCD.32179136",
+        "COND.LB.LBSPEC.2a0ba9ed"
+      ]
+    },
+    {
+      "OID": "WC.LB.f59f4529",
+      "conditions": [
+        "COND.LB.LBTESTCD.68013b69",
+        "COND.LB.LBSPEC.2a0ba9ed"
+      ]
+    },
+    {
+      "OID": "WC.LB.c54221c6",
+      "conditions": [
+        "COND.LB.LBTESTCD.af474d82",
+        "COND.LB.LBSPEC.2a0ba9ed"
+      ]
+    },
+    {
+      "OID": "WC.LB.cb02cad8",
+      "conditions": [
+        "COND.LB.LBTESTCD.ee2fb0c8",
+        "COND.LB.LBSPEC.2a0ba9ed"
+      ]
+    },
+    {
+      "OID": "WC.LB.d0f49556",
+      "conditions": [
+        "COND.LB.LBTESTCD.a07b5dee",
+        "COND.LB.LBSPEC.2a0ba9ed"
+      ]
+    },
+    {
+      "OID": "WC.LB.4987b41e",
+      "conditions": [
+        "COND.LB.LBTESTCD.797729c2",
+        "COND.LB.LBSPEC.fe2e0fb3"
+      ]
+    },
+    {
+      "OID": "WC.LB.cbf789d8",
+      "conditions": [
+        "COND.LB.LBTESTCD.5613f4c1",
+        "COND.LB.LBSPEC.fe2e0fb3"
+      ]
+    },
+    {
+      "OID": "WC.LB.3239d7a3",
+      "conditions": [
+        "COND.LB.LBTESTCD.e6f6bca1",
+        "COND.LB.LBSPEC.fe2e0fb3"
+      ]
+    },
+    {
+      "OID": "WC.LB.59366afe",
+      "conditions": [
+        "COND.LB.LBTESTCD.ce5391eb",
+        "COND.LB.LBSPEC.fe2e0fb3"
+      ]
+    },
+    {
+      "OID": "WC.LB.3adc4566",
+      "conditions": [
+        "COND.LB.LBTESTCD.d277d8f1",
+        "COND.LB.LBSPEC.22e91b54"
+      ]
+    },
+    {
+      "OID": "WC.LB.59074de1",
+      "conditions": [
+        "COND.LB.LBTESTCD.b3c8bdba",
+        "COND.LB.LBSPEC.fe2e0fb3"
+      ]
+    },
+    {
+      "OID": "WC.LB.c1765eee",
+      "conditions": [
+        "COND.LB.LBTESTCD.1350d454",
+        "COND.LB.LBSPEC.f6f6df0c"
+      ]
+    },
+    {
+      "OID": "WC.LB.dd459ec6",
+      "conditions": [
+        "COND.LB.LBTESTCD.5717b134",
+        "COND.LB.LBSPEC.f6f6df0c"
+      ]
+    },
+    {
+      "OID": "WC.LB.e9a1c33d",
+      "conditions": [
+        "COND.LB.LBTESTCD.04aa6f0c",
+        "COND.LB.LBSPEC.f6f6df0c",
+        "COND.LB.LBMETHOD.ac001fcd"
+      ]
+    },
+    {
+      "OID": "WC.LB.7f0975c7",
+      "conditions": [
+        "COND.LB.LBTESTCD.2596a002",
+        "COND.LB.LBSPEC.f6f6df0c"
+      ]
+    },
+    {
+      "OID": "WC.LB.f7f1de35",
+      "conditions": [
+        "COND.LB.LBTESTCD.f0b51e31",
+        "COND.LB.LBSPEC.f6f6df0c"
+      ]
+    },
+    {
+      "OID": "WC.LB.c32acb17",
+      "conditions": [
+        "COND.LB.LBTESTCD.ca27fffa",
+        "COND.LB.LBSPEC.d1bfd10c"
+      ]
+    },
+    {
+      "OID": "WC.LB.eb7f048a",
+      "conditions": [
+        "COND.LB.LBTESTCD.e647bee9",
+        "COND.LB.LBSPEC.d1bfd10c"
+      ]
+    },
+    {
+      "OID": "WC.LB.e881d4b5",
+      "conditions": [
+        "COND.LB.LBTESTCD.347788eb",
+        "COND.LB.LBSPEC.d1bfd10c"
+      ]
+    },
+    {
+      "OID": "WC.LB.41785be6",
+      "conditions": [
+        "COND.LB.LBTESTCD.d093221c",
+        "COND.LB.LBSPEC.f6f6df0c"
+      ]
+    },
+    {
+      "OID": "WC.LB.a68e5eaa",
+      "conditions": [
+        "COND.LB.LBTESTCD.d7f9d982",
+        "COND.LB.LBSPEC.f6f6df0c"
+      ]
+    },
+    {
+      "OID": "WC.LB.aad6dbd6",
+      "conditions": [
+        "COND.LB.LBTESTCD.ee1bd4eb",
+        "COND.LB.LBSPEC.f6f6df0c"
+      ]
+    },
+    {
+      "OID": "WC.LB.d13d6578",
+      "conditions": [
+        "COND.LB.LBTESTCD.7949af26",
+        "COND.LB.LBSPEC.f6f6df0c"
+      ]
+    },
+    {
+      "OID": "WC.LB.00e6d228",
+      "conditions": [
+        "COND.LB.LBTESTCD.875d3e51",
+        "COND.LB.LBSPEC.f6f6df0c"
+      ]
+    },
+    {
+      "OID": "WC.LB.ef654de1",
+      "conditions": [
+        "COND.LB.LBTESTCD.67b49e63",
+        "COND.LB.LBSPEC.f6f6df0c"
+      ]
+    },
+    {
+      "OID": "WC.LB.b6fa6e8d",
+      "conditions": [
+        "COND.LB.LBTESTCD.287c5431",
+        "COND.LB.LBSPEC.f6f6df0c"
+      ]
+    },
+    {
+      "OID": "WC.LB.90eedf3b",
+      "conditions": [
+        "COND.LB.LBTESTCD.e319c1c9",
+        "COND.LB.LBSPEC.f6f6df0c"
+      ]
+    },
+    {
+      "OID": "WC.LB.8914eb45",
+      "conditions": [
+        "COND.LB.LBTESTCD.2cf3f505",
+        "COND.LB.LBSPEC.2a0ba9ed"
+      ]
+    },
+    {
+      "OID": "WC.LB.6660e11c",
+      "conditions": [
+        "COND.LB.LBTESTCD.b2d661b6",
+        "COND.LB.LBSPEC.2a0ba9ed"
+      ]
+    },
+    {
+      "OID": "WC.LB.37e389df",
+      "conditions": [
+        "COND.LB.LBTESTCD.ee16e022",
+        "COND.LB.LBSPEC.2a0ba9ed"
+      ]
+    },
+    {
+      "OID": "WC.LB.549f5ae4",
+      "conditions": [
+        "COND.LB.LBTESTCD.09d56ffc",
+        "COND.LB.LBSPEC.fe2e0fb3"
+      ]
+    },
+    {
+      "OID": "WC.LB.ee634517",
+      "conditions": [
+        "COND.LB.LBTESTCD.5e7b0134",
+        "COND.LB.LBSPEC.fe2e0fb3"
+      ]
+    },
+    {
+      "OID": "WC.LB.07a8daa1",
+      "conditions": [
+        "COND.LB.LBTESTCD.1f6a1d0f",
+        "COND.LB.LBSPEC.fe2e0fb3"
+      ]
+    },
+    {
+      "OID": "WC.LB.91d1c3d5",
+      "conditions": [
+        "COND.LB.LBTESTCD.c95065ae",
+        "COND.LB.LBSPEC.2a0ba9ed"
+      ]
+    },
+    {
+      "OID": "WC.LB.9df0845c",
+      "conditions": [
+        "COND.LB.LBTESTCD.608ed901",
+        "COND.LB.LBSPEC.f6f6df0c"
+      ]
+    },
+    {
+      "OID": "WC.LB.cc8b6004",
+      "conditions": [
+        "COND.LB.LBTESTCD.4bda7613",
+        "COND.LB.LBSPEC.2a0ba9ed"
+      ]
+    },
+    {
+      "OID": "WC.LB.3c564f36",
+      "conditions": [
+        "COND.LB.LBTESTCD.4ea796f7",
+        "COND.LB.LBSPEC.2a0ba9ed"
+      ]
+    },
+    {
+      "OID": "WC.LB.13fbb1a5",
+      "conditions": [
+        "COND.LB.LBTESTCD.4787c4c4",
+        "COND.LB.LBSPEC.2a0ba9ed"
+      ]
+    },
+    {
+      "OID": "WC.LB.3749493c",
+      "conditions": [
+        "COND.LB.LBTESTCD.9181afaf",
+        "COND.LB.LBSPEC.2a0ba9ed"
+      ]
+    },
+    {
+      "OID": "WC.LB.38f9f39d",
+      "conditions": [
+        "COND.LB.LBTESTCD.9bb90c0f",
+        "COND.LB.LBSPEC.2a0ba9ed"
+      ]
+    },
+    {
+      "OID": "WC.LB.516f3664",
+      "conditions": [
+        "COND.LB.LBTESTCD.546f62a6",
+        "COND.LB.LBSPEC.2a0ba9ed"
+      ]
+    },
+    {
+      "OID": "WC.LB.dcbcbe57",
+      "conditions": [
+        "COND.LB.LBTESTCD.662421ca",
+        "COND.LB.LBSPEC.2a0ba9ed"
+      ]
+    },
+    {
+      "OID": "WC.LB.b7b215a1",
+      "conditions": [
+        "COND.LB.LBTESTCD.253a2d2c",
+        "COND.LB.LBSPEC.2a0ba9ed"
+      ]
+    },
+    {
+      "OID": "WC.LB.0f071538",
+      "conditions": [
+        "COND.LB.LBTESTCD.32179136",
+        "COND.LB.LBSPEC.2a0ba9ed"
+      ]
+    },
+    {
+      "OID": "WC.LB.258e657c",
+      "conditions": [
+        "COND.LB.LBTESTCD.68013b69",
+        "COND.LB.LBSPEC.2a0ba9ed"
+      ]
+    },
+    {
+      "OID": "WC.LB.d675561c",
+      "conditions": [
+        "COND.LB.LBTESTCD.af474d82",
+        "COND.LB.LBSPEC.2a0ba9ed"
+      ]
+    },
+    {
+      "OID": "WC.LB.e81938d6",
+      "conditions": [
+        "COND.LB.LBTESTCD.ee2fb0c8",
+        "COND.LB.LBSPEC.2a0ba9ed"
+      ]
+    },
+    {
+      "OID": "WC.LB.54dda2d1",
+      "conditions": [
+        "COND.LB.LBTESTCD.a07b5dee",
+        "COND.LB.LBSPEC.2a0ba9ed"
+      ]
+    },
+    {
+      "OID": "WC.LB.e6a434ec",
+      "conditions": [
+        "COND.LB.LBTESTCD.ce5391eb",
+        "COND.LB.LBSPEC.fe2e0fb3"
+      ]
+    },
+    {
+      "OID": "WC.LB.9e9118c8",
+      "conditions": [
+        "COND.LB.LBTESTCD.1350d454",
+        "COND.LB.LBSPEC.f6f6df0c"
+      ]
+    },
+    {
+      "OID": "WC.LB.8644d9ca",
+      "conditions": [
+        "COND.LB.LBTESTCD.5717b134",
+        "COND.LB.LBSPEC.f6f6df0c"
+      ]
+    },
+    {
+      "OID": "WC.MB.49773274",
+      "conditions": [
+        "COND.MB.MBTESTCD.b145c972",
+        "COND.MB.MBTSTDTL.4a168fd0",
+        "COND.MB.MBSPEC.41a5e97b",
+        "COND.MB.MBMETHOD.6348a3e5"
+      ]
+    },
+    {
+      "OID": "WC.MB.e698c5a2",
+      "conditions": [
+        "COND.MB.MBTESTCD.18cb7208",
+        "COND.MB.MBTSTDTL.4a168fd0",
+        "COND.MB.MBSPEC.b395cb00",
+        "COND.MB.MBMETHOD.92bec008"
+      ]
+    },
+    {
+      "OID": "WC.TS.08ebd0ce",
+      "conditions": [
+        "COND.TS.TSPARMCD.8e8bd467"
+      ]
+    },
+    {
+      "OID": "WC.TS.a7d24f4a",
+      "conditions": [
+        "COND.TS.TSPARMCD.a188954a"
+      ]
+    },
+    {
+      "OID": "WC.TS.4ac86c98",
+      "conditions": [
+        "COND.TS.TSPARMCD.ec5a57e2"
+      ]
+    },
+    {
+      "OID": "WC.TS.54cd02f1",
+      "conditions": [
+        "COND.TS.TSPARMCD.cd7838e7"
+      ]
+    },
+    {
+      "OID": "WC.TS.f9fa8745",
+      "conditions": [
+        "COND.TS.TSPARMCD.ceb735c9"
+      ]
+    },
+    {
+      "OID": "WC.TS.7fc6c3e6",
+      "conditions": [
+        "COND.TS.TSPARMCD.b47a17a8"
+      ]
+    },
+    {
+      "OID": "WC.TS.5cd14c68",
+      "conditions": [
+        "COND.TS.TSPARMCD.31172311"
+      ]
+    },
+    {
+      "OID": "WC.TS.4053f56c",
+      "conditions": [
+        "COND.TS.TSPARMCD.586a7d9a"
+      ]
+    },
+    {
+      "OID": "WC.TS.9cdae039",
+      "conditions": [
+        "COND.TS.TSPARMCD.204aa07d"
+      ]
+    },
+    {
+      "OID": "WC.TS.2c83b5d9",
+      "conditions": [
+        "COND.TS.TSPARMCD.66a1c586"
+      ]
+    },
+    {
+      "OID": "WC.TS.e3ae16cd",
+      "conditions": [
+        "COND.TS.TSPARMCD.fd076a8d"
+      ]
+    },
+    {
+      "OID": "WC.TS.89c0d243",
+      "conditions": [
+        "COND.TS.TSPARMCD.770c1610"
+      ]
+    },
+    {
+      "OID": "WC.TS.7a056c75",
+      "conditions": [
+        "COND.TS.TSPARMCD.eb0c9bb2"
+      ]
+    },
+    {
+      "OID": "WC.TS.36721696",
+      "conditions": [
+        "COND.TS.TSPARMCD.5ca3cd0c"
+      ]
+    },
+    {
+      "OID": "WC.TS.d8b84608",
+      "conditions": [
+        "COND.TS.TSPARMCD.a724d633"
+      ]
+    },
+    {
+      "OID": "WC.TS.1d3cd461",
+      "conditions": [
+        "COND.TS.TSPARMCD.b313e712"
+      ]
+    },
+    {
+      "OID": "WC.TS.3a1c5c3c",
+      "conditions": [
+        "COND.TS.TSPARMCD.116dcbeb"
+      ]
+    },
+    {
+      "OID": "WC.TS.2b2d70bc",
+      "conditions": [
+        "COND.TS.TSPARMCD.05d6aaed"
+      ]
+    },
+    {
+      "OID": "WC.TS.3c4a8bf2",
+      "conditions": [
+        "COND.TS.TSPARMCD.2254e8e7"
+      ]
+    },
+    {
+      "OID": "WC.TS.4f0c74c2",
+      "conditions": [
+        "COND.TS.TSPARMCD.501d0db2"
+      ]
+    },
+    {
+      "OID": "WC.TS.51236927",
+      "conditions": [
+        "COND.TS.TSPARMCD.2e2517d1"
+      ]
+    },
+    {
+      "OID": "WC.TS.f4cb41bb",
+      "conditions": [
+        "COND.TS.TSPARMCD.5888eb50"
+      ]
+    },
+    {
+      "OID": "WC.TS.9e101607",
+      "conditions": [
+        "COND.TS.TSPARMCD.f1a61db1"
+      ]
+    },
+    {
+      "OID": "WC.TS.d8c1ac4c",
+      "conditions": [
+        "COND.TS.TSPARMCD.688d36b6"
+      ]
+    },
+    {
+      "OID": "WC.TS.e423672b",
+      "conditions": [
+        "COND.TS.TSPARMCD.80d7d149"
+      ]
+    },
+    {
+      "OID": "WC.TS.43684533",
+      "conditions": [
+        "COND.TS.TSPARMCD.52dad99f"
+      ]
+    },
+    {
+      "OID": "WC.TS.22640600",
+      "conditions": [
+        "COND.TS.TSPARMCD.342e8413"
+      ]
+    },
+    {
+      "OID": "WC.TS.1948fed3",
+      "conditions": [
+        "COND.TS.TSPARMCD.185bd9b1"
+      ]
+    },
+    {
+      "OID": "WC.TS.29af0670",
+      "conditions": [
+        "COND.TS.TSPARMCD.91606039"
+      ]
+    },
+    {
+      "OID": "WC.IE.1d2bb25f",
+      "conditions": [
+        "COND.IE.IETESTCD.02e45534"
+      ]
+    },
+    {
+      "OID": "WC.IE.fa688bf3",
+      "conditions": [
+        "COND.IE.IETESTCD.b98e6bfa"
+      ]
+    },
+    {
+      "OID": "WC.IE.f276b607",
+      "conditions": [
+        "COND.IE.IETESTCD.414aa6b7"
+      ]
+    },
+    {
+      "OID": "WC.IE.cd528448",
+      "conditions": [
+        "COND.IE.IETESTCD.5600ece7"
+      ]
+    },
+    {
+      "OID": "WC.IE.c1db3fd3",
+      "conditions": [
+        "COND.IE.IETESTCD.e62058fb"
+      ]
+    },
+    {
+      "OID": "WC.IE.c2ec614b",
+      "conditions": [
+        "COND.IE.IETESTCD.cae1a567"
+      ]
+    },
+    {
+      "OID": "WC.IE.2ef341aa",
+      "conditions": [
+        "COND.IE.IETESTCD.0b4d25da"
+      ]
+    },
+    {
+      "OID": "WC.IE.5d85184b",
+      "conditions": [
+        "COND.IE.IETESTCD.dd1bb437"
+      ]
+    },
+    {
+      "OID": "WC.IE.8579104c",
+      "conditions": [
+        "COND.IE.IETESTCD.b86f72a6"
+      ]
+    },
+    {
+      "OID": "WC.IE.74eacc45",
+      "conditions": [
+        "COND.IE.IETESTCD.ee806e62"
+      ]
+    },
+    {
+      "OID": "WC.IE.ce0e8d09",
+      "conditions": [
+        "COND.IE.IETESTCD.13b40508"
+      ]
+    },
+    {
+      "OID": "WC.IE.945bafbd",
+      "conditions": [
+        "COND.IE.IETESTCD.27412cd0"
+      ]
+    },
+    {
+      "OID": "WC.IE.afbec960",
+      "conditions": [
+        "COND.IE.IETESTCD.c264aeb4"
+      ]
+    },
+    {
+      "OID": "WC.IE.cac0d3f4",
+      "conditions": [
+        "COND.IE.IETESTCD.904b6c2f"
+      ]
+    },
+    {
+      "OID": "WC.IE.cabd9be0",
+      "conditions": [
+        "COND.IE.IETESTCD.29880e8c"
+      ]
+    },
+    {
+      "OID": "WC.IE.fbae7983",
+      "conditions": [
+        "COND.IE.IETESTCD.7f6091a2"
+      ]
+    },
+    {
+      "OID": "WC.IE.0952c014",
+      "conditions": [
+        "COND.IE.IETESTCD.8f18d21b"
+      ]
+    },
+    {
+      "OID": "WC.IE.5b8b02b2",
+      "conditions": [
+        "COND.IE.IETESTCD.86209c99"
+      ]
+    },
+    {
+      "OID": "WC.IE.70a941e7",
+      "conditions": [
+        "COND.IE.IETESTCD.aab5d609"
+      ]
+    },
+    {
+      "OID": "WC.IE.611f5d7b",
+      "conditions": [
+        "COND.IE.IETESTCD.25355161"
+      ]
+    },
+    {
+      "OID": "WC.IE.8abff918",
+      "conditions": [
+        "COND.IE.IETESTCD.a38963bd"
+      ]
+    },
+    {
+      "OID": "WC.IE.b089a2a0",
+      "conditions": [
+        "COND.IE.IETESTCD.4f25707e"
+      ]
+    },
+    {
+      "OID": "WC.IE.39cb2456",
+      "conditions": [
+        "COND.IE.IETESTCD.2a079ede"
+      ]
+    },
+    {
+      "OID": "WC.IE.2cdb5c18",
+      "conditions": [
+        "COND.IE.IETESTCD.871b7729"
+      ]
+    },
+    {
+      "OID": "WC.IE.b415f3a9",
+      "conditions": [
+        "COND.IE.IETESTCD.51c4af93"
+      ]
+    },
+    {
+      "OID": "WC.IE.5c29f970",
+      "conditions": [
+        "COND.IE.IETESTCD.a954a7c8"
+      ]
+    },
+    {
+      "OID": "WC.IE.9fe9a358",
+      "conditions": [
+        "COND.IE.IETESTCD.8f66ca7f"
+      ]
+    },
+    {
+      "OID": "WC.IE.e36b210b",
+      "conditions": [
+        "COND.IE.IETESTCD.528d2eb0"
+      ]
+    },
+    {
+      "OID": "WC.IE.743b4fb5",
+      "conditions": [
+        "COND.IE.IETESTCD.bd5f1313"
+      ]
+    },
+    {
+      "OID": "WC.IE.76a82754",
+      "conditions": [
+        "COND.IE.IETESTCD.01e1c173"
+      ]
+    },
+    {
+      "OID": "WC.IE.fbeb5a1e",
+      "conditions": [
+        "COND.IE.IETESTCD.b8e48983"
+      ]
+    }
+  ],
+  "codeLists": [
+    {
+      "OID": "CL.ARMCD",
+      "name": "ARM Code",
+      "dataType": "text",
+      "isNonStandard": true,
+      "codeListItems": [
+        {
+          "codedValue": "Placebo"
+        },
+        {
+          "codedValue": "Xanomeline Low Dose"
+        },
+        {
+          "codedValue": "Xanomeline High Dose"
+        }
+      ]
+    },
+    {
+      "OID": "CL.ARM",
+      "name": "ARM",
+      "dataType": "text",
+      "isNonStandard": true,
+      "codeListItems": [
+        {
+          "codedValue": "Placebo"
+        },
+        {
+          "codedValue": "Xanomeline Low Dose"
+        },
+        {
+          "codedValue": "Xanomeline High Dose"
+        }
+      ]
+    },
+    {
+      "OID": "CL.IETEST",
+      "name": "Inclusion/Exclusion Test Name",
+      "dataType": "text",
+      "isNonStandard": true,
+      "codeListItems": [
+        {
+          "codedValue": "Age greater than 50"
+        },
+        {
+          "codedValue": "Diagnosis of Alzheimer's"
+        },
+        {
+          "codedValue": "MMSE Score"
+        },
+        {
+          "codedValue": "Hachinski Ischemic Score"
+        },
+        {
+          "codedValue": "CNS imaging comptaible with Alzheimer's"
+        },
+        {
+          "codedValue": "Informed consent criteria"
+        },
+        {
+          "codedValue": "Geographic proximity criteria"
+        },
+        {
+          "codedValue": "Reliable caregiver criteria"
+        },
+        {
+          "codedValue": "Previous study criteria"
+        },
+        {
+          "codedValue": "Other Alzheimer's therapy criteria"
+        },
+        {
+          "codedValue": "Serious illness criteria"
+        },
+        {
+          "codedValue": "Serious neurolocal conditions criteria"
+        },
+        {
+          "codedValue": "Depression criteria"
+        },
+        {
+          "codedValue": "Schizophrenia, Bipolar, Ethanol or psychoactive abuse criteria"
+        },
+        {
+          "codedValue": "Syncope criteria"
+        },
+        {
+          "codedValue": "ECG Criteria"
+        },
+        {
+          "codedValue": "Cardiovascular criteria"
+        },
+        {
+          "codedValue": "Gastrointensinal criteria"
+        },
+        {
+          "codedValue": "Endocrine criteria"
+        },
+        {
+          "codedValue": "Resporatory criteria"
+        },
+        {
+          "codedValue": "Genitourinary criteria"
+        },
+        {
+          "codedValue": "Rheumatologic criteria"
+        },
+        {
+          "codedValue": "HIV criteria"
+        },
+        {
+          "codedValue": "Neurosyphilis, Meningitis,Encephalitis criteria"
+        },
+        {
+          "codedValue": "Malignant disease criteria"
+        },
+        {
+          "codedValue": "Ability to participate in study criteria"
+        },
+        {
+          "codedValue": "Laboratory values criteria"
+        },
+        {
+          "codedValue": "Central laboratory values criteria"
+        },
+        {
+          "codedValue": "Syphilia criteria"
+        },
+        {
+          "codedValue": "Hemoglobin criteria"
+        },
+        {
+          "codedValue": "Medications Criteria"
+        }
+      ]
+    },
+    {
+      "OID": "CL.IETESTCD",
+      "name": "Inclusion/Exclusion Test Code",
+      "dataType": "text",
+      "isNonStandard": true,
+      "codeListItems": [
+        {
+          "codedValue": "IN01",
+          "decode": "Age greater than 50"
+        },
+        {
+          "codedValue": "IN02",
+          "decode": "Diagnosis of Alzheimer's"
+        },
+        {
+          "codedValue": "IN03",
+          "decode": "MMSE Score"
+        },
+        {
+          "codedValue": "IN04",
+          "decode": "Hachinski Ischemic Score"
+        },
+        {
+          "codedValue": "IN05",
+          "decode": "CNS imaging comptaible with Alzheimer's"
+        },
+        {
+          "codedValue": "IN06",
+          "decode": "Informed consent criteria"
+        },
+        {
+          "codedValue": "IN07",
+          "decode": "Geographic proximity criteria"
+        },
+        {
+          "codedValue": "IN08",
+          "decode": "Reliable caregiver criteria"
+        },
+        {
+          "codedValue": "EX01",
+          "decode": "Previous study criteria"
+        },
+        {
+          "codedValue": "EX02",
+          "decode": "Other Alzheimer's therapy criteria"
+        },
+        {
+          "codedValue": "EX03",
+          "decode": "Serious illness criteria"
+        },
+        {
+          "codedValue": "EX04",
+          "decode": "Serious neurolocal conditions criteria"
+        },
+        {
+          "codedValue": "EX05",
+          "decode": "Depression criteria"
+        },
+        {
+          "codedValue": "EX06",
+          "decode": "Schizophrenia, Bipolar, Ethanol or psychoactive abuse criteria"
+        },
+        {
+          "codedValue": "EX07",
+          "decode": "Syncope criteria"
+        },
+        {
+          "codedValue": "EX08",
+          "decode": "ECG Criteria"
+        },
+        {
+          "codedValue": "EX09",
+          "decode": "Cardiovascular criteria"
+        },
+        {
+          "codedValue": "EX10",
+          "decode": "Gastrointensinal criteria"
+        },
+        {
+          "codedValue": "EX11",
+          "decode": "Endocrine criteria"
+        },
+        {
+          "codedValue": "EX12",
+          "decode": "Resporatory criteria"
+        },
+        {
+          "codedValue": "EX13",
+          "decode": "Genitourinary criteria"
+        },
+        {
+          "codedValue": "EX14",
+          "decode": "Rheumatologic criteria"
+        },
+        {
+          "codedValue": "EX15",
+          "decode": "HIV criteria"
+        },
+        {
+          "codedValue": "EX16",
+          "decode": "Neurosyphilis, Meningitis,Encephalitis criteria"
+        },
+        {
+          "codedValue": "EX17",
+          "decode": "Malignant disease criteria"
+        },
+        {
+          "codedValue": "EX18",
+          "decode": "Ability to participate in study criteria"
+        },
+        {
+          "codedValue": "EX19",
+          "decode": "Laboratory values criteria"
+        },
+        {
+          "codedValue": "EX20",
+          "decode": "Central laboratory values criteria"
+        },
+        {
+          "codedValue": "EX21",
+          "decode": "Syphilia criteria"
+        },
+        {
+          "codedValue": "EX22",
+          "decode": "Hemoglobin criteria"
+        },
+        {
+          "codedValue": "EX23",
+          "decode": "Medications Criteria"
+        }
+      ]
+    },
+    {
+      "OID": "CL.ELEMENT",
+      "name": "Description of Element",
+      "dataType": "text",
+      "isNonStandard": true,
+      "codeListItems": [
+        {
+          "codedValue": "Screening"
+        },
+        {
+          "codedValue": "Placebo"
+        },
+        {
+          "codedValue": "Follow up"
+        },
+        {
+          "codedValue": "Low"
+        },
+        {
+          "codedValue": "High - Start"
+        },
+        {
+          "codedValue": "High - Middle"
+        },
+        {
+          "codedValue": "High - End"
+        }
+      ]
+    },
+    {
+      "OID": "CL.ETCD",
+      "name": "Element Code",
+      "dataType": "text",
+      "isNonStandard": true,
+      "codeListItems": [
+        {
+          "codedValue": "EL1",
+          "decode": "Screening"
+        },
+        {
+          "codedValue": "EL2",
+          "decode": "Placebo"
+        },
+        {
+          "codedValue": "EL7",
+          "decode": "Follow up"
+        },
+        {
+          "codedValue": "EL3",
+          "decode": "Low"
+        },
+        {
+          "codedValue": "EL4",
+          "decode": "High - Start"
+        },
+        {
+          "codedValue": "EL5",
+          "decode": "High - Middle"
+        },
+        {
+          "codedValue": "EL6",
+          "decode": "High - End"
+        }
+      ]
+    },
+    {
+      "OID": "CL.EPOCH",
+      "name": "Epoch",
+      "dataType": "text",
+      "standard": "STD.SDTMCT",
+      "coding": [
+        {
+          "code": "C99079",
+          "codeSystem": "nci:ExtCodeID"
+        }
+      ],
+      "codeListItems": [
+        {
+          "codedValue": "Screening",
+          "coding": {
+            "code": "C202487",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Treatment 1",
+          "coding": {
+            "code": "C101526",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Treatment 2",
+          "coding": {
+            "code": "C101526",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Treatment 3",
+          "coding": {
+            "code": "C101526",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Follow-Up",
+          "coding": {
+            "code": "C202578",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        }
+      ]
+    },
+    {
+      "OID": "CL.NCOMPLT",
+      "name": "Completion/Reason for Non-Completion",
+      "dataType": "text",
+      "standard": "STD.SDTMCT",
+      "coding": [
+        {
+          "code": "C66727",
+          "codeSystem": "nci:ExtCodeID"
+        }
+      ],
+      "codeListItems": [
+        {
+          "codedValue": "__PLACEHOLDER__",
+          "decode": "__PLACEHOLDER__"
+        }
+      ]
+    },
+    {
+      "OID": "CL.DSCAT",
+      "name": "Category of Disposition Event",
+      "dataType": "text",
+      "standard": "STD.SDTMCT",
+      "coding": [
+        {
+          "code": "C74558",
+          "codeSystem": "nci:ExtCodeID"
+        }
+      ],
+      "codeListItems": [
+        {
+          "codedValue": "__PLACEHOLDER__",
+          "decode": "__PLACEHOLDER__"
+        }
+      ]
+    },
+    {
+      "OID": "CL.DSSCAT",
+      "name": "Subcategory for Disposition Event",
+      "dataType": "text",
+      "standard": "STD.SDTMCT",
+      "coding": [
+        {
+          "code": "C170443",
+          "codeSystem": "nci:ExtCodeID"
+        }
+      ],
+      "codeListItems": [
+        {
+          "codedValue": "__PLACEHOLDER__",
+          "decode": "__PLACEHOLDER__"
+        }
+      ]
+    },
+    {
+      "OID": "CL.NY",
+      "name": "No Yes Response",
+      "dataType": "text",
+      "standard": "STD.SDTMCT",
+      "coding": [
+        {
+          "code": "C66742",
+          "codeSystem": "nci:ExtCodeID"
+        }
+      ],
+      "codeListItems": [
+        {
+          "codedValue": "N",
+          "decode": "No",
+          "coding": {
+            "code": "C49487",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Y",
+          "decode": "Yes",
+          "coding": {
+            "code": "C49488",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        }
+      ]
+    },
+    {
+      "OID": "CL.AGEU",
+      "name": "Age Unit",
+      "dataType": "text",
+      "standard": "STD.SDTMCT",
+      "coding": [
+        {
+          "code": "C66781",
+          "codeSystem": "nci:ExtCodeID"
+        }
+      ],
+      "codeListItems": [
+        {
+          "codedValue": "__PLACEHOLDER__",
+          "decode": "__PLACEHOLDER__"
+        }
+      ]
+    },
+    {
+      "OID": "CL.SEX",
+      "name": "Sex",
+      "dataType": "text",
+      "standard": "STD.SDTMCT",
+      "coding": [
+        {
+          "code": "C66731",
+          "codeSystem": "nci:ExtCodeID"
+        }
+      ],
+      "codeListItems": [
+        {
+          "codedValue": "F",
+          "decode": "Female",
+          "coding": {
+            "code": "C16576",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "M",
+          "decode": "Male",
+          "coding": {
+            "code": "C20197",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        }
+      ]
+    },
+    {
+      "OID": "CL.RACE",
+      "name": "Race",
+      "dataType": "text",
+      "standard": "STD.SDTMCT",
+      "coding": [
+        {
+          "code": "C74457",
+          "codeSystem": "nci:ExtCodeID"
+        }
+      ],
+      "codeListItems": [
+        {
+          "codedValue": "__PLACEHOLDER__",
+          "decode": "__PLACEHOLDER__"
+        }
+      ]
+    },
+    {
+      "OID": "CL.ETHNIC",
+      "name": "Ethnic Group",
+      "dataType": "text",
+      "standard": "STD.SDTMCT",
+      "coding": [
+        {
+          "code": "C66790",
+          "codeSystem": "nci:ExtCodeID"
+        }
+      ],
+      "codeListItems": [
+        {
+          "codedValue": "__PLACEHOLDER__",
+          "decode": "__PLACEHOLDER__"
+        }
+      ]
+    },
+    {
+      "OID": "CL.ARMNULRS",
+      "name": "Arm Null Reason",
+      "dataType": "text",
+      "standard": "STD.SDTMCT",
+      "coding": [
+        {
+          "code": "C142179",
+          "codeSystem": "nci:ExtCodeID"
+        }
+      ],
+      "codeListItems": [
+        {
+          "codedValue": "__PLACEHOLDER__",
+          "decode": "__PLACEHOLDER__"
+        }
+      ]
+    },
+    {
+      "OID": "CL.SCTESTCD",
+      "name": "Subject Characteristic Test Code",
+      "dataType": "text",
+      "standard": "STD.SDTMCT",
+      "coding": [
+        {
+          "code": "C74559",
+          "codeSystem": "nci:ExtCodeID"
+        }
+      ],
+      "codeListItems": [
+        {
+          "codedValue": "EDULEVEL",
+          "decode": "Level of Education Attained",
+          "coding": {
+            "code": "C17953",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "EDUYRNUM",
+          "decode": "Number of Years of Education",
+          "coding": {
+            "code": "C122393",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        }
+      ]
+    },
+    {
+      "OID": "CL.SCTEST",
+      "name": "Subject Characteristic Test Name",
+      "dataType": "text",
+      "standard": "STD.SDTMCT",
+      "coding": [
+        {
+          "code": "C103330",
+          "codeSystem": "nci:ExtCodeID"
+        }
+      ],
+      "codeListItems": [
+        {
+          "codedValue": "Level of Education Attained",
+          "decode": "Level of Education Attained",
+          "coding": {
+            "code": "C17953",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Number of Years of Education",
+          "decode": "Number of Years of Education",
+          "coding": {
+            "code": "C122393",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        }
+      ]
+    },
+    {
+      "OID": "CL.UNIT",
+      "name": "Unit",
+      "dataType": "text",
+      "standard": "STD.SDTMCT",
+      "coding": [
+        {
+          "code": "C71620",
+          "codeSystem": "nci:ExtCodeID"
+        }
+      ],
+      "codeListItems": [
+        {
+          "codedValue": "%",
+          "decode": "Percentage",
+          "coding": {
+            "code": "C25613",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "10^12/L",
+          "decode": "/pL",
+          "coding": {
+            "code": "C67308",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "10^6/L",
+          "decode": "/mm3",
+          "coding": {
+            "code": "C67452",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "10^9/L",
+          "decode": "/nL",
+          "coding": {
+            "code": "C67255",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "CIGAR",
+          "decode": "Cigar Dosing Unit",
+          "coding": {
+            "code": "C116244",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "CIGARETTE",
+          "decode": "Cigarette Dosing Unit",
+          "coding": {
+            "code": "C116245",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "DRINK",
+          "decode": "Drink Dosing Unit",
+          "coding": {
+            "code": "C161487",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "EU",
+          "decode": "Ehrlich Units",
+          "coding": {
+            "code": "C96599",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "fmol",
+          "decode": "Femtomole",
+          "coding": {
+            "code": "C68854",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "fraction of 1",
+          "decode": "Proportion of 1",
+          "coding": {
+            "code": "C105484",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "g",
+          "decode": "Gram",
+          "coding": {
+            "code": "C48155",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "g/dL",
+          "decode": "g%",
+          "coding": {
+            "code": "C64783",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "g/L",
+          "decode": "g/L",
+          "coding": {
+            "code": "C42576",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "GLASS",
+          "decode": "Glass Dosing Unit",
+          "coding": {
+            "code": "C198391",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "IU/L",
+          "decode": "IE/L",
+          "coding": {
+            "code": "C67376",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "kg/m2",
+          "decode": "Kilogram per Square Meter",
+          "coding": {
+            "code": "C49671",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "L",
+          "decode": "Liter",
+          "coding": {
+            "code": "C48505",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "mEq/dL",
+          "decode": "Milliequivalent per Deciliter",
+          "coding": {
+            "code": "C67473",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "mEq/L",
+          "decode": "Milliequivalent Per Liter",
+          "coding": {
+            "code": "C67474",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "mg",
+          "decode": "Milligram",
+          "coding": {
+            "code": "C28253",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "mg/dL",
+          "decode": "mg%",
+          "coding": {
+            "code": "C67015",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "mg/L",
+          "decode": "g/m3",
+          "coding": {
+            "code": "C64572",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "mIU/L",
+          "decode": "mcIU/mL",
+          "coding": {
+            "code": "C67405",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "mL",
+          "decode": "cc",
+          "coding": {
+            "code": "C28254",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "mmol/L",
+          "decode": "mcmol/mL",
+          "coding": {
+            "code": "C64387",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "ms",
+          "decode": "Millisecond",
+          "coding": {
+            "code": "C41140",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "mU/L",
+          "decode": "uU/mL",
+          "coding": {
+            "code": "C67408",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "ng/dL",
+          "decode": "Nanogram per Deciliter",
+          "coding": {
+            "code": "C67326",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "ng/L",
+          "decode": "Microgram per Cubic Meter",
+          "coding": {
+            "code": "C67327",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "nkat/L",
+          "decode": "Nanokatal per Liter",
+          "coding": {
+            "code": "C70510",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "nmol/L",
+          "decode": "Nanomole per Liter",
+          "coding": {
+            "code": "C67432",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "oz",
+          "decode": "Ounce",
+          "coding": {
+            "code": "C48519",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "PACK",
+          "decode": "",
+          "coding": {
+            "code": "C62653",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "pg",
+          "decode": "Picogram",
+          "coding": {
+            "code": "C64551",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "PIPE",
+          "decode": "Pipe Dosing Unit",
+          "coding": {
+            "code": "C116246",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "pmol/L",
+          "decode": "Femtomole per Milliliter",
+          "coding": {
+            "code": "C67434",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "psi",
+          "decode": "Pounds per Square Inch",
+          "coding": {
+            "code": "C67334",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "s",
+          "decode": "sec",
+          "coding": {
+            "code": "C42535",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "U/L",
+          "decode": "mU/mL",
+          "coding": {
+            "code": "C67456",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "ug/dL",
+          "decode": "Microgram per Deciliter",
+          "coding": {
+            "code": "C67305",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "ug/L",
+          "decode": "mcg/L",
+          "coding": {
+            "code": "C67306",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "ukat/L",
+          "decode": "mckat/L",
+          "coding": {
+            "code": "C67397",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "umol/L",
+          "decode": "nmol/mL",
+          "coding": {
+            "code": "C48508",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        }
+      ]
+    },
+    {
+      "OID": "CL.STENRF",
+      "name": "Relation to Reference Period",
+      "dataType": "text",
+      "standard": "STD.SDTMCT",
+      "coding": [
+        {
+          "code": "C66728",
+          "codeSystem": "nci:ExtCodeID"
+        }
+      ],
+      "codeListItems": [
+        {
+          "codedValue": "__PLACEHOLDER__",
+          "decode": "__PLACEHOLDER__"
+        }
+      ]
+    },
+    {
+      "OID": "CL.FREQ",
+      "name": "Frequency",
+      "dataType": "text",
+      "standard": "STD.SDTMCT",
+      "coding": [
+        {
+          "code": "C71113",
+          "codeSystem": "nci:ExtCodeID"
+        }
+      ],
+      "codeListItems": [
+        {
+          "codedValue": "Q7D",
+          "decode": "Every 7 Days",
+          "coding": {
+            "code": "C139177",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "QD",
+          "decode": "/day",
+          "coding": {
+            "code": "C25473",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        }
+      ]
+    },
+    {
+      "OID": "CL.PROCEDUR",
+      "name": "Procedure",
+      "dataType": "text",
+      "standard": "STD.SDTMCT",
+      "coding": [
+        {
+          "code": "C101858",
+          "codeSystem": "nci:ExtCodeID"
+        }
+      ],
+      "codeListItems": [
+        {
+          "codedValue": "__PLACEHOLDER__",
+          "decode": "__PLACEHOLDER__"
+        }
+      ]
+    },
+    {
+      "OID": "CL.LOC",
+      "name": "Anatomical Location",
+      "dataType": "text",
+      "standard": "STD.SDTMCT",
+      "coding": [
+        {
+          "code": "C74456",
+          "codeSystem": "nci:ExtCodeID"
+        }
+      ],
+      "codeListItems": [
+        {
+          "codedValue": "ARM",
+          "decode": "Arm",
+          "coding": {
+            "code": "C32141",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "AXILLA",
+          "decode": "Armpit",
+          "coding": {
+            "code": "C12674",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "BACK",
+          "decode": "Back",
+          "coding": {
+            "code": "C13062",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "BRACHIAL ARTERY",
+          "decode": "",
+          "coding": {
+            "code": "C12681",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "BUTTOCK",
+          "decode": "Buttock",
+          "coding": {
+            "code": "C89806",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "CAROTID ARTERY",
+          "decode": "Common Carotid Artery",
+          "coding": {
+            "code": "C12687",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "CEREBRAL ARTERY",
+          "decode": "",
+          "coding": {
+            "code": "C12691",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "CHEST",
+          "decode": "Chest",
+          "coding": {
+            "code": "C25389",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "DORSALIS PEDIS ARTERY",
+          "decode": "Dorsal Pedal Artery",
+          "coding": {
+            "code": "C32478",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "EAR",
+          "decode": "",
+          "coding": {
+            "code": "C12394",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "FEMORAL ARTERY",
+          "decode": "",
+          "coding": {
+            "code": "C12715",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "FINGER",
+          "decode": "Finger",
+          "coding": {
+            "code": "C32608",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "FOREHEAD",
+          "decode": "Forehead",
+          "coding": {
+            "code": "C89803",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "ORAL CAVITY",
+          "decode": "Buccal cavity",
+          "coding": {
+            "code": "C12421",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "RADIAL ARTERY",
+          "decode": "Radial Artery",
+          "coding": {
+            "code": "C12838",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "RECTUM",
+          "decode": "",
+          "coding": {
+            "code": "C12390",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "THIGH",
+          "decode": "Thigh",
+          "coding": {
+            "code": "C33763",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        }
+      ]
+    },
+    {
+      "OID": "CL.VSTESTCD",
+      "name": "Vital Signs Test Code",
+      "dataType": "text",
+      "standard": "STD.SDTMCT",
+      "coding": [
+        {
+          "code": "C66741",
+          "codeSystem": "nci:ExtCodeID"
+        }
+      ],
+      "codeListItems": [
+        {
+          "codedValue": "BMI",
+          "decode": "Body Mass Index",
+          "coding": {
+            "code": "C16358",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "DIABP",
+          "decode": "Diastolic Blood Pressure",
+          "coding": {
+            "code": "C25299",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "HEIGHT",
+          "decode": "Height",
+          "coding": {
+            "code": "C25347",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "HR",
+          "decode": "Heart Rate",
+          "coding": {
+            "code": "C49677",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "PULSE",
+          "decode": "Pulse Rate",
+          "coding": {
+            "code": "C49676",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "RESP",
+          "decode": "Respiratory Rate",
+          "coding": {
+            "code": "C49678",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "SYSBP",
+          "decode": "Systolic Blood Pressure",
+          "coding": {
+            "code": "C25298",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "TEMP",
+          "decode": "Body Temperature",
+          "coding": {
+            "code": "C174446",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "WEIGHT",
+          "decode": "Weight",
+          "coding": {
+            "code": "C25208",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        }
+      ]
+    },
+    {
+      "OID": "CL.VSTEST",
+      "name": "Vital Signs Test Name",
+      "dataType": "text",
+      "standard": "STD.SDTMCT",
+      "coding": [
+        {
+          "code": "C67153",
+          "codeSystem": "nci:ExtCodeID"
+        }
+      ],
+      "codeListItems": [
+        {
+          "codedValue": "Body Mass Index",
+          "decode": "Body Mass Index",
+          "coding": {
+            "code": "C16358",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Diastolic Blood Pressure",
+          "decode": "Diastolic Blood Pressure",
+          "coding": {
+            "code": "C25299",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Heart Rate",
+          "decode": "Heart Rate",
+          "coding": {
+            "code": "C49677",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Height",
+          "decode": "Height",
+          "coding": {
+            "code": "C25347",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Pulse Rate",
+          "decode": "Pulse Rate",
+          "coding": {
+            "code": "C49676",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Respiratory Rate",
+          "decode": "Respiratory Rate",
+          "coding": {
+            "code": "C49678",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Systolic Blood Pressure",
+          "decode": "Systolic Blood Pressure",
+          "coding": {
+            "code": "C25298",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Temperature",
+          "decode": "Body Temperature",
+          "coding": {
+            "code": "C174446",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Weight",
+          "decode": "Weight",
+          "coding": {
+            "code": "C25208",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        }
+      ]
+    },
+    {
+      "OID": "CL.POSITION",
+      "name": "Position",
+      "dataType": "text",
+      "standard": "STD.SDTMCT",
+      "coding": [
+        {
+          "code": "C71148",
+          "codeSystem": "nci:ExtCodeID"
+        }
+      ],
+      "codeListItems": [
+        {
+          "codedValue": "PRONE",
+          "decode": "Prone",
+          "coding": {
+            "code": "C62165",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "SEMI-RECUMBENT",
+          "decode": "Semi-Supine",
+          "coding": {
+            "code": "C111310",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "SITTING",
+          "decode": "Sitting",
+          "coding": {
+            "code": "C62122",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "STANDING",
+          "decode": "Orthostatic",
+          "coding": {
+            "code": "C62166",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "SUPINE",
+          "decode": "Supine",
+          "coding": {
+            "code": "C62167",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        }
+      ]
+    },
+    {
+      "OID": "CL.VSRESU",
+      "name": "Units for Vital Signs Results",
+      "dataType": "text",
+      "standard": "STD.SDTMCT",
+      "coding": [
+        {
+          "code": "C66770",
+          "codeSystem": "nci:ExtCodeID"
+        }
+      ],
+      "codeListItems": [
+        {
+          "codedValue": "C",
+          "decode": "Degree Celsius",
+          "coding": {
+            "code": "C42559",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "cm",
+          "decode": "Centimeter",
+          "coding": {
+            "code": "C49668",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "F",
+          "decode": "Degree Fahrenheit",
+          "coding": {
+            "code": "C44277",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "g",
+          "decode": "Gram",
+          "coding": {
+            "code": "C48155",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "in",
+          "decode": "Inch",
+          "coding": {
+            "code": "C48500",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "K",
+          "decode": "Kelvin",
+          "coding": {
+            "code": "C42537",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "kg",
+          "decode": "Kilogram",
+          "coding": {
+            "code": "C28252",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "LB",
+          "decode": "lb",
+          "coding": {
+            "code": "C48531",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "m",
+          "decode": "Meter",
+          "coding": {
+            "code": "C41139",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "kg/m2",
+          "decode": "Kilogram per Square Meter",
+          "coding": {
+            "code": "C49671",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        }
+      ]
+    },
+    {
+      "OID": "CL.LAT",
+      "name": "Laterality",
+      "dataType": "text",
+      "standard": "STD.SDTMCT",
+      "coding": [
+        {
+          "code": "C99073",
+          "codeSystem": "nci:ExtCodeID"
+        }
+      ],
+      "codeListItems": [
+        {
+          "codedValue": "LEFT",
+          "decode": "",
+          "coding": {
+            "code": "C25229",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "RIGHT",
+          "decode": "",
+          "coding": {
+            "code": "C25228",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        }
+      ]
+    },
+    {
+      "OID": "CL.EGTESTCD",
+      "name": "ECG Test Code",
+      "dataType": "text",
+      "standard": "STD.SDTMCT",
+      "coding": [
+        {
+          "code": "C71153",
+          "codeSystem": "nci:ExtCodeID"
+        }
+      ],
+      "codeListItems": [
+        {
+          "codedValue": "AVCOND",
+          "decode": "Atrioventricular Conduction",
+          "coding": {
+            "code": "C111131",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "AXISVOLT",
+          "decode": "Axis and Voltage",
+          "coding": {
+            "code": "C111132",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "CHYPTENL",
+          "decode": "Chamber Hypertrophy or Enlargement",
+          "coding": {
+            "code": "C111155",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "EGHRMN",
+          "decode": "ECG Mean Heart Rate",
+          "coding": {
+            "code": "C119259",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "INTP",
+          "decode": "Interpretation",
+          "coding": {
+            "code": "C41255",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "IVTIACD",
+          "decode": "Intraventricular-Intraatrial Conduction",
+          "coding": {
+            "code": "C111238",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "PACEMAKR",
+          "decode": "Pacemaker",
+          "coding": {
+            "code": "C111285",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "PRAG",
+          "decode": "PQ Interval, Aggregate",
+          "coding": {
+            "code": "C117773",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "QRS_AXIS",
+          "decode": "QRS Axis",
+          "coding": {
+            "code": "C118165",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "QRSAG",
+          "decode": "QRS Duration, Aggregate",
+          "coding": {
+            "code": "C117779",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "QTAG",
+          "decode": "QT Interval, Aggregate",
+          "coding": {
+            "code": "C117783",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "QTCBAG",
+          "decode": "QTcB Interval, Aggregate",
+          "coding": {
+            "code": "C117784",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "QTCFAG",
+          "decode": "QTcF Interval, Aggregate",
+          "coding": {
+            "code": "C117786",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "RHYNOS",
+          "decode": "Rhythm Not Otherwise Specified",
+          "coding": {
+            "code": "C111307",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "RRAG",
+          "decode": "RR Interval, Aggregate",
+          "coding": {
+            "code": "C117791",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "SNRARRY",
+          "decode": "Sinus Node Rhythms and Arrhythmias",
+          "coding": {
+            "code": "C111312",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "SPRARRY",
+          "decode": "Supraventricular Arrhythmias",
+          "coding": {
+            "code": "C111320",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "SPRTARRY",
+          "decode": "Supraventricular Tachyarrhythmias",
+          "coding": {
+            "code": "C111321",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "TECHQUAL",
+          "decode": "Technical Quality",
+          "coding": {
+            "code": "C117807",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "VTARRY",
+          "decode": "Ventricular Arrhythmias",
+          "coding": {
+            "code": "C111330",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "VTTARRY",
+          "decode": "Ventricular Tachyarrhythmias",
+          "coding": {
+            "code": "C111331",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        }
+      ]
+    },
+    {
+      "OID": "CL.EGTEST",
+      "name": "ECG Test Name",
+      "dataType": "text",
+      "standard": "STD.SDTMCT",
+      "coding": [
+        {
+          "code": "C71152",
+          "codeSystem": "nci:ExtCodeID"
+        }
+      ],
+      "codeListItems": [
+        {
+          "codedValue": "Atrioventricular Conduction",
+          "decode": "Atrioventricular Conduction",
+          "coding": {
+            "code": "C111131",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Axis and Voltage",
+          "decode": "Axis and Voltage",
+          "coding": {
+            "code": "C111132",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Chamber Hypertrophy or Enlargement",
+          "decode": "Chamber Hypertrophy or Enlargement",
+          "coding": {
+            "code": "C111155",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "ECG Mean Heart Rate",
+          "decode": "ECG Mean Heart Rate",
+          "coding": {
+            "code": "C119259",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Interpretation",
+          "decode": "Interpretation",
+          "coding": {
+            "code": "C41255",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Intraventricular-Intraatrial Conduction",
+          "decode": "Intraventricular-Intraatrial Conduction",
+          "coding": {
+            "code": "C111238",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Pacemaker",
+          "decode": "Pacemaker",
+          "coding": {
+            "code": "C111285",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "PR Interval, Aggregate",
+          "decode": "PQ Interval, Aggregate",
+          "coding": {
+            "code": "C117773",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "QRS Axis",
+          "decode": "QRS Axis",
+          "coding": {
+            "code": "C118165",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "QRS Duration, Aggregate",
+          "decode": "QRS Duration, Aggregate",
+          "coding": {
+            "code": "C117779",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "QT Interval, Aggregate",
+          "decode": "QT Interval, Aggregate",
+          "coding": {
+            "code": "C117783",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "QTcB Interval, Aggregate",
+          "decode": "QTcB Interval, Aggregate",
+          "coding": {
+            "code": "C117784",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "QTcF Interval, Aggregate",
+          "decode": "QTcF Interval, Aggregate",
+          "coding": {
+            "code": "C117786",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Rhythm Not Otherwise Specified",
+          "decode": "Rhythm Not Otherwise Specified",
+          "coding": {
+            "code": "C111307",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "RR Interval, Aggregate",
+          "decode": "RR Interval, Aggregate",
+          "coding": {
+            "code": "C117791",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Sinus Node Rhythms and Arrhythmias",
+          "decode": "Sinus Node Rhythms and Arrhythmias",
+          "coding": {
+            "code": "C111312",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Supraventricular Arrhythmias",
+          "decode": "Supraventricular Arrhythmias",
+          "coding": {
+            "code": "C111320",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Supraventricular Tachyarrhythmias",
+          "decode": "Supraventricular Tachyarrhythmias",
+          "coding": {
+            "code": "C111321",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Technical Quality",
+          "decode": "Technical Quality",
+          "coding": {
+            "code": "C117807",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Ventricular Arrhythmias",
+          "decode": "Ventricular Arrhythmias",
+          "coding": {
+            "code": "C111330",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Ventricular Tachyarrhythmias",
+          "decode": "Ventricular Tachyarrhythmias",
+          "coding": {
+            "code": "C111331",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        }
+      ]
+    },
+    {
+      "OID": "CL.EGSTRESC",
+      "name": "ECG Result",
+      "dataType": "text",
+      "standard": "STD.SDTMCT",
+      "coding": [
+        {
+          "code": "C71150",
+          "codeSystem": "nci:ExtCodeID"
+        }
+      ],
+      "codeListItems": [
+        {
+          "codedValue": "__PLACEHOLDER__",
+          "decode": "__PLACEHOLDER__"
+        }
+      ]
+    },
+    {
+      "OID": "CL.EGMETHOD",
+      "name": "ECG Test Method",
+      "dataType": "text",
+      "standard": "STD.SDTMCT",
+      "coding": [
+        {
+          "code": "C71151",
+          "codeSystem": "nci:ExtCodeID"
+        }
+      ],
+      "codeListItems": [
+        {
+          "codedValue": "__PLACEHOLDER__",
+          "decode": "__PLACEHOLDER__"
+        }
+      ]
+    },
+    {
+      "OID": "CL.EVAL",
+      "name": "Evaluator",
+      "dataType": "text",
+      "standard": "STD.SDTMCT",
+      "coding": [
+        {
+          "code": "C78735",
+          "codeSystem": "nci:ExtCodeID"
+        }
+      ],
+      "codeListItems": [
+        {
+          "codedValue": "ADJUDICATION COMMITTEE",
+          "decode": "",
+          "coding": {
+            "code": "C78726",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "INDEPENDENT ASSESSOR",
+          "decode": "",
+          "coding": {
+            "code": "C78720",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "INVESTIGATOR",
+          "decode": "",
+          "coding": {
+            "code": "C25936",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "VENDOR",
+          "decode": "",
+          "coding": {
+            "code": "C68608",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        }
+      ]
+    },
+    {
+      "OID": "CL.FRM",
+      "name": "Dosage Form",
+      "dataType": "text",
+      "standard": "STD.SDTMCT",
+      "coding": [
+        {
+          "code": "C66726",
+          "codeSystem": "nci:ExtCodeID"
+        }
+      ],
+      "codeListItems": [
+        {
+          "codedValue": "__PLACEHOLDER__",
+          "decode": "__PLACEHOLDER__"
+        }
+      ]
+    },
+    {
+      "OID": "CL.ROUTE",
+      "name": "Route of Administration Response",
+      "dataType": "text",
+      "standard": "STD.SDTMCT",
+      "coding": [
+        {
+          "code": "C66729",
+          "codeSystem": "nci:ExtCodeID"
+        }
+      ],
+      "codeListItems": [
+        {
+          "codedValue": "__PLACEHOLDER__",
+          "decode": "__PLACEHOLDER__"
+        }
+      ]
+    },
+    {
+      "OID": "CL.LBTESTCD",
+      "name": "Laboratory Test Code",
+      "dataType": "text",
+      "standard": "STD.SDTMCT",
+      "coding": [
+        {
+          "code": "C65047",
+          "codeSystem": "nci:ExtCodeID"
+        }
+      ],
+      "codeListItems": [
+        {
+          "codedValue": "ALB",
+          "decode": "Albumin",
+          "coding": {
+            "code": "C64431",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "ALP",
+          "decode": "Alkaline Phosphatase",
+          "coding": {
+            "code": "C64432",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "ALT",
+          "decode": "Alanine Aminotransferase",
+          "coding": {
+            "code": "C64433",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "ANISO",
+          "decode": "Anisocytes",
+          "coding": {
+            "code": "C74797",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "AST",
+          "decode": "Aspartate Aminotransferase",
+          "coding": {
+            "code": "C64467",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "BASO",
+          "decode": "Basophils",
+          "coding": {
+            "code": "C64470",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "BICARB",
+          "decode": "Bicarbonate",
+          "coding": {
+            "code": "C74667",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "BILI",
+          "decode": "Bilirubin",
+          "coding": {
+            "code": "C38037",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "CA",
+          "decode": "Calcium",
+          "coding": {
+            "code": "C64488",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "CHOL",
+          "decode": "Cholesterol",
+          "coding": {
+            "code": "C105586",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "CL",
+          "decode": "Chloride",
+          "coding": {
+            "code": "C64495",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "COLOR",
+          "decode": "Color",
+          "coding": {
+            "code": "C64546",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "CREAT",
+          "decode": "Creatinine",
+          "coding": {
+            "code": "C64547",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "EOS",
+          "decode": "Eosinophils",
+          "coding": {
+            "code": "C64550",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "GGT",
+          "decode": "Gamma Glutamyl Transferase",
+          "coding": {
+            "code": "C64847",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "GLUC",
+          "decode": "Glucose",
+          "coding": {
+            "code": "C105585",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "HBA1C",
+          "decode": "HbA1c",
+          "coding": {
+            "code": "C64849",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "HBA1CHGB",
+          "decode": "Hemoglobin A1C/Hemoglobin",
+          "coding": {
+            "code": "C111207",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "HCT",
+          "decode": "Erythrocyte Volume Fraction",
+          "coding": {
+            "code": "C64796",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "HGB",
+          "decode": "Hemoglobin",
+          "coding": {
+            "code": "C64848",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "K",
+          "decode": "Potassium",
+          "coding": {
+            "code": "C64853",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "KETONES",
+          "decode": "Ketones",
+          "coding": {
+            "code": "C64854",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "MACROCY",
+          "decode": "Macrocytes",
+          "coding": {
+            "code": "C64821",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "MCH",
+          "decode": "Ery. Mean Corpuscular Hemoglobin",
+          "coding": {
+            "code": "C64797",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "MCHC",
+          "decode": "Ery. Mean Corpuscular HGB Concentration",
+          "coding": {
+            "code": "C64798",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "MCV",
+          "decode": "Ery. Mean Corpuscular Volume",
+          "coding": {
+            "code": "C64799",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "MICROCY",
+          "decode": "Microcytes",
+          "coding": {
+            "code": "C64822",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "MONO",
+          "decode": "Monocytes",
+          "coding": {
+            "code": "C64823",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "NEUT",
+          "decode": "Neutrophils",
+          "coding": {
+            "code": "C63321",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "NEUTB",
+          "decode": "Neutrophils Band Form",
+          "coding": {
+            "code": "C64830",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "NEUTSG",
+          "decode": "Neutrophils, Segmented",
+          "coding": {
+            "code": "C81997",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "NITRITE",
+          "decode": "Nitrite",
+          "coding": {
+            "code": "C64810",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "OCCBLD",
+          "decode": "Occult Blood",
+          "coding": {
+            "code": "C74686",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "PHOS",
+          "decode": "Inorganic Phosphate",
+          "coding": {
+            "code": "C64857",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "PLAT",
+          "decode": "Platelets",
+          "coding": {
+            "code": "C51951",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "POIKILO",
+          "decode": "Poikilocytes",
+          "coding": {
+            "code": "C79602",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "POLYCHR",
+          "decode": "Polychromasia",
+          "coding": {
+            "code": "C64803",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "PROT",
+          "decode": "Protein",
+          "coding": {
+            "code": "C64858",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "RBC",
+          "decode": "Erythrocytes",
+          "coding": {
+            "code": "C51946",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "SODIUM",
+          "decode": "Sodium",
+          "coding": {
+            "code": "C64809",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "SPGRAV",
+          "decode": "Specific Gravity",
+          "coding": {
+            "code": "C64832",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "T3",
+          "decode": "Total T3",
+          "coding": {
+            "code": "C74747",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "T3UP",
+          "decode": "T3RU",
+          "coding": {
+            "code": "C74748",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "T4FR",
+          "decode": "Free T4",
+          "coding": {
+            "code": "C74786",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "T4FRIDX",
+          "decode": "Thyroxine, Free Index",
+          "coding": {
+            "code": "C170598",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "TSH",
+          "decode": "Thyroid Stimulating Hormone",
+          "coding": {
+            "code": "C64813",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "URATE",
+          "decode": "Urate",
+          "coding": {
+            "code": "C64814",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "UREAN",
+          "decode": "Urea Nitrogen",
+          "coding": {
+            "code": "C125949",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "UROBIL",
+          "decode": "Urobilinogen",
+          "coding": {
+            "code": "C64816",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "VITB12",
+          "decode": "Cobalamin",
+          "coding": {
+            "code": "C64817",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "VITB9",
+          "decode": "Folate",
+          "coding": {
+            "code": "C74676",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "WBC",
+          "decode": "Leukocytes",
+          "coding": {
+            "code": "C51948",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        }
+      ]
+    },
+    {
+      "OID": "CL.LBTEST",
+      "name": "Laboratory Test Name",
+      "dataType": "text",
+      "standard": "STD.SDTMCT",
+      "coding": [
+        {
+          "code": "C67154",
+          "codeSystem": "nci:ExtCodeID"
+        }
+      ],
+      "codeListItems": [
+        {
+          "codedValue": "Alanine Aminotransferase",
+          "decode": "Alanine Aminotransferase",
+          "coding": {
+            "code": "C64433",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Albumin",
+          "decode": "Albumin",
+          "coding": {
+            "code": "C64431",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Alkaline Phosphatase",
+          "decode": "Alkaline Phosphatase",
+          "coding": {
+            "code": "C64432",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Anisocytes",
+          "decode": "Anisocytes",
+          "coding": {
+            "code": "C74797",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Aspartate Aminotransferase",
+          "decode": "Aspartate Aminotransferase",
+          "coding": {
+            "code": "C64467",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Basophils",
+          "decode": "Basophils",
+          "coding": {
+            "code": "C64470",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Bicarbonate",
+          "decode": "Bicarbonate",
+          "coding": {
+            "code": "C74667",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Bilirubin",
+          "decode": "Bilirubin",
+          "coding": {
+            "code": "C38037",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Calcium",
+          "decode": "Calcium",
+          "coding": {
+            "code": "C64488",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Chloride",
+          "decode": "Chloride",
+          "coding": {
+            "code": "C64495",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Cholesterol",
+          "decode": "Cholesterol",
+          "coding": {
+            "code": "C105586",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Color",
+          "decode": "Color",
+          "coding": {
+            "code": "C64546",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Creatinine",
+          "decode": "Creatinine",
+          "coding": {
+            "code": "C64547",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Eosinophils",
+          "decode": "Eosinophils",
+          "coding": {
+            "code": "C64550",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Ery. Mean Corpuscular Hemoglobin",
+          "decode": "Ery. Mean Corpuscular Hemoglobin",
+          "coding": {
+            "code": "C64797",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Ery. Mean Corpuscular HGB Concentration",
+          "decode": "Ery. Mean Corpuscular HGB Concentration",
+          "coding": {
+            "code": "C64798",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Ery. Mean Corpuscular Volume",
+          "decode": "Ery. Mean Corpuscular Volume",
+          "coding": {
+            "code": "C64799",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Erythrocytes",
+          "decode": "Erythrocytes",
+          "coding": {
+            "code": "C51946",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Gamma Glutamyl Transferase",
+          "decode": "Gamma Glutamyl Transferase",
+          "coding": {
+            "code": "C64847",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Glucose",
+          "decode": "Glucose",
+          "coding": {
+            "code": "C105585",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Hematocrit",
+          "decode": "Erythrocyte Volume Fraction",
+          "coding": {
+            "code": "C64796",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Hemoglobin A1C",
+          "decode": "HbA1c",
+          "coding": {
+            "code": "C64849",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Hemoglobin A1C/Hemoglobin",
+          "decode": "Hemoglobin A1C/Hemoglobin",
+          "coding": {
+            "code": "C111207",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Hemoglobin",
+          "decode": "Hemoglobin",
+          "coding": {
+            "code": "C64848",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Ketones",
+          "decode": "Ketones",
+          "coding": {
+            "code": "C64854",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Leukocytes",
+          "decode": "Leukocytes",
+          "coding": {
+            "code": "C51948",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Macrocytes",
+          "decode": "Macrocytes",
+          "coding": {
+            "code": "C64821",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Microcytes",
+          "decode": "Microcytes",
+          "coding": {
+            "code": "C64822",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Monocytes",
+          "decode": "Monocytes",
+          "coding": {
+            "code": "C64823",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Neutrophils Band Form",
+          "decode": "Neutrophils Band Form",
+          "coding": {
+            "code": "C64830",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Neutrophils",
+          "decode": "Neutrophils",
+          "coding": {
+            "code": "C63321",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Neutrophils, Segmented",
+          "decode": "Neutrophils, Segmented",
+          "coding": {
+            "code": "C81997",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Nitrite",
+          "decode": "Nitrite",
+          "coding": {
+            "code": "C64810",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Occult Blood",
+          "decode": "Occult Blood",
+          "coding": {
+            "code": "C74686",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Phosphate",
+          "decode": "Inorganic Phosphate",
+          "coding": {
+            "code": "C64857",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Platelets",
+          "decode": "Platelets",
+          "coding": {
+            "code": "C51951",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Poikilocytes",
+          "decode": "Poikilocytes",
+          "coding": {
+            "code": "C79602",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Polychromasia",
+          "decode": "Polychromasia",
+          "coding": {
+            "code": "C64803",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Potassium",
+          "decode": "Potassium",
+          "coding": {
+            "code": "C64853",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Protein",
+          "decode": "Protein",
+          "coding": {
+            "code": "C64858",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Sodium",
+          "decode": "Sodium",
+          "coding": {
+            "code": "C64809",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Specific Gravity",
+          "decode": "Specific Gravity",
+          "coding": {
+            "code": "C64832",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Thyrotropin",
+          "decode": "Thyroid Stimulating Hormone",
+          "coding": {
+            "code": "C64813",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Thyroxine, Free Index",
+          "decode": "Thyroxine, Free Index",
+          "coding": {
+            "code": "C170598",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Thyroxine, Free",
+          "decode": "Free T4",
+          "coding": {
+            "code": "C74786",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Triiodothyronine Uptake",
+          "decode": "T3RU",
+          "coding": {
+            "code": "C74748",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Triiodothyronine",
+          "decode": "Total T3",
+          "coding": {
+            "code": "C74747",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Urate",
+          "decode": "Urate",
+          "coding": {
+            "code": "C64814",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Urea Nitrogen",
+          "decode": "Urea Nitrogen",
+          "coding": {
+            "code": "C125949",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Urobilinogen",
+          "decode": "Urobilinogen",
+          "coding": {
+            "code": "C64816",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Vitamin B12",
+          "decode": "Cobalamin",
+          "coding": {
+            "code": "C64817",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Vitamin B9",
+          "decode": "Folate",
+          "coding": {
+            "code": "C74676",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        }
+      ]
+    },
+    {
+      "OID": "CL.LBSTRESC",
+      "name": "Laboratory Test Standard Character Result",
+      "dataType": "text",
+      "standard": "STD.SDTMCT",
+      "coding": [
+        {
+          "code": "C102580",
+          "codeSystem": "nci:ExtCodeID"
+        }
+      ],
+      "codeListItems": [
+        {
+          "codedValue": "__PLACEHOLDER__",
+          "decode": "__PLACEHOLDER__"
+        }
+      ]
+    },
+    {
+      "OID": "CL.NRIND",
+      "name": "Reference Range Indicator",
+      "dataType": "text",
+      "standard": "STD.SDTMCT",
+      "coding": [
+        {
+          "code": "C78736",
+          "codeSystem": "nci:ExtCodeID"
+        }
+      ],
+      "codeListItems": [
+        {
+          "codedValue": "__PLACEHOLDER__",
+          "decode": "__PLACEHOLDER__"
+        }
+      ]
+    },
+    {
+      "OID": "CL.SPECTYPE",
+      "name": "Specimen Type",
+      "dataType": "text",
+      "standard": "STD.SDTMCT",
+      "coding": [
+        {
+          "code": "C78734",
+          "codeSystem": "nci:ExtCodeID"
+        }
+      ],
+      "codeListItems": [
+        {
+          "codedValue": "BLOOD",
+          "decode": "Peripheral Blood",
+          "coding": {
+            "code": "C12434",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "ERYTHROCYTES",
+          "decode": "RBC",
+          "coding": {
+            "code": "C12521",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "SERUM OR PLASMA",
+          "decode": "Ser/Plas",
+          "coding": {
+            "code": "C105706",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "STOOL",
+          "decode": "Feces",
+          "coding": {
+            "code": "C13234",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "URINE SEDIMENT",
+          "decode": "",
+          "coding": {
+            "code": "C158282",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "URINE",
+          "decode": "",
+          "coding": {
+            "code": "C13283",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "CEREBROSPINAL FLUID",
+          "decode": "CSF",
+          "coding": {
+            "code": "C12692",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "FLUID",
+          "decode": "",
+          "coding": {
+            "code": "C13236",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "SERUM",
+          "decode": "Sera",
+          "coding": {
+            "code": "C13325",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "SWABBED MATERIAL",
+          "decode": "",
+          "coding": {
+            "code": "C150895",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        }
+      ]
+    },
+    {
+      "OID": "CL.METHOD",
+      "name": "Method",
+      "dataType": "text",
+      "standard": "STD.SDTMCT",
+      "coding": [
+        {
+          "code": "C85492",
+          "codeSystem": "nci:ExtCodeID"
+        }
+      ],
+      "codeListItems": [
+        {
+          "codedValue": "DIPSTICK MEASUREMENT METHOD",
+          "decode": "",
+          "coding": {
+            "code": "C178142",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "CHEMILUMINESCENT MICROPARTICLE IMMUNOASSAY",
+          "decode": "Chemiluminescent Magnetic Microparticle Immunoassay",
+          "coding": {
+            "code": "C172557",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "FLUORESCENT IMMUNOASSAY",
+          "decode": "Fluorescent Antibody Assay",
+          "coding": {
+            "code": "C17370",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "HEMAGGLUTINATION ASSAY",
+          "decode": "",
+          "coding": {
+            "code": "C130173",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "IMMUNOBLOT",
+          "decode": "",
+          "coding": {
+            "code": "C17638",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "LINE PROBE ASSAY",
+          "decode": "LiPA",
+          "coding": {
+            "code": "C102656",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "POLYMERASE CHAIN REACTION",
+          "decode": "PCR",
+          "coding": {
+            "code": "C17003",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "RAPID IMMUNOASSAY",
+          "decode": "",
+          "coding": {
+            "code": "C178031",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        }
+      ]
+    },
+    {
+      "OID": "CL.MBTESTCD",
+      "name": "Microbiology Test Code",
+      "dataType": "text",
+      "standard": "STD.SDTMCT",
+      "coding": [
+        {
+          "code": "C120527",
+          "codeSystem": "nci:ExtCodeID"
+        }
+      ],
+      "codeListItems": [
+        {
+          "codedValue": "TPADNA",
+          "decode": "Treponema pallidum DNA",
+          "coding": {
+            "code": "C198341",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "TPLAB",
+          "decode": ""
+        }
+      ]
+    },
+    {
+      "OID": "CL.MBTEST",
+      "name": "Microbiology Test Name",
+      "dataType": "text",
+      "standard": "STD.SDTMCT",
+      "coding": [
+        {
+          "code": "C120528",
+          "codeSystem": "nci:ExtCodeID"
+        }
+      ],
+      "codeListItems": [
+        {
+          "codedValue": "Treponema pallidum DNA",
+          "decode": "Treponema pallidum DNA",
+          "coding": {
+            "code": "C198341",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        }
+      ]
+    },
+    {
+      "OID": "CL.MBFTSDTL",
+      "name": "Microbiology Findings Test Details",
+      "dataType": "text",
+      "standard": "STD.SDTMCT",
+      "coding": [
+        {
+          "code": "C174225",
+          "codeSystem": "nci:ExtCodeID"
+        }
+      ],
+      "codeListItems": [
+        {
+          "codedValue": "DETECTION",
+          "decode": "",
+          "coding": {
+            "code": "C174330",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        }
+      ]
+    },
+    {
+      "OID": "CL.DIR",
+      "name": "Directionality",
+      "dataType": "text",
+      "standard": "STD.SDTMCT",
+      "coding": [
+        {
+          "code": "C99074",
+          "codeSystem": "nci:ExtCodeID"
+        }
+      ],
+      "codeListItems": [
+        {
+          "codedValue": "LOWER",
+          "decode": "",
+          "coding": {
+            "code": "C25309",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "MIDLINE",
+          "decode": "",
+          "coding": {
+            "code": "C81170",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "UPPER",
+          "decode": "",
+          "coding": {
+            "code": "C25355",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        }
+      ]
+    },
+    {
+      "OID": "CL.AESEV",
+      "name": "Severity/Intensity Scale for Adverse Events",
+      "dataType": "text",
+      "standard": "STD.SDTMCT",
+      "coding": [
+        {
+          "code": "C66769",
+          "codeSystem": "nci:ExtCodeID"
+        }
+      ],
+      "codeListItems": [
+        {
+          "codedValue": "__PLACEHOLDER__",
+          "decode": "__PLACEHOLDER__"
+        }
+      ]
+    },
+    {
+      "OID": "CL.ACN",
+      "name": "Action Taken with Study Treatment",
+      "dataType": "text",
+      "standard": "STD.SDTMCT",
+      "coding": [
+        {
+          "code": "C66767",
+          "codeSystem": "nci:ExtCodeID"
+        }
+      ],
+      "codeListItems": [
+        {
+          "codedValue": "__PLACEHOLDER__",
+          "decode": "__PLACEHOLDER__"
+        }
+      ]
+    },
+    {
+      "OID": "CL.OUT",
+      "name": "Outcome of Event",
+      "dataType": "text",
+      "standard": "STD.SDTMCT",
+      "coding": [
+        {
+          "code": "C66768",
+          "codeSystem": "nci:ExtCodeID"
+        }
+      ],
+      "codeListItems": [
+        {
+          "codedValue": "__PLACEHOLDER__",
+          "decode": "__PLACEHOLDER__"
+        }
+      ]
+    },
+    {
+      "OID": "CL.TSPARMCD",
+      "name": "Trial Summary Parameter Test Code",
+      "dataType": "text",
+      "standard": "STD.SDTMCT",
+      "coding": [
+        {
+          "code": "C66738",
+          "codeSystem": "nci:ExtCodeID"
+        }
+      ],
+      "codeListItems": [
+        {
+          "codedValue": "ADAPT",
+          "decode": "Adaptive Design",
+          "coding": {
+            "code": "C146995",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "AGEMAX",
+          "decode": "Planned Maximum Age of Subjects",
+          "coding": {
+            "code": "C49694",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "AGEMIN",
+          "decode": "Planned Minimum Age of Subjects",
+          "coding": {
+            "code": "C49693",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "COMPTRT",
+          "decode": "Comparative Treatment Name",
+          "coding": {
+            "code": "C68612",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "CRMDUR",
+          "decode": "Confirmed Response Minimum Duration",
+          "coding": {
+            "code": "C98715",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "DOSE",
+          "decode": "Dose Level",
+          "coding": {
+            "code": "C25488",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "DOSFRQ",
+          "decode": "Dosing Frequency",
+          "coding": {
+            "code": "C89081",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "DOSU",
+          "decode": "Dose Units",
+          "coding": {
+            "code": "C73558",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "INDIC",
+          "decode": "Indication for Use",
+          "coding": {
+            "code": "C112038",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "INTMODEL",
+          "decode": "Intervention Model",
+          "coding": {
+            "code": "C98746",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "INTTYPE",
+          "decode": "Intervention Type",
+          "coding": {
+            "code": "C98747",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "NARMS",
+          "decode": "Planned Number of Arms",
+          "coding": {
+            "code": "C98771",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "OBJPRIM",
+          "decode": "Study Primary Objective",
+          "coding": {
+            "code": "C85826",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "OBJSEC",
+          "decode": "Study Secondary Objective",
+          "coding": {
+            "code": "C85827",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "OUTMSPRI",
+          "decode": "Primary Outcome Measure",
+          "coding": {
+            "code": "C98772",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "OUTMSSEC",
+          "decode": "Secondary Outcome Measure",
+          "coding": {
+            "code": "C98781",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "PLANSUB",
+          "decode": "Anticipated Enrollment",
+          "coding": {
+            "code": "C49692",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "PTRTDUR",
+          "decode": "Planned Treatment Duration",
+          "coding": {
+            "code": "C139276",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "ROUTE",
+          "decode": "Route of Administration",
+          "coding": {
+            "code": "C38114",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "SEXPOP",
+          "decode": "Sex of Participants",
+          "coding": {
+            "code": "C49696",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "SPONSOR",
+          "decode": "Clinical Study Sponsor",
+          "coding": {
+            "code": "C70793",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "STYPE",
+          "decode": "Study Type",
+          "coding": {
+            "code": "C142175",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "TBLIND",
+          "decode": "Study Blinding Design",
+          "coding": {
+            "code": "C49658",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "THERAREA",
+          "decode": "Therapeutic Area",
+          "coding": {
+            "code": "C101302",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "TINDTP",
+          "decode": "Trial Intent Type",
+          "coding": {
+            "code": "C49652",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "TITLE",
+          "decode": "Official Study Title",
+          "coding": {
+            "code": "C49802",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "TPHASE",
+          "decode": "Trial Phase",
+          "coding": {
+            "code": "C48281",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "TRT",
+          "decode": "Investigational Interventional",
+          "coding": {
+            "code": "C41161",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "TTYPE",
+          "decode": "Trial Scope",
+          "coding": {
+            "code": "C49660",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        }
+      ]
+    },
+    {
+      "OID": "CL.TSPARM",
+      "name": "Trial Summary Parameter Test Name",
+      "dataType": "text",
+      "standard": "STD.SDTMCT",
+      "coding": [
+        {
+          "code": "C67152",
+          "codeSystem": "nci:ExtCodeID"
+        }
+      ],
+      "codeListItems": [
+        {
+          "codedValue": "Adaptive Design",
+          "decode": "Adaptive Design",
+          "coding": {
+            "code": "C146995",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Clinical Study Sponsor",
+          "decode": "Clinical Study Sponsor",
+          "coding": {
+            "code": "C70793",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Comparative Treatment Name",
+          "decode": "Comparative Treatment Name",
+          "coding": {
+            "code": "C68612",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Confirmed Response Minimum Duration",
+          "decode": "Confirmed Response Minimum Duration",
+          "coding": {
+            "code": "C98715",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Dose per Administration",
+          "decode": "Dose Level",
+          "coding": {
+            "code": "C25488",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Dose Units",
+          "decode": "Dose Units",
+          "coding": {
+            "code": "C73558",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Dosing Frequency",
+          "decode": "Dosing Frequency",
+          "coding": {
+            "code": "C89081",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Intervention Model",
+          "decode": "Intervention Model",
+          "coding": {
+            "code": "C98746",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Intervention Type",
+          "decode": "Intervention Type",
+          "coding": {
+            "code": "C98747",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Investigational Therapy or Treatment",
+          "decode": "Investigational Interventional",
+          "coding": {
+            "code": "C41161",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Planned Maximum Age of Subjects",
+          "decode": "Planned Maximum Age of Subjects",
+          "coding": {
+            "code": "C49694",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Planned Minimum Age of Subjects",
+          "decode": "Planned Minimum Age of Subjects",
+          "coding": {
+            "code": "C49693",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Planned Number of Arms",
+          "decode": "Planned Number of Arms",
+          "coding": {
+            "code": "C98771",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Planned Number of Subjects",
+          "decode": "Anticipated Enrollment",
+          "coding": {
+            "code": "C49692",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Planned Treatment Duration",
+          "decode": "Planned Treatment Duration",
+          "coding": {
+            "code": "C139276",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Primary Outcome Measure",
+          "decode": "Primary Outcome Measure",
+          "coding": {
+            "code": "C98772",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Route of Administration",
+          "decode": "Route of Administration",
+          "coding": {
+            "code": "C38114",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Secondary Outcome Measure",
+          "decode": "Secondary Outcome Measure",
+          "coding": {
+            "code": "C98781",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Sex of Participants",
+          "decode": "Sex of Participants",
+          "coding": {
+            "code": "C49696",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Study Type",
+          "decode": "Study Type",
+          "coding": {
+            "code": "C142175",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Therapeutic Area",
+          "decode": "Therapeutic Area",
+          "coding": {
+            "code": "C101302",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Trial Blinding Schema",
+          "decode": "Study Blinding Design",
+          "coding": {
+            "code": "C49658",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Trial Disease/Condition Indication",
+          "decode": "Indication for Use",
+          "coding": {
+            "code": "C112038",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Trial Intent Type",
+          "decode": "Trial Intent Type",
+          "coding": {
+            "code": "C49652",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Trial Phase Classification",
+          "decode": "Trial Phase",
+          "coding": {
+            "code": "C48281",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Trial Primary Objective",
+          "decode": "Study Primary Objective",
+          "coding": {
+            "code": "C85826",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Trial Secondary Objective",
+          "decode": "Study Secondary Objective",
+          "coding": {
+            "code": "C85827",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Trial Title",
+          "decode": "Official Study Title",
+          "coding": {
+            "code": "C49802",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "Trial Type",
+          "decode": "Trial Scope",
+          "coding": {
+            "code": "C49660",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        }
+      ]
+    },
+    {
+      "OID": "CL.DICTNAM",
+      "name": "Dictionary Name",
+      "dataType": "text",
+      "standard": "STD.SDTMCT",
+      "coding": [
+        {
+          "code": "C66788",
+          "codeSystem": "nci:ExtCodeID"
+        }
+      ],
+      "codeListItems": [
+        {
+          "codedValue": "__PLACEHOLDER__",
+          "decode": "__PLACEHOLDER__"
+        }
+      ]
+    },
+    {
+      "OID": "CL.IECAT",
+      "name": "Category of Inclusion/Exclusion",
+      "dataType": "text",
+      "standard": "STD.SDTMCT",
+      "coding": [
+        {
+          "code": "C66797",
+          "codeSystem": "nci:ExtCodeID"
+        }
+      ],
+      "codeListItems": [
+        {
+          "codedValue": "__PLACEHOLDER__",
+          "decode": "__PLACEHOLDER__"
+        }
+      ]
+    },
+    {
+      "OID": "CL.CNTMODE",
+      "name": "Mode of Subject Contact",
+      "dataType": "text",
+      "standard": "STD.SDTMCT",
+      "coding": [
+        {
+          "code": "C171445",
+          "codeSystem": "nci:ExtCodeID"
+        }
+      ],
+      "codeListItems": [
+        {
+          "codedValue": "IN PERSON",
+          "decode": "In-Person",
+          "coding": {
+            "code": "C175574",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        },
+        {
+          "codedValue": "TELEPHONE CALL",
+          "decode": "",
+          "coding": {
+            "code": "C171537",
+            "codeSystem": "nci:ExtCodeID"
+          }
+        }
+      ]
+    }
+  ],
+  "methods": [],
+  "standards": [
+    {
+      "OID": "STD.SDTMIG",
+      "name": "SDTMIG",
+      "type": "IG",
+      "version": "3.4",
+      "status": "FINAL"
+    },
+    {
+      "OID": "STD.SDTMCT",
+      "name": "CDISC/NCI",
+      "type": "CT",
+      "version": "2025-03-28",
+      "status": "FINAL",
+      "publishingSet": "SDTM"
+    }
+  ],
+  "annotatedCRF": [],
+  "concepts": [],
+  "conceptProperties": []
+}

--- a/src/generators/define/itemGroups.py
+++ b/src/generators/define/itemGroups.py
@@ -6,6 +6,8 @@ import items
 import valueLevel as VL
 from constants import TRIAL_DESIGN_DOMAINS, NON_REPEATING_DOMAINS, DEFAULT_PURPOSE
 
+MAX_SUBCLASS_DEPTH = 4
+
 
 class ItemGroups(define_object.DefineObject):
     """ create a Define-XML v2.1 ItemGroupDef element template """
@@ -51,22 +53,46 @@ class ItemGroups(define_object.DefineObject):
         slices = dataset.get("slices")
         items.Items().create_define_objects(items_list, define_objects, lang, acrf, slice=slices)
 
-        # assumption: list of subclasses, but no nested subclasses - may need to revisit this for ADaM
-        if dataset.get("observationClass", {}).get("name", ""):
-            ds_class = dataset["observationClass"]["name"].upper().replace("-", " ")
+        observation_class = dataset.get("observationClass") or {}
+        if observation_class.get("name"):
+            ds_class = observation_class["name"].upper().replace("-", " ")
             itg.Class = DEFINE.Class(Name=ds_class)
-            sub_classes = dataset.get("observationClass").get("subClasses", [])
-            for sub_class in sub_classes:
-                sub_class_name = sub_class.get("name")
-                if sub_class_name.get("parentClass", ""):
-                    itg.Class.SubClass.append(DEFINE.SubClass(Name=sub_class["name"], ParentClass=sub_class["parentClass"]))
-                else:
-                    itg.Class.SubClass.append(DEFINE.SubClass(Name=sub_class["name"]))
+            self._append_subclasses(
+                itg.Class,
+                observation_class.get("subClasses") or [],
+                parent_name=None,
+                depth=1,
+            )
 
         # default is Dataset-JSON .ndjson datasets - will be overridden in post-processing if is_xpt CL arg is True
         leaf = DEFINE.leaf(ID="LF." + dataset_name, href=dataset_name.lower() + ".ndjson")
         leaf.title = DEFINE.title(_content=dataset_name.lower() + ".ndjson")
         itg.leaf = leaf
+
+    def _append_subclasses(self, class_obj, sub_classes, parent_name, depth):
+        """
+        Flatten a nested subClasses JSON tree into Class.SubClass siblings.
+
+        Define-XML v2.1 represents nested SubClasses as flat siblings under def:Class
+        with the ParentClass attribute referencing the parent SubClass's Name. Depth
+        is capped at MAX_SUBCLASS_DEPTH; deeper levels are silently dropped.
+        """
+        if depth > MAX_SUBCLASS_DEPTH:
+            return
+        for sub_class in sub_classes:
+            name = sub_class.get("name")
+            if not name:
+                continue
+            resolved_parent = sub_class.get("parentClass") or parent_name
+            if resolved_parent:
+                class_obj.SubClass.append(
+                    DEFINE.SubClass(Name=name, ParentClass=resolved_parent)
+                )
+            else:
+                class_obj.SubClass.append(DEFINE.SubClass(Name=name))
+            nested = sub_class.get("subClasses") or []
+            if nested:
+                self._append_subclasses(class_obj, nested, parent_name=name, depth=depth + 1)
 
     def _create_itemgroupdef_object(self, obj):
         name = self.require_key(obj, "name", "ItemGroupDef")

--- a/src/generators/define/items.py
+++ b/src/generators/define/items.py
@@ -149,11 +149,11 @@ class Items(define_object.DefineObject):
             attr["SignificantDigits"] = obj["significantDigits"]
         elif obj.get("displayFormat") and obj.get("dataType") == "float":
             # TODO work around issue 78 - missing missing significant digits - remove after USDM updated
-            length, significant_digits = obj["displayFormat"].split(".")
-            if significant_digits:
-                attr["SignificantDigits"] = significant_digits
-            if length and attr.get("Length") == "__PLACEHOLDER__":
-                attr["Length"] = length
+            length_str, sep, sig_str = str(obj["displayFormat"]).partition(".")
+            if sep and sig_str.isdigit():
+                attr["SignificantDigits"] = int(sig_str)
+            if length_str.isdigit() and attr.get("Length") == "__PLACEHOLDER__":
+                attr["Length"] = int(length_str)
         if obj.get("displayFormat"):
             attr["DisplayFormat"] = obj["displayFormat"]
         if obj.get("comment"):

--- a/src/generators/define/items.py
+++ b/src/generators/define/items.py
@@ -89,7 +89,23 @@ class Items(define_object.DefineObject):
             self._add_origin(item, obj)
 
     def _add_origin(self, item, obj):
-        origin_in = obj["origin"]
+        origins_in = obj["origin"]
+        if isinstance(origins_in, dict):
+            # Today's DDS shape: a single origin dict with item-level predecessor/pages siblings.
+            # Future shape: a list of origin dicts, each carrying its own predecessor/pages.
+            # Normalize today's shape by folding the item-level fields into the wrapped dict so
+            # the per-origin builder only ever reads from the origin dict.
+            wrapped = dict(origins_in)
+            if obj.get("predecessor") and "predecessor" not in wrapped:
+                wrapped["predecessor"] = obj["predecessor"]
+            if obj.get("pages") and "pages" not in wrapped:
+                wrapped["pages"] = obj["pages"]
+            origins_in = [wrapped]
+
+        for origin_in in origins_in:
+            item.Origin.append(self._build_origin(origin_in))
+
+    def _build_origin(self, origin_in):
         origin_type = origin_in.get("type")
         origin_source = origin_in.get("source")
         attr: dict[str, Any] = {}
@@ -109,17 +125,16 @@ class Items(define_object.DefineObject):
             dr.PDFPageRef.append(DEFINE.PDFPageRef(PageRefs="__PLACEHOLDER__", Type="PhysicalRef"))
             origin.DocumentRef.append(dr)
 
-        if obj.get("predecessor"):
+        if origin_in.get("predecessor"):
             origin.Description = DEFINE.Description()
             origin.Description.TranslatedText.append(
-                DEFINE.TranslatedText(_content=obj["predecessor"], lang=self.lang)
+                DEFINE.TranslatedText(_content=origin_in["predecessor"], lang=self.lang)
             )
-        if obj.get("pages"):
+        if origin_in.get("pages"):
             dr = DEFINE.DocumentRef(leafID=self.acrf)
-            dr.PDFPageRef.append(DEFINE.PDFPageRef(PageRefs=obj["pages"], Type="PhysicalRef"))
+            dr.PDFPageRef.append(DEFINE.PDFPageRef(PageRefs=origin_in["pages"], Type="PhysicalRef"))
             origin.DocumentRef.append(dr)
-
-        item.Origin.append(origin)
+        return origin
 
     @staticmethod
     def _add_optional_itemdef_attributes(attr, obj):

--- a/src/generators/define/items.py
+++ b/src/generators/define/items.py
@@ -133,7 +133,7 @@ class Items(define_object.DefineObject):
         if obj.get("significantDigits"):
             attr["SignificantDigits"] = obj["significantDigits"]
         elif obj.get("displayFormat") and obj.get("dataType") == "float":
-            # TODO hack to work around issue 78 - missing missing significant digits - remove after updated
+            # TODO work around issue 78 - missing missing significant digits - remove after USDM updated
             length, significant_digits = obj["displayFormat"].split(".")
             if significant_digits:
                 attr["SignificantDigits"] = significant_digits

--- a/src/generators/define/items.py
+++ b/src/generators/define/items.py
@@ -69,6 +69,7 @@ class Items(define_object.DefineObject):
     @staticmethod
     def _new_itemdef(attr: dict[str, Any]) -> Any:
         """Instantiate an ItemDef without triggering descriptor validation."""
+        # TODO replace this with v0.2.0 odmlib permissive mode
         item = object.__new__(DEFINE.ItemDef)
         for key, value in attr.items():
             item.__dict__[key] = value
@@ -131,6 +132,13 @@ class Items(define_object.DefineObject):
             attr["Length"] = "__PLACEHOLDER__"
         if obj.get("significantDigits"):
             attr["SignificantDigits"] = obj["significantDigits"]
+        elif obj.get("displayFormat") and obj.get("dataType") == "float":
+            # TODO hack to work around issue 78 - missing missing significant digits - remove after updated
+            length, significant_digits = obj["displayFormat"].split(".")
+            if significant_digits:
+                attr["SignificantDigits"] = significant_digits
+            if length and attr.get("Length") == "__PLACEHOLDER__":
+                attr["Length"] = length
         if obj.get("displayFormat"):
             attr["DisplayFormat"] = obj["displayFormat"]
         if obj.get("comment"):

--- a/src/generators/define/items.py
+++ b/src/generators/define/items.py
@@ -148,7 +148,7 @@ class Items(define_object.DefineObject):
         if obj.get("significantDigits"):
             attr["SignificantDigits"] = obj["significantDigits"]
         elif obj.get("displayFormat") and obj.get("dataType") == "float":
-            # TODO work around issue 78 - missing missing significant digits - remove after USDM updated
+            # TODO work around issue 78 - missing significant digits - remove after USDM updated
             length_str, sep, sig_str = str(obj["displayFormat"]).partition(".")
             if sep and sig_str.isdigit():
                 attr["SignificantDigits"] = int(sig_str)

--- a/src/generators/define/post_processing.py
+++ b/src/generators/define/post_processing.py
@@ -36,8 +36,7 @@ class PostProcessing:
         Add methods to ItemDefs where the def:Origin Type="Derived".
         """
         for item_def in self.define_objects['ItemDef']:
-            # assumes we're interested in the first origin; define.json defines origin as an object, not a list
-            if  item_def.Origin and item_def.Origin[0].Type == 'Derived':
+            if any(getattr(o, "Type", None) == "Derived" for o in (item_def.Origin or [])):
                 # generate the MethodOID
                 method_oid = self._generate_method_oid(item_def.OID)
                 # find the ItemRef and add a MethodOID attribute

--- a/src/generators/define/tests/fixtures/define-360i.json
+++ b/src/generators/define/tests/fixtures/define-360i.json
@@ -36635,7 +36635,7 @@
           "decode": "Chemiluminescent Magnetic Microparticle Immunoassay",
           "coding": {
             "code": "C172557",
-            "codeSystem": "nci:ExtCodeID"Class
+            "codeSystem": "nci:ExtCodeID"
           }
         },
         {

--- a/src/generators/define/tests/fixtures/define-360i.xml
+++ b/src/generators/define/tests/fixtures/define-360i.xml
@@ -1,2 +1,8491 @@
 <?xml version='1.0' encoding='utf-8'?>
-<ODM FileOID="ODM.DEFINE21.aa7223ae-376b-49b4-bdfa-29b1b5c69885" AsOfDateTime="2026-05-11T16:14:49.947046+00:00" CreationDateTime="2026-05-11T16:14:49.947053+00:00" ODMVersion="1.3.2" FileType="Snapshot" Originator="360i Define-XML Team" SourceSystem="odmlib" SourceSystemVersion="0.2" def:Context="Other" xmlns="http://www.cdisc.org/ns/odm/v1.3" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xmlns:xml="http://www.w3.org/XML/1998/namespace" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:def="http://www.cdisc.org/ns/def/v2.1"><Study OID="ODM.LZZT - NEW.Version1.Design1"><GlobalVariables><StudyName>LZZT - NEW</StudyName><StudyDescription>Safety and Efficacy of the Xanomeline Transdermal Therapeutic System (TTS) in Patients with Mild to Moderate Alzheimer's Disease</StudyDescription><ProtocolName>LZZT - NEW</ProtocolName></GlobalVariables><MetaDataVersion OID="MDV.LZZT---NEW" Name="MDV LZZT - NEW" Description="Data Definitions for LZZT - NEW" def:DefineVersion="2.1.0"><def:Standards><def:Standard OID="STD.SDTMIG" Name="SDTMIG" Type="IG" Version="3.4" Status="FINAL" /><def:Standard OID="STD.SDTMCT" Name="CDISC/NCI" Type="CT" Version="2025-03-28" Status="FINAL" PublishingSet="SDTM" /></def:Standards><def:AnnotatedCRF><def:DocumentRef leafID="LF.acrf" /></def:AnnotatedCRF><def:ValueListDef OID="VL.SC.SCORRES"><ItemRef ItemOID="IT.SC.SCORRES.EDULEVEL" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.SC.48924878" /></ItemRef><ItemRef ItemOID="IT.SC.SCORRES.EDUYRNUM" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.SC.e7173a71" /></ItemRef></def:ValueListDef><def:ValueListDef OID="VL.SC.SCORRESU"><ItemRef ItemOID="IT.SC.SCORRESU.EDUYRNUM" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.SC.5fc4562e" /></ItemRef></def:ValueListDef><def:ValueListDef OID="VL.VS.VSORRES"><ItemRef ItemOID="IT.VS.VSORRES.TEMP" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.VS.df8e6ed8" /></ItemRef><ItemRef ItemOID="IT.VS.VSORRES.WEIGHT" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.VS.362bc1cf" /></ItemRef><ItemRef ItemOID="IT.VS.VSORRES.HEIGHT" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.VS.22da90ca" /></ItemRef><ItemRef ItemOID="IT.VS.VSORRES.PULSE" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.VS.90269389" /></ItemRef><ItemRef ItemOID="IT.VS.VSORRES.RESP" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.VS.02e0f161" /></ItemRef><ItemRef ItemOID="IT.VS.VSORRES.BMI" Mandatory="No" MethodOID="MT.VS.VSORRES.BMI"><def:WhereClauseRef WhereClauseOID="WC.VS.ba9d17a7" /></ItemRef><ItemRef ItemOID="IT.VS.VSORRES.SYSBP" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.VS.037b6848" /></ItemRef><ItemRef ItemOID="IT.VS.VSORRES.DIABP" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.VS.fe755a11" /></ItemRef><ItemRef ItemOID="IT.VS.VSORRES.HR" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.VS.324e0cc0" /></ItemRef></def:ValueListDef><def:ValueListDef OID="VL.VS.VSORRESU"><ItemRef ItemOID="IT.VS.VSORRESU.TEMP" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.VS.dea56915" /></ItemRef><ItemRef ItemOID="IT.VS.VSORRESU.WEIGHT" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.VS.ef959fbb" /></ItemRef><ItemRef ItemOID="IT.VS.VSORRESU.HEIGHT" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.VS.97262f9f" /></ItemRef><ItemRef ItemOID="IT.VS.VSORRESU.PULSE" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.VS.2fad3005" /></ItemRef><ItemRef ItemOID="IT.VS.VSORRESU.RESP" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.VS.f296848d" /></ItemRef><ItemRef ItemOID="IT.VS.VSORRESU.BMI" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.VS.ca4251ba" /></ItemRef><ItemRef ItemOID="IT.VS.VSORRESU.SYSBP" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.VS.301c7ee3" /></ItemRef><ItemRef ItemOID="IT.VS.VSORRESU.DIABP" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.VS.714dfc07" /></ItemRef><ItemRef ItemOID="IT.VS.VSORRESU.HR" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.VS.5a9c1ab0" /></ItemRef></def:ValueListDef><def:ValueListDef OID="VL.EG.EGORRES"><ItemRef ItemOID="IT.EG.EGORRES.INTP" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.EG.f60b99cb" /></ItemRef><ItemRef ItemOID="IT.EG.EGORRES.AVCOND" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.EG.d30401ba" /></ItemRef><ItemRef ItemOID="IT.EG.EGORRES.AXISVOLT" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.EG.0764363d" /></ItemRef><ItemRef ItemOID="IT.EG.EGORRES.CHYPTENL" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.EG.c7ca2c0d" /></ItemRef><ItemRef ItemOID="IT.EG.EGORRES.TECHQUAL" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.EG.0110957e" /></ItemRef><ItemRef ItemOID="IT.EG.EGORRES.IVTIACD" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.EG.7a2cbb17" /></ItemRef><ItemRef ItemOID="IT.EG.EGORRES.PACEMAKR" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.EG.c82f004b" /></ItemRef><ItemRef ItemOID="IT.EG.EGORRES.RHYNOS" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.EG.aaf51dd5" /></ItemRef><ItemRef ItemOID="IT.EG.EGORRES.SNRARRY" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.EG.0a478649" /></ItemRef><ItemRef ItemOID="IT.EG.EGORRES.SPRARRY" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.EG.44c12ce4" /></ItemRef><ItemRef ItemOID="IT.EG.EGORRES.SPRTARRY" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.EG.7c9fb72d" /></ItemRef><ItemRef ItemOID="IT.EG.EGORRES.VTARRY" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.EG.3a146a53" /></ItemRef><ItemRef ItemOID="IT.EG.EGORRES.VTTARRY" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.EG.5571a969" /></ItemRef><ItemRef ItemOID="IT.EG.EGORRES.PRAG" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.EG.13a9fd00" /></ItemRef><ItemRef ItemOID="IT.EG.EGORRES.QRSAG" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.EG.72304c3a" /></ItemRef><ItemRef ItemOID="IT.EG.EGORRES.QTAG" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.EG.6f155b1d" /></ItemRef><ItemRef ItemOID="IT.EG.EGORRES.QTCBAG" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.EG.dff815c6" /></ItemRef><ItemRef ItemOID="IT.EG.EGORRES.QTCFAG" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.EG.e967e1e7" /></ItemRef><ItemRef ItemOID="IT.EG.EGORRES.RRAG" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.EG.64f26102" /></ItemRef><ItemRef ItemOID="IT.EG.EGORRES.EGHRMN" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.EG.2ecbdce2" /></ItemRef><ItemRef ItemOID="IT.EG.EGORRES.QRS_AXIS" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.EG.9ce29aa6" /></ItemRef></def:ValueListDef><def:ValueListDef OID="VL.EG.EGORRESU"><ItemRef ItemOID="IT.EG.EGORRESU.PRAG" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.EG.cec16291" /></ItemRef><ItemRef ItemOID="IT.EG.EGORRESU.QRSAG" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.EG.5a1ab0f5" /></ItemRef><ItemRef ItemOID="IT.EG.EGORRESU.QTAG" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.EG.ddb86367" /></ItemRef><ItemRef ItemOID="IT.EG.EGORRESU.QTCBAG" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.EG.e847517c" /></ItemRef><ItemRef ItemOID="IT.EG.EGORRESU.QTCFAG" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.EG.7f463007" /></ItemRef><ItemRef ItemOID="IT.EG.EGORRESU.RRAG" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.EG.3d1ba9c3" /></ItemRef><ItemRef ItemOID="IT.EG.EGORRESU.EGHRMN" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.EG.a40eb46d" /></ItemRef><ItemRef ItemOID="IT.EG.EGORRESU.QRS_AXIS" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.EG.02ebb46f" /></ItemRef></def:ValueListDef><def:ValueListDef OID="VL.LB.LBORRES"><ItemRef ItemOID="IT.LB.LBORRES.HGB" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.c192b07f" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRES.HCT" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.82b97100" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRES.RBC" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.87582e25" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRES.MCH" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.95f4de22" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRES.MCHC" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.92bd1f17" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRES.MCV" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.24c0e2bc" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRES.WBC" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.351df44b" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRES.NEUTSG" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.5f2a0bab" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRES.NEUTB" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.eea0ae49" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRES.NEUT" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.550c7a01" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRES.MONO" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.de4c119b" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRES.EOS" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.a5684311" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRES.BASO" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.7b86c15b" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRES.PLAT" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.3a9d73e1" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRES.MICROCY" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.ddc3319f" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRES.MACROCY" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.116f85e4" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRES.ANISO" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.84ceb0ad" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRES.POIKILO" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.b622c728" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRES.POLYCHR" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.87b1b367" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRES.ALT" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.5412b298" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRES.ALB" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.e42a3c09" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRES.ALP" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.cdac7fcc" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRES.AST" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.b9d7ddba" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRES.CREAT" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.969c1a6d" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRES.K" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.7ce691fd" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRES.SODIUM" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.88601b52" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRES.UREAN" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.42392cd1" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRES.BICARB" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.9279ec22" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRES.CL" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.8b779a3b" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRES.BILI" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.cfe14422" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRES.GGT" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.8285c765" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRES.URATE" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.37c7b4ba" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRES.PHOS" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.e4e81dc5" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRES.CA" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.470def9b" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRES.GLUC" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.c891c160" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRES.PROT" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.abcfd20c" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRES.CHOL" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.5a1bca67" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRES.T3UP" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.4226ee02" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRES.T3" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.df33e99e" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRES.T4FR" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.30f3d8b3" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRES.T4FRIDX" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.f59f4529" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRES.TSH" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.c54221c6" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRES.VITB9" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.cb02cad8" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRES.VITB12" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.d0f49556" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRES.COLOR" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.4987b41e" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRES.SPGRAV" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.cbf789d8" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRES.KETONES" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.3239d7a3" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRES.UROBIL" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.59366afe" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRES.OCCBLD" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.3adc4566" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRES.NITRITE" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.59074de1" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRES.HBA1C" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.c1765eee" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRES.HBA1CHGB" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.dd459ec6" /></ItemRef></def:ValueListDef><def:ValueListDef OID="VL.LB.LBORRESU"><ItemRef ItemOID="IT.LB.LBORRESU.HGB" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.e9a1c33d" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRESU.HCT" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.7f0975c7" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRESU.RBC" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.f7f1de35" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRESU.MCH" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.c32acb17" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRESU.MCHC" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.eb7f048a" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRESU.MCV" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.e881d4b5" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRESU.WBC" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.41785be6" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRESU.NEUTSG" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.a68e5eaa" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRESU.NEUTB" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.aad6dbd6" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRESU.NEUT" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.d13d6578" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRESU.MONO" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.00e6d228" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRESU.EOS" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.ef654de1" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRESU.BASO" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.b6fa6e8d" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRESU.PLAT" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.90eedf3b" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRESU.ALT" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.8914eb45" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRESU.ALP" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.6660e11c" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRESU.AST" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.37e389df" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRESU.CREAT" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.549f5ae4" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRESU.K" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.ee634517" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRESU.SODIUM" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.07a8daa1" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRESU.UREAN" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.91d1c3d5" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRESU.BICARB" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.9df0845c" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRESU.CL" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.cc8b6004" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRESU.GGT" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.3c564f36" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRESU.URATE" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.13fbb1a5" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRESU.PHOS" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.3749493c" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRESU.CA" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.38f9f39d" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRESU.CHOL" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.516f3664" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRESU.T3UP" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.dcbcbe57" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRESU.T3" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.b7b215a1" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRESU.T4FR" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.0f071538" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRESU.T4FRIDX" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.258e657c" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRESU.TSH" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.d675561c" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRESU.VITB9" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.e81938d6" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRESU.VITB12" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.54dda2d1" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRESU.UROBIL" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.e6a434ec" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRESU.HBA1C" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.9e9118c8" /></ItemRef><ItemRef ItemOID="IT.LB.LBORRESU.HBA1CHGB" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.LB.8644d9ca" /></ItemRef></def:ValueListDef><def:ValueListDef OID="VL.MB.MBORRES"><ItemRef ItemOID="IT.MB.MBORRES.TPLAB" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.MB.49773274" /></ItemRef><ItemRef ItemOID="IT.MB.MBORRES.TPADNA" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.MB.e698c5a2" /></ItemRef></def:ValueListDef><def:ValueListDef OID="VL.TS.TSPARMCD"><ItemRef ItemOID="IT.TS.TSPARMCD.ADAPT" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.TS.08ebd0ce" /></ItemRef><ItemRef ItemOID="IT.TS.TSPARMCD.AGEMIN" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.TS.a7d24f4a" /></ItemRef><ItemRef ItemOID="IT.TS.TSPARMCD.AGEMAX" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.TS.4ac86c98" /></ItemRef><ItemRef ItemOID="IT.TS.TSPARMCD.COMPTRT" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.TS.54cd02f1" /></ItemRef><ItemRef ItemOID="IT.TS.TSPARMCD.CRMDUR" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.TS.f9fa8745" /></ItemRef><ItemRef ItemOID="IT.TS.TSPARMCD.DOSE" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.TS.7fc6c3e6" /></ItemRef><ItemRef ItemOID="IT.TS.TSPARMCD.DOSFRQ" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.TS.5cd14c68" /></ItemRef><ItemRef ItemOID="IT.TS.TSPARMCD.DOSU" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.TS.4053f56c" /></ItemRef><ItemRef ItemOID="IT.TS.TSPARMCD.INDIC" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.TS.9cdae039" /></ItemRef><ItemRef ItemOID="IT.TS.TSPARMCD.INTMODEL" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.TS.2c83b5d9" /></ItemRef><ItemRef ItemOID="IT.TS.TSPARMCD.INTTYPE" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.TS.e3ae16cd" /></ItemRef><ItemRef ItemOID="IT.TS.TSPARMCD.NARMS" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.TS.89c0d243" /></ItemRef><ItemRef ItemOID="IT.TS.TSPARMCD.OBJPRIM" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.TS.7a056c75" /></ItemRef><ItemRef ItemOID="IT.TS.TSPARMCD.OBJSEC" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.TS.36721696" /></ItemRef><ItemRef ItemOID="IT.TS.TSPARMCD.OUTMSPRI" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.TS.d8b84608" /></ItemRef><ItemRef ItemOID="IT.TS.TSPARMCD.OUTMSSEC" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.TS.1d3cd461" /></ItemRef><ItemRef ItemOID="IT.TS.TSPARMCD.PLANSUB" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.TS.3a1c5c3c" /></ItemRef><ItemRef ItemOID="IT.TS.TSPARMCD.PTRTDUR" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.TS.2b2d70bc" /></ItemRef><ItemRef ItemOID="IT.TS.TSPARMCD.ROUTE" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.TS.3c4a8bf2" /></ItemRef><ItemRef ItemOID="IT.TS.TSPARMCD.SEXPOP" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.TS.4f0c74c2" /></ItemRef><ItemRef ItemOID="IT.TS.TSPARMCD.SPONSOR" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.TS.51236927" /></ItemRef><ItemRef ItemOID="IT.TS.TSPARMCD.STYPE" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.TS.f4cb41bb" /></ItemRef><ItemRef ItemOID="IT.TS.TSPARMCD.TBLIND" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.TS.9e101607" /></ItemRef><ItemRef ItemOID="IT.TS.TSPARMCD.THERAREA" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.TS.d8c1ac4c" /></ItemRef><ItemRef ItemOID="IT.TS.TSPARMCD.TINDTP" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.TS.e423672b" /></ItemRef><ItemRef ItemOID="IT.TS.TSPARMCD.TITLE" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.TS.43684533" /></ItemRef><ItemRef ItemOID="IT.TS.TSPARMCD.TPHASE" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.TS.22640600" /></ItemRef><ItemRef ItemOID="IT.TS.TSPARMCD.TRT" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.TS.1948fed3" /></ItemRef><ItemRef ItemOID="IT.TS.TSPARMCD.TTYPE" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.TS.29af0670" /></ItemRef></def:ValueListDef><def:ValueListDef OID="VL.IE.IEORRES"><ItemRef ItemOID="IT.IE.IEORRES.IN01" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.IE.1d2bb25f" /></ItemRef><ItemRef ItemOID="IT.IE.IEORRES.IN02" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.IE.fa688bf3" /></ItemRef><ItemRef ItemOID="IT.IE.IEORRES.IN03" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.IE.f276b607" /></ItemRef><ItemRef ItemOID="IT.IE.IEORRES.IN04" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.IE.cd528448" /></ItemRef><ItemRef ItemOID="IT.IE.IEORRES.IN05" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.IE.c1db3fd3" /></ItemRef><ItemRef ItemOID="IT.IE.IEORRES.IN06" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.IE.c2ec614b" /></ItemRef><ItemRef ItemOID="IT.IE.IEORRES.IN07" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.IE.2ef341aa" /></ItemRef><ItemRef ItemOID="IT.IE.IEORRES.IN08" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.IE.5d85184b" /></ItemRef><ItemRef ItemOID="IT.IE.IEORRES.EX01" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.IE.8579104c" /></ItemRef><ItemRef ItemOID="IT.IE.IEORRES.EX02" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.IE.74eacc45" /></ItemRef><ItemRef ItemOID="IT.IE.IEORRES.EX03" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.IE.ce0e8d09" /></ItemRef><ItemRef ItemOID="IT.IE.IEORRES.EX04" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.IE.945bafbd" /></ItemRef><ItemRef ItemOID="IT.IE.IEORRES.EX05" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.IE.afbec960" /></ItemRef><ItemRef ItemOID="IT.IE.IEORRES.EX06" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.IE.cac0d3f4" /></ItemRef><ItemRef ItemOID="IT.IE.IEORRES.EX07" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.IE.cabd9be0" /></ItemRef><ItemRef ItemOID="IT.IE.IEORRES.EX08" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.IE.fbae7983" /></ItemRef><ItemRef ItemOID="IT.IE.IEORRES.EX09" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.IE.0952c014" /></ItemRef><ItemRef ItemOID="IT.IE.IEORRES.EX10" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.IE.5b8b02b2" /></ItemRef><ItemRef ItemOID="IT.IE.IEORRES.EX11" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.IE.70a941e7" /></ItemRef><ItemRef ItemOID="IT.IE.IEORRES.EX12" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.IE.611f5d7b" /></ItemRef><ItemRef ItemOID="IT.IE.IEORRES.EX13" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.IE.8abff918" /></ItemRef><ItemRef ItemOID="IT.IE.IEORRES.EX14" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.IE.b089a2a0" /></ItemRef><ItemRef ItemOID="IT.IE.IEORRES.EX15" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.IE.39cb2456" /></ItemRef><ItemRef ItemOID="IT.IE.IEORRES.EX16" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.IE.2cdb5c18" /></ItemRef><ItemRef ItemOID="IT.IE.IEORRES.EX17" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.IE.b415f3a9" /></ItemRef><ItemRef ItemOID="IT.IE.IEORRES.EX18" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.IE.5c29f970" /></ItemRef><ItemRef ItemOID="IT.IE.IEORRES.EX19" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.IE.9fe9a358" /></ItemRef><ItemRef ItemOID="IT.IE.IEORRES.EX20" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.IE.e36b210b" /></ItemRef><ItemRef ItemOID="IT.IE.IEORRES.EX21" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.IE.743b4fb5" /></ItemRef><ItemRef ItemOID="IT.IE.IEORRES.EX22" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.IE.76a82754" /></ItemRef><ItemRef ItemOID="IT.IE.IEORRES.EX23" Mandatory="No"><def:WhereClauseRef WhereClauseOID="WC.IE.fbeb5a1e" /></ItemRef></def:ValueListDef><def:WhereClauseDef OID="WC.SC.48924878"><RangeCheck SoftHard="Soft" def:ItemOID="IT.SC.SCTESTCD" Comparator="EQ"><CheckValue>EDULEVEL</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.SC.e7173a71"><RangeCheck SoftHard="Soft" def:ItemOID="IT.SC.SCTESTCD" Comparator="EQ"><CheckValue>EDUYRNUM</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.SC.5fc4562e"><RangeCheck SoftHard="Soft" def:ItemOID="IT.SC.SCTESTCD" Comparator="EQ"><CheckValue>EDUYRNUM</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.VS.df8e6ed8"><RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSTESTCD" Comparator="EQ"><CheckValue>TEMP</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSLOC" Comparator="IN"><CheckValue>AXILLA</CheckValue><CheckValue>EAR</CheckValue><CheckValue>FOREHEAD</CheckValue><CheckValue>ORAL CAVITY</CheckValue><CheckValue>RECTUM</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.VS.362bc1cf"><RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSTESTCD" Comparator="EQ"><CheckValue>WEIGHT</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.VS.22da90ca"><RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSTESTCD" Comparator="EQ"><CheckValue>HEIGHT</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.VS.90269389"><RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSTESTCD" Comparator="EQ"><CheckValue>PULSE</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSPOS" Comparator="IN"><CheckValue>PRONE</CheckValue><CheckValue>SEMI-RECUMBENT</CheckValue><CheckValue>SITTING</CheckValue><CheckValue>STANDING</CheckValue><CheckValue>SUPINE</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSLOC" Comparator="IN"><CheckValue>BRACHIAL ARTERY</CheckValue><CheckValue>CAROTID ARTERY</CheckValue><CheckValue>CEREBRAL ARTERY</CheckValue><CheckValue>DORSALIS PEDIS ARTERY</CheckValue><CheckValue>FEMORAL ARTERY</CheckValue><CheckValue>RADIAL ARTERY</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSLAT" Comparator="IN"><CheckValue>LEFT</CheckValue><CheckValue>RIGHT</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.VS.02e0f161"><RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSTESTCD" Comparator="EQ"><CheckValue>RESP</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.VS.ba9d17a7"><RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSTESTCD" Comparator="EQ"><CheckValue>BMI</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.VS.037b6848"><RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSTESTCD" Comparator="EQ"><CheckValue>SYSBP</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSPOS" Comparator="IN"><CheckValue>PRONE</CheckValue><CheckValue>SEMI-RECUMBENT</CheckValue><CheckValue>SITTING</CheckValue><CheckValue>STANDING</CheckValue><CheckValue>SUPINE</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSLOC" Comparator="IN"><CheckValue>BRACHIAL ARTERY</CheckValue><CheckValue>CAROTID ARTERY</CheckValue><CheckValue>DORSALIS PEDIS ARTERY</CheckValue><CheckValue>FEMORAL ARTERY</CheckValue><CheckValue>FINGER</CheckValue><CheckValue>RADIAL ARTERY</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSLAT" Comparator="IN"><CheckValue>LEFT</CheckValue><CheckValue>RIGHT</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.VS.fe755a11"><RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSTESTCD" Comparator="EQ"><CheckValue>DIABP</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSPOS" Comparator="IN"><CheckValue>PRONE</CheckValue><CheckValue>SEMI-RECUMBENT</CheckValue><CheckValue>SITTING</CheckValue><CheckValue>STANDING</CheckValue><CheckValue>SUPINE</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSLOC" Comparator="IN"><CheckValue>BRACHIAL ARTERY</CheckValue><CheckValue>CAROTID ARTERY</CheckValue><CheckValue>DORSALIS PEDIS ARTERY</CheckValue><CheckValue>FEMORAL ARTERY</CheckValue><CheckValue>FINGER</CheckValue><CheckValue>RADIAL ARTERY</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSLAT" Comparator="IN"><CheckValue>LEFT</CheckValue><CheckValue>RIGHT</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.VS.324e0cc0"><RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSTESTCD" Comparator="EQ"><CheckValue>HR</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSPOS" Comparator="IN"><CheckValue>PRONE</CheckValue><CheckValue>SEMI-RECUMBENT</CheckValue><CheckValue>SITTING</CheckValue><CheckValue>STANDING</CheckValue><CheckValue>SUPINE</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSLOC" Comparator="IN"><CheckValue>BRACHIAL ARTERY</CheckValue><CheckValue>CAROTID ARTERY</CheckValue><CheckValue>CEREBRAL ARTERY</CheckValue><CheckValue>DORSALIS PEDIS ARTERY</CheckValue><CheckValue>FEMORAL ARTERY</CheckValue><CheckValue>RADIAL ARTERY</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSLAT" Comparator="IN"><CheckValue>LEFT</CheckValue><CheckValue>RIGHT</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.VS.dea56915"><RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSTESTCD" Comparator="EQ"><CheckValue>TEMP</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSLOC" Comparator="IN"><CheckValue>AXILLA</CheckValue><CheckValue>EAR</CheckValue><CheckValue>FOREHEAD</CheckValue><CheckValue>ORAL CAVITY</CheckValue><CheckValue>RECTUM</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.VS.ef959fbb"><RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSTESTCD" Comparator="EQ"><CheckValue>WEIGHT</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.VS.97262f9f"><RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSTESTCD" Comparator="EQ"><CheckValue>HEIGHT</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.VS.2fad3005"><RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSTESTCD" Comparator="EQ"><CheckValue>PULSE</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSPOS" Comparator="IN"><CheckValue>PRONE</CheckValue><CheckValue>SEMI-RECUMBENT</CheckValue><CheckValue>SITTING</CheckValue><CheckValue>STANDING</CheckValue><CheckValue>SUPINE</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSLOC" Comparator="IN"><CheckValue>BRACHIAL ARTERY</CheckValue><CheckValue>CAROTID ARTERY</CheckValue><CheckValue>CEREBRAL ARTERY</CheckValue><CheckValue>DORSALIS PEDIS ARTERY</CheckValue><CheckValue>FEMORAL ARTERY</CheckValue><CheckValue>RADIAL ARTERY</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSLAT" Comparator="IN"><CheckValue>LEFT</CheckValue><CheckValue>RIGHT</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.VS.f296848d"><RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSTESTCD" Comparator="EQ"><CheckValue>RESP</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.VS.ca4251ba"><RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSTESTCD" Comparator="EQ"><CheckValue>BMI</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.VS.301c7ee3"><RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSTESTCD" Comparator="EQ"><CheckValue>SYSBP</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSPOS" Comparator="IN"><CheckValue>PRONE</CheckValue><CheckValue>SEMI-RECUMBENT</CheckValue><CheckValue>SITTING</CheckValue><CheckValue>STANDING</CheckValue><CheckValue>SUPINE</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSLOC" Comparator="IN"><CheckValue>BRACHIAL ARTERY</CheckValue><CheckValue>CAROTID ARTERY</CheckValue><CheckValue>DORSALIS PEDIS ARTERY</CheckValue><CheckValue>FEMORAL ARTERY</CheckValue><CheckValue>FINGER</CheckValue><CheckValue>RADIAL ARTERY</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSLAT" Comparator="IN"><CheckValue>LEFT</CheckValue><CheckValue>RIGHT</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.VS.714dfc07"><RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSTESTCD" Comparator="EQ"><CheckValue>DIABP</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSPOS" Comparator="IN"><CheckValue>PRONE</CheckValue><CheckValue>SEMI-RECUMBENT</CheckValue><CheckValue>SITTING</CheckValue><CheckValue>STANDING</CheckValue><CheckValue>SUPINE</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSLOC" Comparator="IN"><CheckValue>BRACHIAL ARTERY</CheckValue><CheckValue>CAROTID ARTERY</CheckValue><CheckValue>DORSALIS PEDIS ARTERY</CheckValue><CheckValue>FEMORAL ARTERY</CheckValue><CheckValue>FINGER</CheckValue><CheckValue>RADIAL ARTERY</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSLAT" Comparator="IN"><CheckValue>LEFT</CheckValue><CheckValue>RIGHT</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.VS.5a9c1ab0"><RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSTESTCD" Comparator="EQ"><CheckValue>HR</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSPOS" Comparator="IN"><CheckValue>PRONE</CheckValue><CheckValue>SEMI-RECUMBENT</CheckValue><CheckValue>SITTING</CheckValue><CheckValue>STANDING</CheckValue><CheckValue>SUPINE</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSLOC" Comparator="IN"><CheckValue>BRACHIAL ARTERY</CheckValue><CheckValue>CAROTID ARTERY</CheckValue><CheckValue>CEREBRAL ARTERY</CheckValue><CheckValue>DORSALIS PEDIS ARTERY</CheckValue><CheckValue>FEMORAL ARTERY</CheckValue><CheckValue>RADIAL ARTERY</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSLAT" Comparator="IN"><CheckValue>LEFT</CheckValue><CheckValue>RIGHT</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.EG.f60b99cb"><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ"><CheckValue>INTP</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN"><CheckValue>ADJUDICATION COMMITTEE</CheckValue><CheckValue>INDEPENDENT ASSESSOR</CheckValue><CheckValue>INVESTIGATOR</CheckValue><CheckValue>VENDOR</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.EG.d30401ba"><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ"><CheckValue>AVCOND</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN"><CheckValue>ADJUDICATION COMMITTEE</CheckValue><CheckValue>INDEPENDENT ASSESSOR</CheckValue><CheckValue>INVESTIGATOR</CheckValue><CheckValue>VENDOR</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.EG.0764363d"><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ"><CheckValue>AXISVOLT</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN"><CheckValue>ADJUDICATION COMMITTEE</CheckValue><CheckValue>INDEPENDENT ASSESSOR</CheckValue><CheckValue>INVESTIGATOR</CheckValue><CheckValue>VENDOR</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.EG.c7ca2c0d"><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ"><CheckValue>CHYPTENL</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN"><CheckValue>ADJUDICATION COMMITTEE</CheckValue><CheckValue>INDEPENDENT ASSESSOR</CheckValue><CheckValue>INVESTIGATOR</CheckValue><CheckValue>VENDOR</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.EG.0110957e"><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ"><CheckValue>TECHQUAL</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN"><CheckValue>ADJUDICATION COMMITTEE</CheckValue><CheckValue>INDEPENDENT ASSESSOR</CheckValue><CheckValue>INVESTIGATOR</CheckValue><CheckValue>VENDOR</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.EG.7a2cbb17"><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ"><CheckValue>IVTIACD</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN"><CheckValue>ADJUDICATION COMMITTEE</CheckValue><CheckValue>INDEPENDENT ASSESSOR</CheckValue><CheckValue>INVESTIGATOR</CheckValue><CheckValue>VENDOR</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.EG.c82f004b"><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ"><CheckValue>PACEMAKR</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN"><CheckValue>ADJUDICATION COMMITTEE</CheckValue><CheckValue>INDEPENDENT ASSESSOR</CheckValue><CheckValue>INVESTIGATOR</CheckValue><CheckValue>VENDOR</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.EG.aaf51dd5"><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ"><CheckValue>RHYNOS</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN"><CheckValue>ADJUDICATION COMMITTEE</CheckValue><CheckValue>INDEPENDENT ASSESSOR</CheckValue><CheckValue>INVESTIGATOR</CheckValue><CheckValue>VENDOR</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.EG.0a478649"><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ"><CheckValue>SNRARRY</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN"><CheckValue>ADJUDICATION COMMITTEE</CheckValue><CheckValue>INDEPENDENT ASSESSOR</CheckValue><CheckValue>INVESTIGATOR</CheckValue><CheckValue>VENDOR</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.EG.44c12ce4"><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ"><CheckValue>SPRARRY</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN"><CheckValue>ADJUDICATION COMMITTEE</CheckValue><CheckValue>INDEPENDENT ASSESSOR</CheckValue><CheckValue>INVESTIGATOR</CheckValue><CheckValue>VENDOR</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.EG.7c9fb72d"><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ"><CheckValue>SPRTARRY</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN"><CheckValue>ADJUDICATION COMMITTEE</CheckValue><CheckValue>INDEPENDENT ASSESSOR</CheckValue><CheckValue>INVESTIGATOR</CheckValue><CheckValue>VENDOR</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.EG.3a146a53"><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ"><CheckValue>VTARRY</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN"><CheckValue>ADJUDICATION COMMITTEE</CheckValue><CheckValue>INDEPENDENT ASSESSOR</CheckValue><CheckValue>INVESTIGATOR</CheckValue><CheckValue>VENDOR</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.EG.5571a969"><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ"><CheckValue>VTTARRY</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN"><CheckValue>ADJUDICATION COMMITTEE</CheckValue><CheckValue>INDEPENDENT ASSESSOR</CheckValue><CheckValue>INVESTIGATOR</CheckValue><CheckValue>VENDOR</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.EG.13a9fd00"><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ"><CheckValue>PRAG</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN"><CheckValue>ADJUDICATION COMMITTEE</CheckValue><CheckValue>INDEPENDENT ASSESSOR</CheckValue><CheckValue>INVESTIGATOR</CheckValue><CheckValue>VENDOR</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.EG.72304c3a"><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ"><CheckValue>QRSAG</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN"><CheckValue>ADJUDICATION COMMITTEE</CheckValue><CheckValue>INDEPENDENT ASSESSOR</CheckValue><CheckValue>INVESTIGATOR</CheckValue><CheckValue>VENDOR</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.EG.6f155b1d"><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ"><CheckValue>QTAG</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN"><CheckValue>ADJUDICATION COMMITTEE</CheckValue><CheckValue>INDEPENDENT ASSESSOR</CheckValue><CheckValue>INVESTIGATOR</CheckValue><CheckValue>VENDOR</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.EG.dff815c6"><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ"><CheckValue>QTCBAG</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN"><CheckValue>ADJUDICATION COMMITTEE</CheckValue><CheckValue>INDEPENDENT ASSESSOR</CheckValue><CheckValue>INVESTIGATOR</CheckValue><CheckValue>VENDOR</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.EG.e967e1e7"><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ"><CheckValue>QTCFAG</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN"><CheckValue>ADJUDICATION COMMITTEE</CheckValue><CheckValue>INDEPENDENT ASSESSOR</CheckValue><CheckValue>INVESTIGATOR</CheckValue><CheckValue>VENDOR</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.EG.64f26102"><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ"><CheckValue>RRAG</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN"><CheckValue>ADJUDICATION COMMITTEE</CheckValue><CheckValue>INDEPENDENT ASSESSOR</CheckValue><CheckValue>INVESTIGATOR</CheckValue><CheckValue>VENDOR</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.EG.2ecbdce2"><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ"><CheckValue>EGHRMN</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN"><CheckValue>ADJUDICATION COMMITTEE</CheckValue><CheckValue>INDEPENDENT ASSESSOR</CheckValue><CheckValue>INVESTIGATOR</CheckValue><CheckValue>VENDOR</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.EG.9ce29aa6"><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ"><CheckValue>QRS_AXIS</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN"><CheckValue>ADJUDICATION COMMITTEE</CheckValue><CheckValue>INDEPENDENT ASSESSOR</CheckValue><CheckValue>INVESTIGATOR</CheckValue><CheckValue>VENDOR</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.EG.cec16291"><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ"><CheckValue>PRAG</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN"><CheckValue>ADJUDICATION COMMITTEE</CheckValue><CheckValue>INDEPENDENT ASSESSOR</CheckValue><CheckValue>INVESTIGATOR</CheckValue><CheckValue>VENDOR</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.EG.5a1ab0f5"><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ"><CheckValue>QRSAG</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN"><CheckValue>ADJUDICATION COMMITTEE</CheckValue><CheckValue>INDEPENDENT ASSESSOR</CheckValue><CheckValue>INVESTIGATOR</CheckValue><CheckValue>VENDOR</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.EG.ddb86367"><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ"><CheckValue>QTAG</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN"><CheckValue>ADJUDICATION COMMITTEE</CheckValue><CheckValue>INDEPENDENT ASSESSOR</CheckValue><CheckValue>INVESTIGATOR</CheckValue><CheckValue>VENDOR</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.EG.e847517c"><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ"><CheckValue>QTCBAG</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN"><CheckValue>ADJUDICATION COMMITTEE</CheckValue><CheckValue>INDEPENDENT ASSESSOR</CheckValue><CheckValue>INVESTIGATOR</CheckValue><CheckValue>VENDOR</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.EG.7f463007"><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ"><CheckValue>QTCFAG</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN"><CheckValue>ADJUDICATION COMMITTEE</CheckValue><CheckValue>INDEPENDENT ASSESSOR</CheckValue><CheckValue>INVESTIGATOR</CheckValue><CheckValue>VENDOR</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.EG.3d1ba9c3"><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ"><CheckValue>RRAG</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN"><CheckValue>ADJUDICATION COMMITTEE</CheckValue><CheckValue>INDEPENDENT ASSESSOR</CheckValue><CheckValue>INVESTIGATOR</CheckValue><CheckValue>VENDOR</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.EG.a40eb46d"><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ"><CheckValue>EGHRMN</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN"><CheckValue>ADJUDICATION COMMITTEE</CheckValue><CheckValue>INDEPENDENT ASSESSOR</CheckValue><CheckValue>INVESTIGATOR</CheckValue><CheckValue>VENDOR</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.EG.02ebb46f"><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ"><CheckValue>QRS_AXIS</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN"><CheckValue>ADJUDICATION COMMITTEE</CheckValue><CheckValue>INDEPENDENT ASSESSOR</CheckValue><CheckValue>INVESTIGATOR</CheckValue><CheckValue>VENDOR</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.c192b07f"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>HGB</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>BLOOD</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBMETHOD" Comparator="EQ"><CheckValue>DIPSTICK MEASUREMENT METHOD</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.82b97100"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>HCT</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>BLOOD</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.87582e25"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>RBC</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>BLOOD</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.95f4de22"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>MCH</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>ERYTHROCYTES</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.92bd1f17"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>MCHC</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>ERYTHROCYTES</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.24c0e2bc"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>MCV</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>ERYTHROCYTES</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.351df44b"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>WBC</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>BLOOD</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.5f2a0bab"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>NEUTSG</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>BLOOD</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.eea0ae49"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>NEUTB</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>BLOOD</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.550c7a01"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>NEUT</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>BLOOD</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.de4c119b"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>MONO</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>BLOOD</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.a5684311"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>EOS</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>BLOOD</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.7b86c15b"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>BASO</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>BLOOD</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.3a9d73e1"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>PLAT</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>BLOOD</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.ddc3319f"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>MICROCY</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>URINE SEDIMENT</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.116f85e4"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>MACROCY</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>URINE SEDIMENT</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.84ceb0ad"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>ANISO</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>BLOOD</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.b622c728"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>POIKILO</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>BLOOD</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.87b1b367"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>POLYCHR</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>BLOOD</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.5412b298"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>ALT</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>SERUM OR PLASMA</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.e42a3c09"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>ALB</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>URINE</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.cdac7fcc"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>ALP</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>SERUM OR PLASMA</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.b9d7ddba"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>AST</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>SERUM OR PLASMA</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.969c1a6d"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>CREAT</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>URINE</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.7ce691fd"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>K</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>URINE</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.88601b52"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>SODIUM</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>URINE</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.42392cd1"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>UREAN</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>SERUM OR PLASMA</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.9279ec22"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>BICARB</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>BLOOD</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.8b779a3b"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>CL</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>SERUM OR PLASMA</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.cfe14422"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>BILI</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>URINE</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.8285c765"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>GGT</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>SERUM OR PLASMA</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.37c7b4ba"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>URATE</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>SERUM OR PLASMA</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.e4e81dc5"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>PHOS</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>SERUM OR PLASMA</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.470def9b"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>CA</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>SERUM OR PLASMA</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.c891c160"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>GLUC</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>URINE</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.abcfd20c"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>PROT</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>URINE</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.5a1bca67"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>CHOL</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>SERUM OR PLASMA</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.4226ee02"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>T3UP</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>SERUM OR PLASMA</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.df33e99e"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>T3</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>SERUM OR PLASMA</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.30f3d8b3"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>T4FR</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>SERUM OR PLASMA</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.f59f4529"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>T4FRIDX</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>SERUM OR PLASMA</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.c54221c6"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>TSH</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>SERUM OR PLASMA</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.cb02cad8"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>VITB9</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>SERUM OR PLASMA</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.d0f49556"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>VITB12</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>SERUM OR PLASMA</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.4987b41e"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>COLOR</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>URINE</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.cbf789d8"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>SPGRAV</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>URINE</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.3239d7a3"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>KETONES</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>URINE</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.59366afe"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>UROBIL</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>URINE</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.3adc4566"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>OCCBLD</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>STOOL</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.59074de1"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>NITRITE</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>URINE</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.c1765eee"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>HBA1C</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>BLOOD</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.dd459ec6"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>HBA1CHGB</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>BLOOD</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.e9a1c33d"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>HGB</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>BLOOD</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBMETHOD" Comparator="EQ"><CheckValue>DIPSTICK MEASUREMENT METHOD</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.7f0975c7"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>HCT</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>BLOOD</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.f7f1de35"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>RBC</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>BLOOD</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.c32acb17"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>MCH</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>ERYTHROCYTES</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.eb7f048a"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>MCHC</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>ERYTHROCYTES</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.e881d4b5"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>MCV</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>ERYTHROCYTES</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.41785be6"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>WBC</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>BLOOD</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.a68e5eaa"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>NEUTSG</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>BLOOD</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.aad6dbd6"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>NEUTB</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>BLOOD</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.d13d6578"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>NEUT</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>BLOOD</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.00e6d228"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>MONO</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>BLOOD</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.ef654de1"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>EOS</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>BLOOD</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.b6fa6e8d"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>BASO</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>BLOOD</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.90eedf3b"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>PLAT</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>BLOOD</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.8914eb45"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>ALT</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>SERUM OR PLASMA</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.6660e11c"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>ALP</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>SERUM OR PLASMA</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.37e389df"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>AST</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>SERUM OR PLASMA</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.549f5ae4"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>CREAT</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>URINE</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.ee634517"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>K</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>URINE</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.07a8daa1"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>SODIUM</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>URINE</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.91d1c3d5"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>UREAN</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>SERUM OR PLASMA</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.9df0845c"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>BICARB</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>BLOOD</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.cc8b6004"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>CL</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>SERUM OR PLASMA</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.3c564f36"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>GGT</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>SERUM OR PLASMA</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.13fbb1a5"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>URATE</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>SERUM OR PLASMA</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.3749493c"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>PHOS</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>SERUM OR PLASMA</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.38f9f39d"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>CA</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>SERUM OR PLASMA</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.516f3664"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>CHOL</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>SERUM OR PLASMA</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.dcbcbe57"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>T3UP</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>SERUM OR PLASMA</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.b7b215a1"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>T3</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>SERUM OR PLASMA</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.0f071538"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>T4FR</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>SERUM OR PLASMA</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.258e657c"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>T4FRIDX</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>SERUM OR PLASMA</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.d675561c"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>TSH</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>SERUM OR PLASMA</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.e81938d6"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>VITB9</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>SERUM OR PLASMA</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.54dda2d1"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>VITB12</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>SERUM OR PLASMA</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.e6a434ec"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>UROBIL</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>URINE</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.9e9118c8"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>HBA1C</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>BLOOD</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.LB.8644d9ca"><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ"><CheckValue>HBA1CHGB</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ"><CheckValue>BLOOD</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.MB.49773274"><RangeCheck SoftHard="Soft" def:ItemOID="IT.MB.MBTESTCD" Comparator="EQ"><CheckValue>TPLAB</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.MB.MBTSTDTL" Comparator="EQ"><CheckValue>DETECTION</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.MB.MBSPEC" Comparator="EQ"><CheckValue>SERUM</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.MB.MBMETHOD" Comparator="IN"><CheckValue>FLUORESCENT IMMUNOASSAY</CheckValue><CheckValue>HEMAGGLUTINATION ASSAY</CheckValue><CheckValue>CHEMILUMINESCENT MICROPARTICLE IMMUNOASSAY</CheckValue><CheckValue>POLYMERASE CHAIN REACTION</CheckValue><CheckValue>IMMUNOBLOT</CheckValue><CheckValue>RAPID IMMUNOASSAY</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.MB.e698c5a2"><RangeCheck SoftHard="Soft" def:ItemOID="IT.MB.MBTESTCD" Comparator="EQ"><CheckValue>TPADNA</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.MB.MBTSTDTL" Comparator="EQ"><CheckValue>DETECTION</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.MB.MBSPEC" Comparator="IN"><CheckValue>BLOOD</CheckValue><CheckValue>CEREBROSPINAL FLUID</CheckValue><CheckValue>FLUID</CheckValue><CheckValue>SWABBED MATERIAL</CheckValue><CheckValue>URINE</CheckValue></RangeCheck><RangeCheck SoftHard="Soft" def:ItemOID="IT.MB.MBMETHOD" Comparator="EQ"><CheckValue>LINE PROBE ASSAY</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.TS.08ebd0ce"><RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ"><CheckValue>ADAPT</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.TS.a7d24f4a"><RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ"><CheckValue>AGEMIN</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.TS.4ac86c98"><RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ"><CheckValue>AGEMAX</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.TS.54cd02f1"><RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ"><CheckValue>COMPTRT</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.TS.f9fa8745"><RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ"><CheckValue>CRMDUR</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.TS.7fc6c3e6"><RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ"><CheckValue>DOSE</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.TS.5cd14c68"><RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ"><CheckValue>DOSFRQ</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.TS.4053f56c"><RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ"><CheckValue>DOSU</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.TS.9cdae039"><RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ"><CheckValue>INDIC</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.TS.2c83b5d9"><RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ"><CheckValue>INTMODEL</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.TS.e3ae16cd"><RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ"><CheckValue>INTTYPE</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.TS.89c0d243"><RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ"><CheckValue>NARMS</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.TS.7a056c75"><RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ"><CheckValue>OBJPRIM</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.TS.36721696"><RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ"><CheckValue>OBJSEC</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.TS.d8b84608"><RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ"><CheckValue>OUTMSPRI</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.TS.1d3cd461"><RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ"><CheckValue>OUTMSSEC</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.TS.3a1c5c3c"><RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ"><CheckValue>PLANSUB</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.TS.2b2d70bc"><RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ"><CheckValue>PTRTDUR</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.TS.3c4a8bf2"><RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ"><CheckValue>ROUTE</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.TS.4f0c74c2"><RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ"><CheckValue>SEXPOP</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.TS.51236927"><RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ"><CheckValue>SPONSOR</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.TS.f4cb41bb"><RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ"><CheckValue>STYPE</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.TS.9e101607"><RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ"><CheckValue>TBLIND</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.TS.d8c1ac4c"><RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ"><CheckValue>THERAREA</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.TS.e423672b"><RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ"><CheckValue>TINDTP</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.TS.43684533"><RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ"><CheckValue>TITLE</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.TS.22640600"><RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ"><CheckValue>TPHASE</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.TS.1948fed3"><RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ"><CheckValue>TRT</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.TS.29af0670"><RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ"><CheckValue>TTYPE</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.IE.1d2bb25f"><RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ"><CheckValue>IN01</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.IE.fa688bf3"><RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ"><CheckValue>IN02</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.IE.f276b607"><RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ"><CheckValue>IN03</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.IE.cd528448"><RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ"><CheckValue>IN04</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.IE.c1db3fd3"><RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ"><CheckValue>IN05</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.IE.c2ec614b"><RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ"><CheckValue>IN06</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.IE.2ef341aa"><RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ"><CheckValue>IN07</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.IE.5d85184b"><RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ"><CheckValue>IN08</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.IE.8579104c"><RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ"><CheckValue>EX01</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.IE.74eacc45"><RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ"><CheckValue>EX02</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.IE.ce0e8d09"><RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ"><CheckValue>EX03</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.IE.945bafbd"><RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ"><CheckValue>EX04</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.IE.afbec960"><RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ"><CheckValue>EX05</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.IE.cac0d3f4"><RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ"><CheckValue>EX06</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.IE.cabd9be0"><RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ"><CheckValue>EX07</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.IE.fbae7983"><RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ"><CheckValue>EX08</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.IE.0952c014"><RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ"><CheckValue>EX09</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.IE.5b8b02b2"><RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ"><CheckValue>EX10</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.IE.70a941e7"><RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ"><CheckValue>EX11</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.IE.611f5d7b"><RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ"><CheckValue>EX12</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.IE.8abff918"><RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ"><CheckValue>EX13</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.IE.b089a2a0"><RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ"><CheckValue>EX14</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.IE.39cb2456"><RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ"><CheckValue>EX15</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.IE.2cdb5c18"><RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ"><CheckValue>EX16</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.IE.b415f3a9"><RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ"><CheckValue>EX17</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.IE.5c29f970"><RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ"><CheckValue>EX18</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.IE.9fe9a358"><RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ"><CheckValue>EX19</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.IE.e36b210b"><RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ"><CheckValue>EX20</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.IE.743b4fb5"><RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ"><CheckValue>EX21</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.IE.76a82754"><RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ"><CheckValue>EX22</CheckValue></RangeCheck></def:WhereClauseDef><def:WhereClauseDef OID="WC.IE.fbeb5a1e"><RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ"><CheckValue>EX23</CheckValue></RangeCheck></def:WhereClauseDef><ItemGroupDef OID="IG.DS" Name="DS" Domain="DS" SASDatasetName="DS" def:Structure="One record per disposition status or protocol milestone per subject" IsReferenceData="No" Repeating="Yes" Purpose="Tabulation" def:StandardOID="STD.SDTMIG"><Description><TranslatedText xml:lang="en">Disposition</TranslatedText></Description><ItemRef ItemOID="IT.DS.STUDYID" Mandatory="Yes" OrderNumber="1" Role="Identifier" /><ItemRef ItemOID="IT.DS.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier" /><ItemRef ItemOID="IT.DS.USUBJID" Mandatory="Yes" OrderNumber="3" Role="Identifier" /><ItemRef ItemOID="IT.DS.DSSEQ" Mandatory="Yes" OrderNumber="4" Role="Identifier" /><ItemRef ItemOID="IT.DS.DSTERM" Mandatory="Yes" OrderNumber="5" Role="Topic" /><ItemRef ItemOID="IT.DS.DSDECOD" Mandatory="Yes" OrderNumber="6" Role="Synonym Qualifier" /><ItemRef ItemOID="IT.DS.DSCAT" Mandatory="No" OrderNumber="7" Role="Grouping Qualifier" /><ItemRef ItemOID="IT.DS.DSSCAT" Mandatory="No" OrderNumber="8" Role="Grouping Qualifier" /><ItemRef ItemOID="IT.DS.DSSTDTC" Mandatory="No" OrderNumber="9" Role="Timing" /><ItemRef ItemOID="IT.DS.DSSTDY" Mandatory="No" OrderNumber="10" Role="Timing" /><def:Class Name="EVENTS" /><def:leaf ID="LF.DS" xlink:href="ds.ndjson"><def:title>ds.ndjson</def:title></def:leaf></ItemGroupDef><ItemGroupDef OID="IG.DM" Name="DM" Domain="DM" SASDatasetName="DM" def:Structure="One record per subject" IsReferenceData="No" Repeating="No" Purpose="Tabulation" def:StandardOID="STD.SDTMIG"><Description><TranslatedText xml:lang="en">Demographics</TranslatedText></Description><ItemRef ItemOID="IT.DM.STUDYID" Mandatory="Yes" OrderNumber="1" Role="Identifier" /><ItemRef ItemOID="IT.DM.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier" /><ItemRef ItemOID="IT.DM.USUBJID" Mandatory="Yes" OrderNumber="3" Role="Identifier" /><ItemRef ItemOID="IT.DM.SUBJID" Mandatory="Yes" OrderNumber="4" Role="Topic" /><ItemRef ItemOID="IT.DM.RFSTDTC" Mandatory="No" OrderNumber="5" Role="Record Qualifier" /><ItemRef ItemOID="IT.DM.RFENDTC" Mandatory="No" OrderNumber="6" Role="Record Qualifier" /><ItemRef ItemOID="IT.DM.RFXSTDTC" Mandatory="No" OrderNumber="7" Role="Record Qualifier" /><ItemRef ItemOID="IT.DM.RFXENDTC" Mandatory="No" OrderNumber="8" Role="Record Qualifier" /><ItemRef ItemOID="IT.DM.RFICDTC" Mandatory="No" OrderNumber="9" Role="Record Qualifier" /><ItemRef ItemOID="IT.DM.RFPENDTC" Mandatory="No" OrderNumber="10" Role="Record Qualifier" /><ItemRef ItemOID="IT.DM.DTHDTC" Mandatory="No" OrderNumber="11" Role="Record Qualifier" /><ItemRef ItemOID="IT.DM.DTHFL" Mandatory="No" OrderNumber="12" Role="Record Qualifier" /><ItemRef ItemOID="IT.DM.SITEID" Mandatory="Yes" OrderNumber="13" Role="Record Qualifier" /><ItemRef ItemOID="IT.DM.AGE" Mandatory="No" OrderNumber="14" Role="Record Qualifier" /><ItemRef ItemOID="IT.DM.AGEU" Mandatory="No" OrderNumber="15" Role="Variable Qualifier" /><ItemRef ItemOID="IT.DM.SEX" Mandatory="Yes" OrderNumber="16" Role="Record Qualifier" /><ItemRef ItemOID="IT.DM.RACE" Mandatory="No" OrderNumber="17" Role="Record Qualifier" /><ItemRef ItemOID="IT.DM.ETHNIC" Mandatory="No" OrderNumber="18" Role="Record Qualifier" /><ItemRef ItemOID="IT.DM.ARMCD" Mandatory="No" OrderNumber="19" Role="Record Qualifier" /><ItemRef ItemOID="IT.DM.ARM" Mandatory="No" OrderNumber="20" Role="Synonym Qualifier" /><ItemRef ItemOID="IT.DM.ACTARMCD" Mandatory="No" OrderNumber="21" Role="Record Qualifier" /><ItemRef ItemOID="IT.DM.ACTARM" Mandatory="No" OrderNumber="22" Role="Synonym Qualifier" /><ItemRef ItemOID="IT.DM.ARMNRS" Mandatory="No" OrderNumber="23" Role="Record Qualifier" /><ItemRef ItemOID="IT.DM.ACTARMUD" Mandatory="No" OrderNumber="24" Role="Record Qualifier" /><ItemRef ItemOID="IT.DM.COUNTRY" Mandatory="Yes" OrderNumber="25" Role="Record Qualifier" /><ItemRef ItemOID="IT.DM.DMDTC" Mandatory="No" OrderNumber="26" Role="Timing" /><def:Class Name="SPECIAL PURPOSE" /><def:leaf ID="LF.DM" xlink:href="dm.ndjson"><def:title>dm.ndjson</def:title></def:leaf></ItemGroupDef><ItemGroupDef OID="IG.SC" Name="SC" Domain="SC" SASDatasetName="SC" def:Structure="One record per characteristic per visit per subject." IsReferenceData="No" Repeating="Yes" Purpose="Tabulation" def:StandardOID="STD.SDTMIG"><Description><TranslatedText xml:lang="en">Subject Characteristics</TranslatedText></Description><ItemRef ItemOID="IT.SC.STUDYID" Mandatory="Yes" OrderNumber="1" Role="Identifier" /><ItemRef ItemOID="IT.SC.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier" /><ItemRef ItemOID="IT.SC.USUBJID" Mandatory="Yes" OrderNumber="3" Role="Identifier" /><ItemRef ItemOID="IT.SC.SCSEQ" Mandatory="Yes" OrderNumber="4" Role="Identifier" /><ItemRef ItemOID="IT.SC.SCTESTCD" Mandatory="Yes" OrderNumber="5" Role="Topic" /><ItemRef ItemOID="IT.SC.SCTEST" Mandatory="Yes" OrderNumber="6" Role="Synonym Qualifier" /><ItemRef ItemOID="IT.SC.SCORRES" Mandatory="No" OrderNumber="7" Role="Result Qualifier" /><ItemRef ItemOID="IT.SC.SCORRESU" Mandatory="No" OrderNumber="8" Role="Variable Qualifier" /><ItemRef ItemOID="IT.SC.SCSTRESC" Mandatory="No" OrderNumber="9" Role="Result Qualifier" /><ItemRef ItemOID="IT.SC.SCSTRESN" Mandatory="No" OrderNumber="10" Role="Result Qualifier" /><ItemRef ItemOID="IT.SC.SCSTRESU" Mandatory="No" OrderNumber="11" Role="Variable Qualifier" /><ItemRef ItemOID="IT.SC.SCDTC" Mandatory="No" OrderNumber="12" Role="Timing" /><def:Class Name="FINDINGS" /><def:leaf ID="LF.SC" xlink:href="sc.ndjson"><def:title>sc.ndjson</def:title></def:leaf></ItemGroupDef><ItemGroupDef OID="IG.MH" Name="MH" Domain="MH" SASDatasetName="MH" def:Structure="One record per medical history event per subject" IsReferenceData="No" Repeating="Yes" Purpose="Tabulation" def:StandardOID="STD.SDTMIG"><Description><TranslatedText xml:lang="en">Medical History</TranslatedText></Description><ItemRef ItemOID="IT.MH.STUDYID" Mandatory="Yes" OrderNumber="1" Role="Identifier" /><ItemRef ItemOID="IT.MH.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier" /><ItemRef ItemOID="IT.MH.USUBJID" Mandatory="Yes" OrderNumber="3" Role="Identifier" /><ItemRef ItemOID="IT.MH.MHSEQ" Mandatory="Yes" OrderNumber="4" Role="Identifier" /><ItemRef ItemOID="IT.MH.MHTERM" Mandatory="Yes" OrderNumber="5" Role="Topic" /><ItemRef ItemOID="IT.MH.MHDECOD" Mandatory="No" OrderNumber="6" Role="Synonym Qualifier" /><ItemRef ItemOID="IT.MH.MHPRESP" Mandatory="No" OrderNumber="7" Role="Variable Qualifier" /><ItemRef ItemOID="IT.MH.MHOCCUR" Mandatory="No" OrderNumber="8" Role="Record Qualifier" /><ItemRef ItemOID="IT.MH.MHENRF" Mandatory="No" OrderNumber="9" Role="Timing" /><ItemRef ItemOID="IT.MH.MHENRTPT" Mandatory="No" OrderNumber="10" Role="Timing" /><ItemRef ItemOID="IT.MH.MHENTPT" Mandatory="No" OrderNumber="11" Role="Timing" /><def:Class Name="EVENTS" /><def:leaf ID="LF.MH" xlink:href="mh.ndjson"><def:title>mh.ndjson</def:title></def:leaf></ItemGroupDef><ItemGroupDef OID="IG.SU" Name="SU" Domain="SU" SASDatasetName="SU" def:Structure="One record per substance type per reported occurrence per subject" IsReferenceData="No" Repeating="Yes" Purpose="Tabulation" def:StandardOID="STD.SDTMIG"><Description><TranslatedText xml:lang="en">Substance Use</TranslatedText></Description><ItemRef ItemOID="IT.SU.STUDYID" Mandatory="Yes" OrderNumber="1" Role="Identifier" /><ItemRef ItemOID="IT.SU.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier" /><ItemRef ItemOID="IT.SU.USUBJID" Mandatory="Yes" OrderNumber="3" Role="Identifier" /><ItemRef ItemOID="IT.SU.SUSEQ" Mandatory="Yes" OrderNumber="4" Role="Identifier" /><ItemRef ItemOID="IT.SU.SUTRT" Mandatory="Yes" OrderNumber="5" Role="Topic" /><ItemRef ItemOID="IT.SU.SUCAT" Mandatory="No" OrderNumber="6" Role="Grouping Qualifier" /><ItemRef ItemOID="IT.SU.SUSCAT" Mandatory="No" OrderNumber="7" Role="Grouping Qualifier" /><ItemRef ItemOID="IT.SU.SUPRESP" Mandatory="No" OrderNumber="8" Role="Variable Qualifier" /><ItemRef ItemOID="IT.SU.SUOCCUR" Mandatory="No" OrderNumber="9" Role="Record Qualifier" /><ItemRef ItemOID="IT.SU.SUDOSE" Mandatory="No" OrderNumber="10" Role="Record Qualifier" /><ItemRef ItemOID="IT.SU.SUDOSTXT" Mandatory="No" OrderNumber="11" Role="Record Qualifier" /><ItemRef ItemOID="IT.SU.SUDOSU" Mandatory="No" OrderNumber="12" Role="Variable Qualifier" /><ItemRef ItemOID="IT.SU.SUDOSFRQ" Mandatory="No" OrderNumber="13" Role="Variable Qualifier" /><ItemRef ItemOID="IT.SU.SUSTDTC" Mandatory="No" OrderNumber="14" Role="Timing" /><ItemRef ItemOID="IT.SU.SUENDTC" Mandatory="No" OrderNumber="15" Role="Timing" /><ItemRef ItemOID="IT.SU.SUDUR" Mandatory="No" OrderNumber="16" Role="Timing" /><ItemRef ItemOID="IT.SU.SUSTRF" Mandatory="No" OrderNumber="17" Role="Timing" /><ItemRef ItemOID="IT.SU.SUENRF" Mandatory="No" OrderNumber="18" Role="Timing" /><ItemRef ItemOID="IT.SU.SUSTRTPT" Mandatory="No" OrderNumber="19" Role="Timing" /><ItemRef ItemOID="IT.SU.SUSTTPT" Mandatory="No" OrderNumber="20" Role="Timing" /><ItemRef ItemOID="IT.SU.SUENRTPT" Mandatory="No" OrderNumber="21" Role="Timing" /><ItemRef ItemOID="IT.SU.SUENTPT" Mandatory="No" OrderNumber="22" Role="Timing" /><def:Class Name="INTERVENTIONS" /><def:leaf ID="LF.SU" xlink:href="su.ndjson"><def:title>su.ndjson</def:title></def:leaf></ItemGroupDef><ItemGroupDef OID="IG.PR" Name="PR" Domain="PR" SASDatasetName="PR" def:Structure="One record per recorded procedure per occurrence per subject" IsReferenceData="No" Repeating="Yes" Purpose="Tabulation" def:StandardOID="STD.SDTMIG"><Description><TranslatedText xml:lang="en">Procedures</TranslatedText></Description><ItemRef ItemOID="IT.PR.STUDYID" Mandatory="Yes" OrderNumber="1" Role="Identifier" /><ItemRef ItemOID="IT.PR.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier" /><ItemRef ItemOID="IT.PR.USUBJID" Mandatory="Yes" OrderNumber="3" Role="Identifier" /><ItemRef ItemOID="IT.PR.PRSEQ" Mandatory="Yes" OrderNumber="4" Role="Identifier" /><ItemRef ItemOID="IT.PR.PRTRT" Mandatory="Yes" OrderNumber="5" Role="Topic" /><ItemRef ItemOID="IT.PR.PRDECOD" Mandatory="No" OrderNumber="6" Role="Synonym Qualifier" /><ItemRef ItemOID="IT.PR.PRCAT" Mandatory="No" OrderNumber="7" Role="Grouping Qualifier" /><ItemRef ItemOID="IT.PR.PRSCAT" Mandatory="No" OrderNumber="8" Role="Grouping Qualifier" /><ItemRef ItemOID="IT.PR.PRPRESP" Mandatory="No" OrderNumber="9" Role="Variable Qualifier" /><ItemRef ItemOID="IT.PR.PROCCUR" Mandatory="No" OrderNumber="10" Role="Record Qualifier" /><ItemRef ItemOID="IT.PR.PRLOC" Mandatory="No" OrderNumber="11" Role="Record Qualifier" /><ItemRef ItemOID="IT.PR.PRSTDTC" Mandatory="No" OrderNumber="12" Role="Timing" /><ItemRef ItemOID="IT.PR.PRENDTC" Mandatory="No" OrderNumber="13" Role="Timing" /><def:Class Name="INTERVENTIONS" /><def:leaf ID="LF.PR" xlink:href="pr.ndjson"><def:title>pr.ndjson</def:title></def:leaf></ItemGroupDef><ItemGroupDef OID="IG.VS" Name="VS" Domain="VS" SASDatasetName="VS" def:Structure="One record per vital sign measurement per time point per visit per subject" IsReferenceData="No" Repeating="Yes" Purpose="Tabulation" def:StandardOID="STD.SDTMIG"><Description><TranslatedText xml:lang="en">Vital Signs</TranslatedText></Description><ItemRef ItemOID="IT.VS.STUDYID" Mandatory="Yes" OrderNumber="1" Role="Identifier" /><ItemRef ItemOID="IT.VS.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier" /><ItemRef ItemOID="IT.VS.USUBJID" Mandatory="Yes" OrderNumber="3" Role="Identifier" /><ItemRef ItemOID="IT.VS.VSSEQ" Mandatory="Yes" OrderNumber="4" Role="Identifier" /><ItemRef ItemOID="IT.VS.VSTESTCD" Mandatory="Yes" OrderNumber="5" Role="Topic" /><ItemRef ItemOID="IT.VS.VSTEST" Mandatory="Yes" OrderNumber="6" Role="Synonym Qualifier" /><ItemRef ItemOID="IT.VS.VSPOS" Mandatory="No" OrderNumber="7" Role="Record Qualifier" /><ItemRef ItemOID="IT.VS.VSORRES" Mandatory="No" OrderNumber="8" Role="Result Qualifier" /><ItemRef ItemOID="IT.VS.VSORRESU" Mandatory="No" OrderNumber="9" Role="Variable Qualifier" /><ItemRef ItemOID="IT.VS.VSSTRESC" Mandatory="No" OrderNumber="10" Role="Result Qualifier" /><ItemRef ItemOID="IT.VS.VSSTRESN" Mandatory="No" OrderNumber="11" Role="Result Qualifier" /><ItemRef ItemOID="IT.VS.VSSTRESU" Mandatory="No" OrderNumber="12" Role="Variable Qualifier" /><ItemRef ItemOID="IT.VS.VSLOC" Mandatory="No" OrderNumber="13" Role="Record Qualifier" /><ItemRef ItemOID="IT.VS.VSLAT" Mandatory="No" OrderNumber="14" Role="Result Qualifier" /><ItemRef ItemOID="IT.VS.VSLOBXFL" Mandatory="No" OrderNumber="15" Role="Record Qualifier" /><ItemRef ItemOID="IT.VS.VISITNUM" Mandatory="No" OrderNumber="16" Role="Timing" /><ItemRef ItemOID="IT.VS.VSDTC" Mandatory="No" OrderNumber="17" Role="Timing" /><def:Class Name="FINDINGS" /><def:leaf ID="LF.VS" xlink:href="vs.ndjson"><def:title>vs.ndjson</def:title></def:leaf></ItemGroupDef><ItemGroupDef OID="IG.EG" Name="EG" Domain="EG" SASDatasetName="EG" def:Structure="One record per ECG observation per replicate per time point or one record per ECG observation per beat per visit per subject" IsReferenceData="No" Repeating="Yes" Purpose="Tabulation" def:StandardOID="STD.SDTMIG"><Description><TranslatedText xml:lang="en">ECG Test Results</TranslatedText></Description><ItemRef ItemOID="IT.EG.STUDYID" Mandatory="Yes" OrderNumber="1" Role="Identifier" /><ItemRef ItemOID="IT.EG.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier" /><ItemRef ItemOID="IT.EG.USUBJID" Mandatory="Yes" OrderNumber="3" Role="Identifier" /><ItemRef ItemOID="IT.EG.EGSEQ" Mandatory="Yes" OrderNumber="4" Role="Identifier" /><ItemRef ItemOID="IT.EG.EGTESTCD" Mandatory="Yes" OrderNumber="5" Role="Topic" /><ItemRef ItemOID="IT.EG.EGTEST" Mandatory="Yes" OrderNumber="6" Role="Synonym Qualifier" /><ItemRef ItemOID="IT.EG.EGCAT" Mandatory="No" OrderNumber="7" Role="Grouping Qualifier" /><ItemRef ItemOID="IT.EG.EGPOS" Mandatory="No" OrderNumber="8" Role="Record Qualifier" /><ItemRef ItemOID="IT.EG.EGORRES" Mandatory="No" OrderNumber="9" Role="Result Qualifier" /><ItemRef ItemOID="IT.EG.EGORRESU" Mandatory="No" OrderNumber="10" Role="Variable Qualifier" /><ItemRef ItemOID="IT.EG.EGSTRESC" Mandatory="No" OrderNumber="11" Role="Result Qualifier" /><ItemRef ItemOID="IT.EG.EGSTRESN" Mandatory="No" OrderNumber="12" Role="Result Qualifier" /><ItemRef ItemOID="IT.EG.EGSTRESU" Mandatory="No" OrderNumber="13" Role="Variable Qualifier" /><ItemRef ItemOID="IT.EG.EGMETHOD" Mandatory="No" OrderNumber="14" Role="Record Qualifier" /><ItemRef ItemOID="IT.EG.EGLOBXFL" Mandatory="No" OrderNumber="15" Role="Record Qualifier" /><ItemRef ItemOID="IT.EG.EGEVAL" Mandatory="No" OrderNumber="16" Role="Record Qualifier" /><ItemRef ItemOID="IT.EG.EGCLSIG" Mandatory="No" OrderNumber="17" Role="Record Qualifier" /><ItemRef ItemOID="IT.EG.VISITNUM" Mandatory="No" OrderNumber="18" Role="Timing" /><ItemRef ItemOID="IT.EG.EGDTC" Mandatory="No" OrderNumber="19" Role="Timing" /><def:Class Name="FINDINGS" /><def:leaf ID="LF.EG" xlink:href="eg.ndjson"><def:title>eg.ndjson</def:title></def:leaf></ItemGroupDef><ItemGroupDef OID="IG.CM" Name="CM" Domain="CM" SASDatasetName="CM" def:Structure="One record per recorded intervention occurrence or constant-dosing interval per subject" IsReferenceData="No" Repeating="Yes" Purpose="Tabulation" def:StandardOID="STD.SDTMIG"><Description><TranslatedText xml:lang="en">Concomitant/Prior Medications</TranslatedText></Description><ItemRef ItemOID="IT.CM.STUDYID" Mandatory="Yes" OrderNumber="1" Role="Identifier" /><ItemRef ItemOID="IT.CM.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier" /><ItemRef ItemOID="IT.CM.USUBJID" Mandatory="Yes" OrderNumber="3" Role="Identifier" /><ItemRef ItemOID="IT.CM.CMSEQ" Mandatory="Yes" OrderNumber="4" Role="Identifier" /><ItemRef ItemOID="IT.CM.CMTRT" Mandatory="Yes" OrderNumber="5" Role="Topic" /><ItemRef ItemOID="IT.CM.CMDECOD" Mandatory="No" OrderNumber="6" Role="Synonym Qualifier" /><ItemRef ItemOID="IT.CM.CMCAT" Mandatory="No" OrderNumber="7" Role="Grouping Qualifier" /><ItemRef ItemOID="IT.CM.CMSCAT" Mandatory="No" OrderNumber="8" Role="Grouping Qualifier" /><ItemRef ItemOID="IT.CM.CMPRESP" Mandatory="No" OrderNumber="9" Role="Variable Qualifier" /><ItemRef ItemOID="IT.CM.CMOCCUR" Mandatory="No" OrderNumber="10" Role="Record Qualifier" /><ItemRef ItemOID="IT.CM.CMINDC" Mandatory="No" OrderNumber="11" Role="Record Qualifier" /><ItemRef ItemOID="IT.CM.CMDOSE" Mandatory="No" OrderNumber="12" Role="Record Qualifier" /><ItemRef ItemOID="IT.CM.CMDOSU" Mandatory="No" OrderNumber="13" Role="Variable Qualifier" /><ItemRef ItemOID="IT.CM.CMDOSFRM" Mandatory="No" OrderNumber="14" Role="Variable Qualifier" /><ItemRef ItemOID="IT.CM.CMROUTE" Mandatory="No" OrderNumber="15" Role="Variable Qualifier" /><ItemRef ItemOID="IT.CM.CMSTDTC" Mandatory="No" OrderNumber="16" Role="Timing" /><ItemRef ItemOID="IT.CM.CMENDTC" Mandatory="No" OrderNumber="17" Role="Timing" /><def:Class Name="INTERVENTIONS" /><def:leaf ID="LF.CM" xlink:href="cm.ndjson"><def:title>cm.ndjson</def:title></def:leaf></ItemGroupDef><ItemGroupDef OID="IG.LB" Name="LB" Domain="LB" SASDatasetName="LB" def:Structure="One record per lab test per time point per visit per subject" IsReferenceData="No" Repeating="Yes" Purpose="Tabulation" def:StandardOID="STD.SDTMIG"><Description><TranslatedText xml:lang="en">Laboratory Test Results</TranslatedText></Description><ItemRef ItemOID="IT.LB.STUDYID" Mandatory="Yes" OrderNumber="1" Role="Identifier" /><ItemRef ItemOID="IT.LB.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier" /><ItemRef ItemOID="IT.LB.USUBJID" Mandatory="Yes" OrderNumber="3" Role="Identifier" /><ItemRef ItemOID="IT.LB.LBSEQ" Mandatory="Yes" OrderNumber="4" Role="Identifier" /><ItemRef ItemOID="IT.LB.LBTESTCD" Mandatory="Yes" OrderNumber="5" Role="Topic" /><ItemRef ItemOID="IT.LB.LBTEST" Mandatory="Yes" OrderNumber="6" Role="Synonym Qualifier" /><ItemRef ItemOID="IT.LB.LBCAT" Mandatory="No" OrderNumber="7" Role="Grouping Qualifier" /><ItemRef ItemOID="IT.LB.LBORRES" Mandatory="No" OrderNumber="8" Role="Result Qualifier" /><ItemRef ItemOID="IT.LB.LBORRESU" Mandatory="No" OrderNumber="9" Role="Variable Qualifier" /><ItemRef ItemOID="IT.LB.LBORNRLO" Mandatory="No" OrderNumber="10" Role="Variable Qualifier" /><ItemRef ItemOID="IT.LB.LBORNRHI" Mandatory="No" OrderNumber="11" Role="Variable Qualifier" /><ItemRef ItemOID="IT.LB.LBSTRESC" Mandatory="No" OrderNumber="12" Role="Result Qualifier" /><ItemRef ItemOID="IT.LB.LBSTRESN" Mandatory="No" OrderNumber="13" Role="Result Qualifier" /><ItemRef ItemOID="IT.LB.LBSTRESU" Mandatory="No" OrderNumber="14" Role="Variable Qualifier" /><ItemRef ItemOID="IT.LB.LBSTNRLO" Mandatory="No" OrderNumber="15" Role="Variable Qualifier" /><ItemRef ItemOID="IT.LB.LBSTNRHI" Mandatory="No" OrderNumber="16" Role="Variable Qualifier" /><ItemRef ItemOID="IT.LB.LBNRIND" Mandatory="No" OrderNumber="17" Role="Variable Qualifier" /><ItemRef ItemOID="IT.LB.LBSPEC" Mandatory="No" OrderNumber="18" Role="Record Qualifier" /><ItemRef ItemOID="IT.LB.LBMETHOD" Mandatory="No" OrderNumber="19" Role="Record Qualifier" /><ItemRef ItemOID="IT.LB.LBLOBXFL" Mandatory="No" OrderNumber="20" Role="Record Qualifier" /><ItemRef ItemOID="IT.LB.LBFAST" Mandatory="No" OrderNumber="21" Role="Record Qualifier" /><ItemRef ItemOID="IT.LB.VISITNUM" Mandatory="No" OrderNumber="22" Role="Timing" /><ItemRef ItemOID="IT.LB.LBDTC" Mandatory="No" OrderNumber="23" Role="Timing" /><def:Class Name="FINDINGS" /><def:leaf ID="LF.LB" xlink:href="lb.ndjson"><def:title>lb.ndjson</def:title></def:leaf></ItemGroupDef><ItemGroupDef OID="IG.MB" Name="MB" Domain="MB" SASDatasetName="MB" def:Structure="One record per microbiology specimen finding per time point per visit per subject" IsReferenceData="No" Repeating="Yes" Purpose="Tabulation" def:StandardOID="STD.SDTMIG"><Description><TranslatedText xml:lang="en">Microbiology Specimen</TranslatedText></Description><ItemRef ItemOID="IT.MB.STUDYID" Mandatory="Yes" OrderNumber="1" Role="Identifier" /><ItemRef ItemOID="IT.MB.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier" /><ItemRef ItemOID="IT.MB.USUBJID" Mandatory="Yes" OrderNumber="3" Role="Identifier" /><ItemRef ItemOID="IT.MB.MBSEQ" Mandatory="Yes" OrderNumber="4" Role="Identifier" /><ItemRef ItemOID="IT.MB.MBTESTCD" Mandatory="Yes" OrderNumber="5" Role="Topic" /><ItemRef ItemOID="IT.MB.MBTEST" Mandatory="Yes" OrderNumber="6" Role="Synonym Qualifier" /><ItemRef ItemOID="IT.MB.MBTSTDTL" Mandatory="No" OrderNumber="7" Role="Variable Qualifier" /><ItemRef ItemOID="IT.MB.MBORRES" Mandatory="No" OrderNumber="8" Role="Result Qualifier" /><ItemRef ItemOID="IT.MB.MBSTRESC" Mandatory="No" OrderNumber="9" Role="Result Qualifier" /><ItemRef ItemOID="IT.MB.MBSPEC" Mandatory="No" OrderNumber="10" Role="Record Qualifier" /><ItemRef ItemOID="IT.MB.MBMETHOD" Mandatory="No" OrderNumber="11" Role="Record Qualifier" /><ItemRef ItemOID="IT.MB.VISITNUM" Mandatory="No" OrderNumber="12" Role="Timing" /><ItemRef ItemOID="IT.MB.MBDTC" Mandatory="No" OrderNumber="13" Role="Timing" /><def:Class Name="FINDINGS" /><def:leaf ID="LF.MB" xlink:href="mb.ndjson"><def:title>mb.ndjson</def:title></def:leaf></ItemGroupDef><ItemGroupDef OID="IG.EC" Name="EC" Domain="EC" SASDatasetName="EC" def:Structure="One record per protocol-specified study treatment, collected-dosing interval, per subject, per mood" IsReferenceData="No" Repeating="Yes" Purpose="Tabulation" def:StandardOID="STD.SDTMIG"><Description><TranslatedText xml:lang="en">Exposure as Collected</TranslatedText></Description><ItemRef ItemOID="IT.EC.STUDYID" Mandatory="Yes" OrderNumber="1" Role="Identifier" /><ItemRef ItemOID="IT.EC.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier" /><ItemRef ItemOID="IT.EC.USUBJID" Mandatory="Yes" OrderNumber="3" Role="Identifier" /><ItemRef ItemOID="IT.EC.ECSEQ" Mandatory="Yes" OrderNumber="4" Role="Identifier" /><ItemRef ItemOID="IT.EC.ECREFID" Mandatory="No" OrderNumber="5" Role="Identifier" /><ItemRef ItemOID="IT.EC.ECTRT" Mandatory="Yes" OrderNumber="6" Role="Topic" /><ItemRef ItemOID="IT.EC.ECDOSE" Mandatory="No" OrderNumber="7" Role="Record Qualifier" /><ItemRef ItemOID="IT.EC.ECDOSTXT" Mandatory="No" OrderNumber="8" Role="Record Qualifier" /><ItemRef ItemOID="IT.EC.ECDOSU" Mandatory="No" OrderNumber="9" Role="Variable Qualifier" /><ItemRef ItemOID="IT.EC.ECDOSFRM" Mandatory="No" OrderNumber="10" Role="Variable Qualifier" /><ItemRef ItemOID="IT.EC.ECDOSFRQ" Mandatory="No" OrderNumber="11" Role="Record Qualifier" /><ItemRef ItemOID="IT.EC.ECDOSRGM" Mandatory="No" OrderNumber="12" Role="Record Qualifier" /><ItemRef ItemOID="IT.EC.ECROUTE" Mandatory="No" OrderNumber="13" Role="Variable Qualifier" /><ItemRef ItemOID="IT.EC.ECLOC" Mandatory="No" OrderNumber="14" Role="Record Qualifier" /><ItemRef ItemOID="IT.EC.ECLAT" Mandatory="No" OrderNumber="15" Role="Variable Qualifier" /><ItemRef ItemOID="IT.EC.ECDIR" Mandatory="No" OrderNumber="16" Role="Variable Qualifier" /><ItemRef ItemOID="IT.EC.ECSTDTC" Mandatory="No" OrderNumber="17" Role="Timing" /><ItemRef ItemOID="IT.EC.ECENDTC" Mandatory="No" OrderNumber="18" Role="Timing" /><def:Class Name="INTERVENTIONS" /><def:leaf ID="LF.EC" xlink:href="ec.ndjson"><def:title>ec.ndjson</def:title></def:leaf></ItemGroupDef><ItemGroupDef OID="IG.AE" Name="AE" Domain="AE" SASDatasetName="AE" def:Structure="One record per adverse event per subject" IsReferenceData="No" Repeating="Yes" Purpose="Tabulation" def:StandardOID="STD.SDTMIG"><Description><TranslatedText xml:lang="en">Adverse Events</TranslatedText></Description><ItemRef ItemOID="IT.AE.STUDYID" Mandatory="Yes" OrderNumber="1" Role="Identifier" /><ItemRef ItemOID="IT.AE.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier" /><ItemRef ItemOID="IT.AE.USUBJID" Mandatory="Yes" OrderNumber="3" Role="Identifier" /><ItemRef ItemOID="IT.AE.AESEQ" Mandatory="Yes" OrderNumber="4" Role="Identifier" /><ItemRef ItemOID="IT.AE.AETERM" Mandatory="Yes" OrderNumber="5" Role="Topic" /><ItemRef ItemOID="IT.AE.AELLT" Mandatory="No" OrderNumber="6" Role="Variable Qualifier" /><ItemRef ItemOID="IT.AE.AELLTCD" Mandatory="No" OrderNumber="7" Role="Variable Qualifier" /><ItemRef ItemOID="IT.AE.AEDECOD" Mandatory="Yes" OrderNumber="8" Role="Synonym Qualifier" /><ItemRef ItemOID="IT.AE.AEPTCD" Mandatory="No" OrderNumber="9" Role="Variable Qualifier" /><ItemRef ItemOID="IT.AE.AEHLT" Mandatory="No" OrderNumber="10" Role="Variable Qualifier" /><ItemRef ItemOID="IT.AE.AEHLTCD" Mandatory="No" OrderNumber="11" Role="Variable Qualifier" /><ItemRef ItemOID="IT.AE.AEHLGT" Mandatory="No" OrderNumber="12" Role="Variable Qualifier" /><ItemRef ItemOID="IT.AE.AEHLGTCD" Mandatory="No" OrderNumber="13" Role="Variable Qualifier" /><ItemRef ItemOID="IT.AE.AECAT" Mandatory="No" OrderNumber="14" Role="Grouping Qualifier" /><ItemRef ItemOID="IT.AE.AESCAT" Mandatory="No" OrderNumber="15" Role="Grouping Qualifier" /><ItemRef ItemOID="IT.AE.AEPRESP" Mandatory="No" OrderNumber="16" Role="Variable Qualifier" /><ItemRef ItemOID="IT.AE.AEBODSYS" Mandatory="No" OrderNumber="17" Role="Record Qualifier" /><ItemRef ItemOID="IT.AE.AEBDSYCD" Mandatory="No" OrderNumber="18" Role="Variable Qualifier" /><ItemRef ItemOID="IT.AE.AESOC" Mandatory="No" OrderNumber="19" Role="Variable Qualifier" /><ItemRef ItemOID="IT.AE.AESOCCD" Mandatory="No" OrderNumber="20" Role="Variable Qualifier" /><ItemRef ItemOID="IT.AE.AELOC" Mandatory="No" OrderNumber="21" Role="Record Qualifier" /><ItemRef ItemOID="IT.AE.AESEV" Mandatory="No" OrderNumber="22" Role="Record Qualifier" /><ItemRef ItemOID="IT.AE.AESER" Mandatory="No" OrderNumber="23" Role="Record Qualifier" /><ItemRef ItemOID="IT.AE.AEACN" Mandatory="No" OrderNumber="24" Role="Record Qualifier" /><ItemRef ItemOID="IT.AE.AEACNOTH" Mandatory="No" OrderNumber="25" Role="Record Qualifier" /><ItemRef ItemOID="IT.AE.AEREL" Mandatory="No" OrderNumber="26" Role="Record Qualifier" /><ItemRef ItemOID="IT.AE.AERELNST" Mandatory="No" OrderNumber="27" Role="Record Qualifier" /><ItemRef ItemOID="IT.AE.AEPATT" Mandatory="No" OrderNumber="28" Role="Record Qualifier" /><ItemRef ItemOID="IT.AE.AEOUT" Mandatory="No" OrderNumber="29" Role="Record Qualifier" /><ItemRef ItemOID="IT.AE.AESCAN" Mandatory="No" OrderNumber="30" Role="Record Qualifier" /><ItemRef ItemOID="IT.AE.AESCONG" Mandatory="No" OrderNumber="31" Role="Record Qualifier" /><ItemRef ItemOID="IT.AE.AESDISAB" Mandatory="No" OrderNumber="32" Role="Record Qualifier" /><ItemRef ItemOID="IT.AE.AESDTH" Mandatory="No" OrderNumber="33" Role="Record Qualifier" /><ItemRef ItemOID="IT.AE.AESHOSP" Mandatory="No" OrderNumber="34" Role="Record Qualifier" /><ItemRef ItemOID="IT.AE.AESLIFE" Mandatory="No" OrderNumber="35" Role="Record Qualifier" /><ItemRef ItemOID="IT.AE.AESOD" Mandatory="No" OrderNumber="36" Role="Record Qualifier" /><ItemRef ItemOID="IT.AE.AESMIE" Mandatory="No" OrderNumber="37" Role="Record Qualifier" /><ItemRef ItemOID="IT.AE.AECONTRT" Mandatory="No" OrderNumber="38" Role="Record Qualifier" /><ItemRef ItemOID="IT.AE.AETOXGR" Mandatory="No" OrderNumber="39" Role="Record Qualifier" /><ItemRef ItemOID="IT.AE.AESTDTC" Mandatory="No" OrderNumber="40" Role="Timing" /><ItemRef ItemOID="IT.AE.AEENDTC" Mandatory="No" OrderNumber="41" Role="Timing" /><ItemRef ItemOID="IT.AE.AEENRF" Mandatory="No" OrderNumber="42" Role="Timing" /><ItemRef ItemOID="IT.AE.AEENRTPT" Mandatory="No" OrderNumber="43" Role="Timing" /><ItemRef ItemOID="IT.AE.AEENTPT" Mandatory="No" OrderNumber="44" Role="Timing" /><def:Class Name="EVENTS" /><def:leaf ID="LF.AE" xlink:href="ae.ndjson"><def:title>ae.ndjson</def:title></def:leaf></ItemGroupDef><ItemGroupDef OID="IG.TS" Name="TS" Domain="TS" SASDatasetName="TS" def:Structure="One record per trial summary parameter value" IsReferenceData="Yes" Repeating="No" Purpose="Tabulation" def:StandardOID="STD.SDTMIG"><Description><TranslatedText xml:lang="en">Trial Summary</TranslatedText></Description><ItemRef ItemOID="IT.TS.STUDYID" Mandatory="Yes" OrderNumber="1" Role="Identifier" /><ItemRef ItemOID="IT.TS.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier" /><ItemRef ItemOID="IT.TS.TSSEQ" Mandatory="Yes" OrderNumber="3" Role="Identifier" /><ItemRef ItemOID="IT.TS.TSPARMCD" Mandatory="Yes" OrderNumber="4" Role="Topic" /><ItemRef ItemOID="IT.TS.TSPARM" Mandatory="Yes" OrderNumber="5" Role="Synonym Qualifier" /><ItemRef ItemOID="IT.TS.TSVAL" Mandatory="No" OrderNumber="6" Role="Result Qualifier" /><ItemRef ItemOID="IT.TS.TSVALCD" Mandatory="No" OrderNumber="7" Role="Result Qualifier" /><ItemRef ItemOID="IT.TS.TSVCDREF" Mandatory="No" OrderNumber="8" Role="Result Qualifier" /><ItemRef ItemOID="IT.TS.TSVCDVER" Mandatory="No" OrderNumber="9" Role="Result Qualifier" /><def:Class Name="TRIAL DESIGN" /><def:leaf ID="LF.TS" xlink:href="ts.ndjson"><def:title>ts.ndjson</def:title></def:leaf></ItemGroupDef><ItemGroupDef OID="IG.TA" Name="TA" Domain="TA" SASDatasetName="TA" def:Structure="One record per planned Element per Arm" IsReferenceData="Yes" Repeating="No" Purpose="Tabulation" def:StandardOID="STD.SDTMIG"><Description><TranslatedText xml:lang="en">Trial Arms</TranslatedText></Description><ItemRef ItemOID="IT.TA.STUDYID" Mandatory="Yes" OrderNumber="1" Role="Identifier" /><ItemRef ItemOID="IT.TA.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier" /><ItemRef ItemOID="IT.TA.ARMCD" Mandatory="Yes" OrderNumber="3" Role="Topic" /><ItemRef ItemOID="IT.TA.ARM" Mandatory="Yes" OrderNumber="4" Role="Synonym Qualifier" /><ItemRef ItemOID="IT.TA.TAETORD" Mandatory="Yes" OrderNumber="5" Role="Timing" /><ItemRef ItemOID="IT.TA.ETCD" Mandatory="Yes" OrderNumber="6" Role="Record Qualifier" /><ItemRef ItemOID="IT.TA.ELEMENT" Mandatory="No" OrderNumber="7" Role="Synonym Qualifier" /><ItemRef ItemOID="IT.TA.TABRANCH" Mandatory="No" OrderNumber="8" Role="Rule" /><ItemRef ItemOID="IT.TA.TATRANS" Mandatory="No" OrderNumber="9" Role="Rule" /><ItemRef ItemOID="IT.TA.EPOCH" Mandatory="Yes" OrderNumber="10" Role="Timing" /><def:Class Name="TRIAL DESIGN" /><def:leaf ID="LF.TA" xlink:href="ta.ndjson"><def:title>ta.ndjson</def:title></def:leaf></ItemGroupDef><ItemGroupDef OID="IG.TE" Name="TE" Domain="TE" SASDatasetName="TE" def:Structure="One record per planned Element" IsReferenceData="Yes" Repeating="No" Purpose="Tabulation" def:StandardOID="STD.SDTMIG"><Description><TranslatedText xml:lang="en">Trial Elements</TranslatedText></Description><ItemRef ItemOID="IT.TE.STUDYID" Mandatory="Yes" OrderNumber="1" Role="Identifier" /><ItemRef ItemOID="IT.TE.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier" /><ItemRef ItemOID="IT.TE.ETCD" Mandatory="Yes" OrderNumber="3" Role="Topic" /><ItemRef ItemOID="IT.TE.ELEMENT" Mandatory="Yes" OrderNumber="4" Role="Synonym Qualifier" /><ItemRef ItemOID="IT.TE.TESTRL" Mandatory="Yes" OrderNumber="5" Role="Rule" /><def:Class Name="TRIAL DESIGN" /><def:leaf ID="LF.TE" xlink:href="te.ndjson"><def:title>te.ndjson</def:title></def:leaf></ItemGroupDef><ItemGroupDef OID="IG.TI" Name="TI" Domain="TI" SASDatasetName="TI" def:Structure="One record per I/E criterion" IsReferenceData="Yes" Repeating="No" Purpose="Tabulation" def:StandardOID="STD.SDTMIG"><Description><TranslatedText xml:lang="en">Trial Inclusion/Exclusion Criteria</TranslatedText></Description><ItemRef ItemOID="IT.TI.STUDYID" Mandatory="Yes" OrderNumber="1" Role="Identifier" /><ItemRef ItemOID="IT.TI.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier" /><ItemRef ItemOID="IT.TI.IETESTCD" Mandatory="Yes" OrderNumber="3" Role="Topic" /><ItemRef ItemOID="IT.TI.IETEST" Mandatory="Yes" OrderNumber="4" Role="Synonym Qualifier" /><ItemRef ItemOID="IT.TI.IECAT" Mandatory="Yes" OrderNumber="5" Role="Grouping Qualifier" /><def:Class Name="TRIAL DESIGN" /><def:leaf ID="LF.TI" xlink:href="ti.ndjson"><def:title>ti.ndjson</def:title></def:leaf></ItemGroupDef><ItemGroupDef OID="IG.TV" Name="TV" Domain="TV" SASDatasetName="TV" def:Structure="One record per planned Visit per Arm" IsReferenceData="Yes" Repeating="No" Purpose="Tabulation" def:StandardOID="STD.SDTMIG"><Description><TranslatedText xml:lang="en">Trial Visits</TranslatedText></Description><ItemRef ItemOID="IT.TV.STUDYID" Mandatory="Yes" OrderNumber="1" Role="Identifier" /><ItemRef ItemOID="IT.TV.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier" /><ItemRef ItemOID="IT.TV.VISITNUM" Mandatory="Yes" OrderNumber="3" Role="Topic" /><ItemRef ItemOID="IT.TV.VISIT" Mandatory="Yes" OrderNumber="4" Role="Synonym Qualifier" /><ItemRef ItemOID="IT.TV.VISITDY" Mandatory="No" OrderNumber="5" Role="Timing" /><ItemRef ItemOID="IT.TV.ARMCD" Mandatory="No" OrderNumber="6" Role="Record Qualifier" /><ItemRef ItemOID="IT.TV.ARM" Mandatory="No" OrderNumber="7" Role="Synonym Qualifier" /><ItemRef ItemOID="IT.TV.TVSTRL" Mandatory="Yes" OrderNumber="8" Role="Rule" /><ItemRef ItemOID="IT.TV.TVENRL" Mandatory="No" OrderNumber="9" Role="Rule" /><def:Class Name="TRIAL DESIGN" /><def:leaf ID="LF.TV" xlink:href="tv.ndjson"><def:title>tv.ndjson</def:title></def:leaf></ItemGroupDef><ItemGroupDef OID="IG.SV" Name="SV" Domain="SV" SASDatasetName="SV" def:Structure="One record per actual or planned visit per subject" IsReferenceData="No" Repeating="Yes" Purpose="Tabulation" def:StandardOID="STD.SDTMIG"><Description><TranslatedText xml:lang="en">Subject Visits</TranslatedText></Description><ItemRef ItemOID="IT.SV.STUDYID" Mandatory="Yes" OrderNumber="1" Role="Identifier" /><ItemRef ItemOID="IT.SV.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier" /><ItemRef ItemOID="IT.SV.USUBJID" Mandatory="Yes" OrderNumber="3" Role="Identifier" /><ItemRef ItemOID="IT.SV.VISITNUM" Mandatory="Yes" OrderNumber="4" Role="Topic" /><ItemRef ItemOID="IT.SV.VISIT" Mandatory="No" OrderNumber="5" Role="Synonym Qualifier" /><ItemRef ItemOID="IT.SV.SVPRESP" Mandatory="No" OrderNumber="6" Role="Variable Qualifier" /><ItemRef ItemOID="IT.SV.SVOCCUR" Mandatory="No" OrderNumber="7" Role="Record Qualifier" /><ItemRef ItemOID="IT.SV.SVCNTMOD" Mandatory="No" OrderNumber="8" Role="Record Qualifier" /><ItemRef ItemOID="IT.SV.SVSTDTC" Mandatory="No" OrderNumber="9" Role="Timing" /><ItemRef ItemOID="IT.SV.SVENDTC" Mandatory="No" OrderNumber="10" Role="Timing" /><def:Class Name="SPECIAL PURPOSE" /><def:leaf ID="LF.SV" xlink:href="sv.ndjson"><def:title>sv.ndjson</def:title></def:leaf></ItemGroupDef><ItemGroupDef OID="IG.IE" Name="IE" Domain="IE" SASDatasetName="IE" def:Structure="One record per inclusion/exclusion criterion not met per subject" IsReferenceData="No" Repeating="Yes" Purpose="Tabulation" def:StandardOID="STD.SDTMIG"><Description><TranslatedText xml:lang="en">Inclusion/Exclusion Criteria Not Met</TranslatedText></Description><ItemRef ItemOID="IT.IE.STUDYID" Mandatory="Yes" OrderNumber="1" Role="Identifier" /><ItemRef ItemOID="IT.IE.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier" /><ItemRef ItemOID="IT.IE.USUBJID" Mandatory="Yes" OrderNumber="3" Role="Identifier" /><ItemRef ItemOID="IT.IE.IESEQ" Mandatory="Yes" OrderNumber="4" Role="Identifier" /><ItemRef ItemOID="IT.IE.IETESTCD" Mandatory="Yes" OrderNumber="5" Role="Topic" /><ItemRef ItemOID="IT.IE.IETEST" Mandatory="Yes" OrderNumber="6" Role="Synonym Qualifier" /><ItemRef ItemOID="IT.IE.IECAT" Mandatory="Yes" OrderNumber="7" Role="Grouping Qualifier" /><ItemRef ItemOID="IT.IE.IEORRES" Mandatory="Yes" OrderNumber="8" Role="Result Qualifier" /><ItemRef ItemOID="IT.IE.IESTRESC" Mandatory="Yes" OrderNumber="9" Role="Result Qualifier" /><def:Class Name="FINDINGS" /><def:leaf ID="LF.IE" xlink:href="ie.ndjson"><def:title>ie.ndjson</def:title></def:leaf></ItemGroupDef><ItemGroupDef OID="IG.SE" Name="SE" Domain="SE" SASDatasetName="SE" def:Structure="One record per actual Element per subject" IsReferenceData="No" Repeating="Yes" Purpose="Tabulation" def:StandardOID="STD.SDTMIG"><Description><TranslatedText xml:lang="en">Subject Elements</TranslatedText></Description><ItemRef ItemOID="IT.SE.STUDYID" Mandatory="Yes" OrderNumber="1" Role="Identifier" /><ItemRef ItemOID="IT.SE.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier" /><ItemRef ItemOID="IT.SE.USUBJID" Mandatory="Yes" OrderNumber="3" Role="Identifier" /><ItemRef ItemOID="IT.SE.SESEQ" Mandatory="Yes" OrderNumber="4" Role="Identifier" /><ItemRef ItemOID="IT.SE.ETCD" Mandatory="Yes" OrderNumber="5" Role="Topic" /><ItemRef ItemOID="IT.SE.ELEMENT" Mandatory="No" OrderNumber="6" Role="Synonym Qualifier" /><ItemRef ItemOID="IT.SE.EPOCH" Mandatory="No" OrderNumber="7" Role="Timing" /><ItemRef ItemOID="IT.SE.SESTDTC" Mandatory="Yes" OrderNumber="8" Role="Timing" /><ItemRef ItemOID="IT.SE.SEENDTC" Mandatory="No" OrderNumber="9" Role="Timing" /><def:Class Name="SPECIAL PURPOSE" /><def:leaf ID="LF.SE" xlink:href="se.ndjson"><def:title>se.ndjson</def:title></def:leaf></ItemGroupDef><ItemDef OID="IT.DS.STUDYID" Name="STUDYID" DataType="text" SASFieldName="STUDYID" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Study Identifier</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.DS.DOMAIN" Name="DOMAIN" DataType="text" SASFieldName="DOMAIN" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.DS.USUBJID" Name="USUBJID" DataType="text" SASFieldName="USUBJID" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.DS.DSSEQ" Name="DSSEQ" DataType="integer" SASFieldName="DSSEQ" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Sequence Number</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.DS.DSTERM" Name="DSTERM" DataType="text" SASFieldName="DSTERM" Length="200"><Description><TranslatedText xml:lang="en">Reported Term for the Disposition Event</TranslatedText></Description><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.DS.DSDECOD" Name="DSDECOD" DataType="text" SASFieldName="DSDECOD" Length="200"><Description><TranslatedText xml:lang="en">Standardized Disposition Term</TranslatedText></Description><CodeListRef CodeListOID="CL.NCOMPLT" /><def:Origin Type="Assigned" Source="Sponsor" /></ItemDef><ItemDef OID="IT.DS.DSCAT" Name="DSCAT" DataType="text" SASFieldName="DSCAT" Length="200"><Description><TranslatedText xml:lang="en">Category for Disposition Event</TranslatedText></Description><CodeListRef CodeListOID="CL.DSCAT" /><def:Origin Type="Assigned" Source="Sponsor" /></ItemDef><ItemDef OID="IT.DS.DSSCAT" Name="DSSCAT" DataType="text" SASFieldName="DSSCAT" Length="200"><Description><TranslatedText xml:lang="en">Subcategory for Disposition Event</TranslatedText></Description><CodeListRef CodeListOID="CL.DSSCAT" /><def:Origin Type="Assigned" Source="Sponsor" /></ItemDef><ItemDef OID="IT.DS.DSSTDTC" Name="DSSTDTC" DataType="datetime" SASFieldName="DSSTDTC"><Description><TranslatedText xml:lang="en">Start Date/Time of Disposition Event</TranslatedText></Description><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.DS.DSSTDY" Name="DSSTDY" DataType="integer" SASFieldName="DSSTDY" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Study Day of Start of Disposition Event</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.DM.STUDYID" Name="STUDYID" DataType="text" SASFieldName="STUDYID" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Study Identifier</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.DM.DOMAIN" Name="DOMAIN" DataType="text" SASFieldName="DOMAIN" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.DM.USUBJID" Name="USUBJID" DataType="text" SASFieldName="USUBJID" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.DM.SUBJID" Name="SUBJID" DataType="text" SASFieldName="SUBJID" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Subject Identifier for the Study</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.DM.RFSTDTC" Name="RFSTDTC" DataType="datetime" SASFieldName="RFSTDTC"><Description><TranslatedText xml:lang="en">Subject Reference Start Date/Time</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.DM.RFENDTC" Name="RFENDTC" DataType="datetime" SASFieldName="RFENDTC"><Description><TranslatedText xml:lang="en">Subject Reference End Date/Time</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.DM.RFXSTDTC" Name="RFXSTDTC" DataType="datetime" SASFieldName="RFXSTDTC"><Description><TranslatedText xml:lang="en">Date/Time of First Study Treatment</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.DM.RFXENDTC" Name="RFXENDTC" DataType="datetime" SASFieldName="RFXENDTC"><Description><TranslatedText xml:lang="en">Date/Time of Last Study Treatment</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.DM.RFICDTC" Name="RFICDTC" DataType="datetime" SASFieldName="RFICDTC"><Description><TranslatedText xml:lang="en">Date/Time of Informed Consent</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.DM.RFPENDTC" Name="RFPENDTC" DataType="datetime" SASFieldName="RFPENDTC"><Description><TranslatedText xml:lang="en">Date/Time of End of Participation</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.DM.DTHDTC" Name="DTHDTC" DataType="datetime" SASFieldName="DTHDTC"><Description><TranslatedText xml:lang="en">Date/Time of Death</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.DM.DTHFL" Name="DTHFL" DataType="text" SASFieldName="DTHFL" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Subject Death Flag</TranslatedText></Description><CodeListRef CodeListOID="CL.NY" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.DM.SITEID" Name="SITEID" DataType="text" SASFieldName="SITEID" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Study Site Identifier</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.DM.AGE" Name="AGE" DataType="float" SASFieldName="AGE" Length="6" SignificantDigits="2" def:DisplayFormat="3.2"><Description><TranslatedText xml:lang="en">Age</TranslatedText></Description><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.DM.AGEU" Name="AGEU" DataType="text" SASFieldName="AGEU" Length="20"><Description><TranslatedText xml:lang="en">Age Units</TranslatedText></Description><CodeListRef CodeListOID="CL.AGEU" /><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.DM.SEX" Name="SEX" DataType="text" SASFieldName="SEX" Length="100"><Description><TranslatedText xml:lang="en">Sex</TranslatedText></Description><CodeListRef CodeListOID="CL.SEX" /><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.DM.RACE" Name="RACE" DataType="text" SASFieldName="RACE" Length="100"><Description><TranslatedText xml:lang="en">Race</TranslatedText></Description><CodeListRef CodeListOID="CL.RACE" /><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.DM.ETHNIC" Name="ETHNIC" DataType="text" SASFieldName="ETHNIC" Length="100"><Description><TranslatedText xml:lang="en">Ethnicity</TranslatedText></Description><CodeListRef CodeListOID="CL.ETHNIC" /><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.DM.ARMCD" Name="ARMCD" DataType="text" SASFieldName="ARMCD" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Planned Arm Code</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.DM.ARM" Name="ARM" DataType="text" SASFieldName="ARM" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Description of Planned Arm</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.DM.ACTARMCD" Name="ACTARMCD" DataType="text" SASFieldName="ACTARMCD" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Actual Arm Code</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.DM.ACTARM" Name="ACTARM" DataType="text" SASFieldName="ACTARM" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Description of Actual Arm</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.DM.ARMNRS" Name="ARMNRS" DataType="text" SASFieldName="ARMNRS" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Reason Arm and/or Actual Arm is Null</TranslatedText></Description><CodeListRef CodeListOID="CL.ARMNULRS" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.DM.ACTARMUD" Name="ACTARMUD" DataType="text" SASFieldName="ACTARMUD" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Description of Unplanned Actual Arm</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.DM.COUNTRY" Name="COUNTRY" DataType="text" SASFieldName="COUNTRY" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Country</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.DM.DMDTC" Name="DMDTC" DataType="datetime" SASFieldName="DMDTC"><Description><TranslatedText xml:lang="en">Date/Time of Collection</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.SC.STUDYID" Name="STUDYID" DataType="text" SASFieldName="STUDYID" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Study Identifier</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.SC.DOMAIN" Name="DOMAIN" DataType="text" SASFieldName="DOMAIN" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.SC.USUBJID" Name="USUBJID" DataType="text" SASFieldName="USUBJID" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.SC.SCSEQ" Name="SCSEQ" DataType="integer" SASFieldName="SCSEQ" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Sequence Number</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.SC.SCTESTCD" Name="SCTESTCD" DataType="text" SASFieldName="SCTESTCD" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Subject Characteristic Short Name</TranslatedText></Description><CodeListRef CodeListOID="CL.SCTESTCD" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.SC.SCTEST" Name="SCTEST" DataType="text" SASFieldName="SCTEST" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Subject Characteristic</TranslatedText></Description><CodeListRef CodeListOID="CL.SCTEST" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.SC.SCORRES" Name="SCORRES" DataType="text" SASFieldName="SCORRES" Length="100"><Description><TranslatedText xml:lang="en">Result or Finding in Original Units</TranslatedText></Description><def:ValueListRef ValueListOID="VL.SC.SCORRES" /><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.SC.SCORRESU" Name="SCORRESU" DataType="text" SASFieldName="SCORRESU" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Original Units</TranslatedText></Description><CodeListRef CodeListOID="CL.UNIT" /><def:ValueListRef ValueListOID="VL.SC.SCORRESU" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.SC.SCSTRESC" Name="SCSTRESC" DataType="text" SASFieldName="SCSTRESC" Length="100"><Description><TranslatedText xml:lang="en">Character Result/Finding in Std Format</TranslatedText></Description><def:Origin Type="Assigned" Source="Sponsor" /></ItemDef><ItemDef OID="IT.SC.SCSTRESN" Name="SCSTRESN" DataType="text" SASFieldName="SCSTRESN" Length="100"><Description><TranslatedText xml:lang="en">Numeric Result/Finding in Standard Units</TranslatedText></Description><def:Origin Type="Assigned" Source="Sponsor" /></ItemDef><ItemDef OID="IT.SC.SCSTRESU" Name="SCSTRESU" DataType="text" SASFieldName="SCSTRESU" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Standard Units</TranslatedText></Description><CodeListRef CodeListOID="CL.UNIT" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.SC.SCDTC" Name="SCDTC" DataType="datetime" SASFieldName="SCDTC"><Description><TranslatedText xml:lang="en">Date/Time of Collection</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.SC.SCORRES.EDULEVEL" Name="SCORRES" DataType="float" SASFieldName="SCORRES" Length="4" SignificantDigits="1" def:DisplayFormat="3.1"><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.SC.SCORRES.EDUYRNUM" Name="SCORRES" DataType="float" SASFieldName="SCORRES" Length="4" SignificantDigits="1" def:DisplayFormat="3.1"><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.SC.SCORRESU.EDUYRNUM" Name="SCORRESU" DataType="text" SASFieldName="SCORRESU" Length="__PLACEHOLDER__" /><ItemDef OID="IT.MH.STUDYID" Name="STUDYID" DataType="text" SASFieldName="STUDYID" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Study Identifier</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.MH.DOMAIN" Name="DOMAIN" DataType="text" SASFieldName="DOMAIN" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.MH.USUBJID" Name="USUBJID" DataType="text" SASFieldName="USUBJID" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.MH.MHSEQ" Name="MHSEQ" DataType="integer" SASFieldName="MHSEQ" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Sequence Number</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.MH.MHTERM" Name="MHTERM" DataType="text" SASFieldName="MHTERM" Length="200"><Description><TranslatedText xml:lang="en">Reported Term for the Medical History</TranslatedText></Description><def:Origin Type="Assigned" Source="Sponsor" /></ItemDef><ItemDef OID="IT.MH.MHDECOD" Name="MHDECOD" DataType="text" SASFieldName="MHDECOD" Length="200"><Description><TranslatedText xml:lang="en">Dictionary-Derived Term</TranslatedText></Description><def:Origin Type="Assigned" Source="Sponsor" /></ItemDef><ItemDef OID="IT.MH.MHPRESP" Name="MHPRESP" DataType="text" SASFieldName="MHPRESP" Length="1"><Description><TranslatedText xml:lang="en">Medical History Event Pre-Specified</TranslatedText></Description><CodeListRef CodeListOID="CL.NY" /><def:Origin Type="Assigned" Source="Sponsor" /></ItemDef><ItemDef OID="IT.MH.MHOCCUR" Name="MHOCCUR" DataType="text" SASFieldName="MHOCCUR" Length="1"><Description><TranslatedText xml:lang="en">Medical History Occurrence</TranslatedText></Description><CodeListRef CodeListOID="CL.NY" /><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.MH.MHENRF" Name="MHENRF" DataType="text" SASFieldName="MHENRF" Length="20"><Description><TranslatedText xml:lang="en">End Relative to Reference Period</TranslatedText></Description><CodeListRef CodeListOID="CL.STENRF" /><def:Origin Type="Assigned" Source="Sponsor" /></ItemDef><ItemDef OID="IT.MH.MHENRTPT" Name="MHENRTPT" DataType="text" SASFieldName="MHENRTPT" Length="20"><Description><TranslatedText xml:lang="en">End Relative to Reference Time Point</TranslatedText></Description><CodeListRef CodeListOID="CL.STENRF" /><def:Origin Type="Assigned" Source="Sponsor" /></ItemDef><ItemDef OID="IT.MH.MHENTPT" Name="MHENTPT" DataType="text" SASFieldName="MHENTPT" Length="20"><Description><TranslatedText xml:lang="en">End Reference Time Point</TranslatedText></Description><def:Origin Type="Assigned" Source="Sponsor" /></ItemDef><ItemDef OID="IT.SU.STUDYID" Name="STUDYID" DataType="text" SASFieldName="STUDYID" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Study Identifier</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.SU.DOMAIN" Name="DOMAIN" DataType="text" SASFieldName="DOMAIN" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.SU.USUBJID" Name="USUBJID" DataType="text" SASFieldName="USUBJID" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.SU.SUSEQ" Name="SUSEQ" DataType="integer" SASFieldName="SUSEQ" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Sequence Number</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.SU.SUTRT" Name="SUTRT" DataType="text" SASFieldName="SUTRT" Length="200"><Description><TranslatedText xml:lang="en">Reported Name of Substance</TranslatedText></Description><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.SU.SUCAT" Name="SUCAT" DataType="text" SASFieldName="SUCAT" Length="200"><Description><TranslatedText xml:lang="en">Category for Substance Use</TranslatedText></Description><def:Origin Type="Assigned" Source="Sponsor" /></ItemDef><ItemDef OID="IT.SU.SUSCAT" Name="SUSCAT" DataType="text" SASFieldName="SUSCAT" Length="200"><Description><TranslatedText xml:lang="en">Subcategory for Substance Use</TranslatedText></Description><def:Origin Type="Assigned" Source="Sponsor" /></ItemDef><ItemDef OID="IT.SU.SUPRESP" Name="SUPRESP" DataType="text" SASFieldName="SUPRESP" Length="1"><Description><TranslatedText xml:lang="en">SU Pre-Specified</TranslatedText></Description><CodeListRef CodeListOID="CL.NY" /><def:Origin Type="Assigned" Source="Sponsor" /></ItemDef><ItemDef OID="IT.SU.SUOCCUR" Name="SUOCCUR" DataType="text" SASFieldName="SUOCCUR" Length="1"><Description><TranslatedText xml:lang="en">SU Occurrence</TranslatedText></Description><CodeListRef CodeListOID="CL.NY" /><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.SU.SUDOSE" Name="SUDOSE" DataType="float" SASFieldName="SUDOSE" Length="12" SignificantDigits="4" def:DisplayFormat="12.4"><Description><TranslatedText xml:lang="en">Substance Use Consumption</TranslatedText></Description><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.SU.SUDOSTXT" Name="SUDOSTXT" DataType="text" SASFieldName="SUDOSTXT" Length="40"><Description><TranslatedText xml:lang="en">Substance Use Consumption Text</TranslatedText></Description><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.SU.SUDOSU" Name="SUDOSU" DataType="text" SASFieldName="SUDOSU" Length="40"><Description><TranslatedText xml:lang="en">Consumption Units</TranslatedText></Description><CodeListRef CodeListOID="CL.UNIT" /><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.SU.SUDOSFRQ" Name="SUDOSFRQ" DataType="text" SASFieldName="SUDOSFRQ" Length="40"><Description><TranslatedText xml:lang="en">Use Frequency Per Interval</TranslatedText></Description><CodeListRef CodeListOID="CL.FREQ" /><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.SU.SUSTDTC" Name="SUSTDTC" DataType="datetime" SASFieldName="SUSTDTC"><Description><TranslatedText xml:lang="en">Start Date/Time of Substance Use</TranslatedText></Description><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.SU.SUENDTC" Name="SUENDTC" DataType="datetime" SASFieldName="SUENDTC"><Description><TranslatedText xml:lang="en">End Date/Time of Substance Use</TranslatedText></Description><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.SU.SUDUR" Name="SUDUR" DataType="durationDatetime" SASFieldName="SUDUR"><Description><TranslatedText xml:lang="en">Duration of Substance Use</TranslatedText></Description><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.SU.SUSTRF" Name="SUSTRF" DataType="text" SASFieldName="SUSTRF" Length="20"><Description><TranslatedText xml:lang="en">Start Relative to Reference Period</TranslatedText></Description><CodeListRef CodeListOID="CL.STENRF" /><def:Origin Type="Assigned" Source="Sponsor" /></ItemDef><ItemDef OID="IT.SU.SUENRF" Name="SUENRF" DataType="text" SASFieldName="SUENRF" Length="20"><Description><TranslatedText xml:lang="en">End Relative to Reference Period</TranslatedText></Description><CodeListRef CodeListOID="CL.STENRF" /><def:Origin Type="Assigned" Source="Sponsor" /></ItemDef><ItemDef OID="IT.SU.SUSTRTPT" Name="SUSTRTPT" DataType="text" SASFieldName="SUSTRTPT" Length="20"><Description><TranslatedText xml:lang="en">Start Relative to Reference Time Point</TranslatedText></Description><CodeListRef CodeListOID="CL.STENRF" /><def:Origin Type="Assigned" Source="Sponsor" /></ItemDef><ItemDef OID="IT.SU.SUSTTPT" Name="SUSTTPT" DataType="text" SASFieldName="SUSTTPT" Length="20"><Description><TranslatedText xml:lang="en">Start Reference Time Point</TranslatedText></Description><def:Origin Type="Assigned" Source="Sponsor" /></ItemDef><ItemDef OID="IT.SU.SUENRTPT" Name="SUENRTPT" DataType="text" SASFieldName="SUENRTPT" Length="20"><Description><TranslatedText xml:lang="en">End Relative to Reference Time Point</TranslatedText></Description><CodeListRef CodeListOID="CL.STENRF" /><def:Origin Type="Assigned" Source="Sponsor" /></ItemDef><ItemDef OID="IT.SU.SUENTPT" Name="SUENTPT" DataType="text" SASFieldName="SUENTPT" Length="20"><Description><TranslatedText xml:lang="en">End Reference Time Point</TranslatedText></Description><def:Origin Type="Assigned" Source="Sponsor" /></ItemDef><ItemDef OID="IT.PR.STUDYID" Name="STUDYID" DataType="text" SASFieldName="STUDYID" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Study Identifier</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.PR.DOMAIN" Name="DOMAIN" DataType="text" SASFieldName="DOMAIN" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.PR.USUBJID" Name="USUBJID" DataType="text" SASFieldName="USUBJID" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.PR.PRSEQ" Name="PRSEQ" DataType="integer" SASFieldName="PRSEQ" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Sequence Number</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.PR.PRTRT" Name="PRTRT" DataType="text" SASFieldName="PRTRT" Length="200"><Description><TranslatedText xml:lang="en">Reported Name of Procedure</TranslatedText></Description><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.PR.PRDECOD" Name="PRDECOD" DataType="text" SASFieldName="PRDECOD" Length="200"><Description><TranslatedText xml:lang="en">Standardized Procedure Name</TranslatedText></Description><CodeListRef CodeListOID="CL.PROCEDUR" /><def:Origin Type="Assigned" Source="Sponsor" /></ItemDef><ItemDef OID="IT.PR.PRCAT" Name="PRCAT" DataType="text" SASFieldName="PRCAT" Length="200"><Description><TranslatedText xml:lang="en">Category</TranslatedText></Description><def:Origin Type="Assigned" Source="Sponsor" /></ItemDef><ItemDef OID="IT.PR.PRSCAT" Name="PRSCAT" DataType="text" SASFieldName="PRSCAT" Length="200"><Description><TranslatedText xml:lang="en">Subcategory</TranslatedText></Description><def:Origin Type="Assigned" Source="Sponsor" /></ItemDef><ItemDef OID="IT.PR.PRPRESP" Name="PRPRESP" DataType="text" SASFieldName="PRPRESP" Length="1"><Description><TranslatedText xml:lang="en">Pre-specified</TranslatedText></Description><CodeListRef CodeListOID="CL.NY" /><def:Origin Type="Assigned" Source="Sponsor" /></ItemDef><ItemDef OID="IT.PR.PROCCUR" Name="PROCCUR" DataType="text" SASFieldName="PROCCUR" Length="1"><Description><TranslatedText xml:lang="en">Occurrence</TranslatedText></Description><CodeListRef CodeListOID="CL.NY" /><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.PR.PRLOC" Name="PRLOC" DataType="text" SASFieldName="PRLOC" Length="200"><Description><TranslatedText xml:lang="en">Location of Procedure</TranslatedText></Description><CodeListRef CodeListOID="CL.LOC" /><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.PR.PRSTDTC" Name="PRSTDTC" DataType="datetime" SASFieldName="PRSTDTC"><Description><TranslatedText xml:lang="en">Start Date/Time of Procedure</TranslatedText></Description><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.PR.PRENDTC" Name="PRENDTC" DataType="datetime" SASFieldName="PRENDTC"><Description><TranslatedText xml:lang="en">End Date/Time of Procedure</TranslatedText></Description><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.VS.STUDYID" Name="STUDYID" DataType="text" SASFieldName="STUDYID" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Study Identifier</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.VS.DOMAIN" Name="DOMAIN" DataType="text" SASFieldName="DOMAIN" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.VS.USUBJID" Name="USUBJID" DataType="text" SASFieldName="USUBJID" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.VS.VSSEQ" Name="VSSEQ" DataType="integer" SASFieldName="VSSEQ" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Sequence Number</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.VS.VSTESTCD" Name="VSTESTCD" DataType="text" SASFieldName="VSTESTCD" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Vital Signs Test Short Name</TranslatedText></Description><CodeListRef CodeListOID="CL.VSTESTCD" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.VS.VSTEST" Name="VSTEST" DataType="text" SASFieldName="VSTEST" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Vital Signs Test Name</TranslatedText></Description><CodeListRef CodeListOID="CL.VSTEST" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.VS.VSPOS" Name="VSPOS" DataType="text" SASFieldName="VSPOS" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Vital Signs Position of Subject</TranslatedText></Description><CodeListRef CodeListOID="CL.POSITION" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.VS.VSORRES" Name="VSORRES" DataType="float" SASFieldName="VSORRES" Length="8" SignificantDigits="3" def:DisplayFormat="8.3"><Description><TranslatedText xml:lang="en">Result or Finding in Original Units</TranslatedText></Description><def:ValueListRef ValueListOID="VL.VS.VSORRES" /><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.VS.VSORRESU" Name="VSORRESU" DataType="text" SASFieldName="VSORRESU" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Original Units</TranslatedText></Description><CodeListRef CodeListOID="CL.VSRESU" /><def:ValueListRef ValueListOID="VL.VS.VSORRESU" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.VS.VSSTRESC" Name="VSSTRESC" DataType="float" SASFieldName="VSSTRESC" Length="8" SignificantDigits="3" def:DisplayFormat="8.3"><Description><TranslatedText xml:lang="en">Character Result/Finding in Std Format</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.VS.VSSTRESN" Name="VSSTRESN" DataType="float" SASFieldName="VSSTRESN" Length="8" SignificantDigits="3" def:DisplayFormat="8.3"><Description><TranslatedText xml:lang="en">Numeric Result/Finding in Standard Units</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.VS.VSSTRESU" Name="VSSTRESU" DataType="text" SASFieldName="VSSTRESU" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Standard Units</TranslatedText></Description><CodeListRef CodeListOID="CL.VSRESU" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.VS.VSLOC" Name="VSLOC" DataType="text" SASFieldName="VSLOC" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Location of Vital Signs Measurement</TranslatedText></Description><CodeListRef CodeListOID="CL.LOC" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.VS.VSLAT" Name="VSLAT" DataType="text" SASFieldName="VSLAT" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Laterality</TranslatedText></Description><CodeListRef CodeListOID="CL.LAT" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.VS.VSLOBXFL" Name="VSLOBXFL" DataType="text" SASFieldName="VSLOBXFL" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Last Observation Before Exposure Flag</TranslatedText></Description><CodeListRef CodeListOID="CL.NY" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.VS.VISITNUM" Name="VISITNUM" DataType="integer" SASFieldName="VISITNUM" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Visit Number</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.VS.VSDTC" Name="VSDTC" DataType="datetime" SASFieldName="VSDTC"><Description><TranslatedText xml:lang="en">Date/Time of Measurements</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.VS.VSORRES.TEMP" Name="VSORRES" DataType="float" SASFieldName="VSORRES" Length="8" SignificantDigits="3" def:DisplayFormat="8.3"><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.VS.VSORRES.WEIGHT" Name="VSORRES" DataType="float" SASFieldName="VSORRES" Length="8" SignificantDigits="3" def:DisplayFormat="8.3"><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.VS.VSORRES.HEIGHT" Name="VSORRES" DataType="float" SASFieldName="VSORRES" Length="8" SignificantDigits="3" def:DisplayFormat="8.3"><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.VS.VSORRES.PULSE" Name="VSORRES" DataType="integer" SASFieldName="VSORRES" Length="3"><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.VS.VSORRES.RESP" Name="VSORRES" DataType="integer" SASFieldName="VSORRES" Length="3"><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.VS.VSORRES.BMI" Name="VSORRES" DataType="float" SASFieldName="VSORRES" Length="8" def:DisplayFormat="8.3"><def:Origin Type="Derived" Source="Sponsor" /></ItemDef><ItemDef OID="IT.VS.VSORRES.SYSBP" Name="VSORRES" DataType="integer" SASFieldName="VSORRES" Length="3"><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.VS.VSORRES.DIABP" Name="VSORRES" DataType="integer" SASFieldName="VSORRES" Length="3"><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.VS.VSORRES.HR" Name="VSORRES" DataType="integer" SASFieldName="VSORRES" Length="3"><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.VS.VSORRESU.TEMP" Name="VSORRESU" DataType="text" SASFieldName="VSORRESU" Length="__PLACEHOLDER__" /><ItemDef OID="IT.VS.VSORRESU.WEIGHT" Name="VSORRESU" DataType="text" SASFieldName="VSORRESU" Length="__PLACEHOLDER__" /><ItemDef OID="IT.VS.VSORRESU.HEIGHT" Name="VSORRESU" DataType="text" SASFieldName="VSORRESU" Length="__PLACEHOLDER__" /><ItemDef OID="IT.VS.VSORRESU.PULSE" Name="VSORRESU" DataType="text" SASFieldName="VSORRESU" Length="__PLACEHOLDER__" /><ItemDef OID="IT.VS.VSORRESU.RESP" Name="VSORRESU" DataType="text" SASFieldName="VSORRESU" Length="__PLACEHOLDER__" /><ItemDef OID="IT.VS.VSORRESU.BMI" Name="VSORRESU" DataType="text" SASFieldName="VSORRESU" Length="__PLACEHOLDER__" /><ItemDef OID="IT.VS.VSORRESU.SYSBP" Name="VSORRESU" DataType="text" SASFieldName="VSORRESU" Length="__PLACEHOLDER__" /><ItemDef OID="IT.VS.VSORRESU.DIABP" Name="VSORRESU" DataType="text" SASFieldName="VSORRESU" Length="__PLACEHOLDER__" /><ItemDef OID="IT.VS.VSORRESU.HR" Name="VSORRESU" DataType="text" SASFieldName="VSORRESU" Length="__PLACEHOLDER__" /><ItemDef OID="IT.EG.STUDYID" Name="STUDYID" DataType="text" SASFieldName="STUDYID" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Study Identifier</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.EG.DOMAIN" Name="DOMAIN" DataType="text" SASFieldName="DOMAIN" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.EG.USUBJID" Name="USUBJID" DataType="text" SASFieldName="USUBJID" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.EG.EGSEQ" Name="EGSEQ" DataType="integer" SASFieldName="EGSEQ" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Sequence Number</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.EG.EGTESTCD" Name="EGTESTCD" DataType="text" SASFieldName="EGTESTCD" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">ECG Test or Examination Short Name</TranslatedText></Description><CodeListRef CodeListOID="CL.EGTESTCD" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.EG.EGTEST" Name="EGTEST" DataType="text" SASFieldName="EGTEST" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">ECG Test or Examination Name</TranslatedText></Description><CodeListRef CodeListOID="CL.EGTEST" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.EG.EGCAT" Name="EGCAT" DataType="text" SASFieldName="EGCAT" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Category for ECG</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.EG.EGPOS" Name="EGPOS" DataType="text" SASFieldName="EGPOS" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">ECG Position of Subject</TranslatedText></Description><CodeListRef CodeListOID="CL.POSITION" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.EG.EGORRES" Name="EGORRES" DataType="text" SASFieldName="EGORRES" Length="20"><Description><TranslatedText xml:lang="en">Result or Finding in Original Units</TranslatedText></Description><def:ValueListRef ValueListOID="VL.EG.EGORRES" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.EG.EGORRESU" Name="EGORRESU" DataType="text" SASFieldName="EGORRESU" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Original Units</TranslatedText></Description><CodeListRef CodeListOID="CL.UNIT" /><def:ValueListRef ValueListOID="VL.EG.EGORRESU" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.EG.EGSTRESC" Name="EGSTRESC" DataType="text" SASFieldName="EGSTRESC" Length="20"><Description><TranslatedText xml:lang="en">Character Result/Finding in Std Format</TranslatedText></Description><CodeListRef CodeListOID="CL.EGSTRESC" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.EG.EGSTRESN" Name="EGSTRESN" DataType="float" SASFieldName="EGSTRESN" Length="8" SignificantDigits="3" def:DisplayFormat="8.3"><Description><TranslatedText xml:lang="en">Numeric Result/Finding in Standard Units</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.EG.EGSTRESU" Name="EGSTRESU" DataType="text" SASFieldName="EGSTRESU" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Standard Units</TranslatedText></Description><CodeListRef CodeListOID="CL.UNIT" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.EG.EGMETHOD" Name="EGMETHOD" DataType="text" SASFieldName="EGMETHOD" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Method of Test or Examination</TranslatedText></Description><CodeListRef CodeListOID="CL.EGMETHOD" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.EG.EGLOBXFL" Name="EGLOBXFL" DataType="text" SASFieldName="EGLOBXFL" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Last Observation Before Exposure Flag</TranslatedText></Description><CodeListRef CodeListOID="CL.NY" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.EG.EGEVAL" Name="EGEVAL" DataType="text" SASFieldName="EGEVAL" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Evaluator</TranslatedText></Description><CodeListRef CodeListOID="CL.EVAL" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.EG.EGCLSIG" Name="EGCLSIG" DataType="text" SASFieldName="EGCLSIG" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Clinically Significant, Collected</TranslatedText></Description><CodeListRef CodeListOID="CL.NY" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.EG.VISITNUM" Name="VISITNUM" DataType="integer" SASFieldName="VISITNUM" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Visit Number</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.EG.EGDTC" Name="EGDTC" DataType="datetime" SASFieldName="EGDTC"><Description><TranslatedText xml:lang="en">Date/Time of ECG</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.EG.EGORRES.INTP" Name="EGORRES" DataType="text" SASFieldName="EGORRES" Length="20" /><ItemDef OID="IT.EG.EGORRES.AVCOND" Name="EGORRES" DataType="text" SASFieldName="EGORRES" Length="8" SignificantDigits="3" def:DisplayFormat="8.3" /><ItemDef OID="IT.EG.EGORRES.AXISVOLT" Name="EGORRES" DataType="text" SASFieldName="EGORRES" Length="8" SignificantDigits="3" def:DisplayFormat="8.3" /><ItemDef OID="IT.EG.EGORRES.CHYPTENL" Name="EGORRES" DataType="text" SASFieldName="EGORRES" Length="8" SignificantDigits="3" def:DisplayFormat="8.3" /><ItemDef OID="IT.EG.EGORRES.TECHQUAL" Name="EGORRES" DataType="text" SASFieldName="EGORRES" Length="200" /><ItemDef OID="IT.EG.EGORRES.IVTIACD" Name="EGORRES" DataType="text" SASFieldName="EGORRES" Length="8" SignificantDigits="3" def:DisplayFormat="8.3" /><ItemDef OID="IT.EG.EGORRES.PACEMAKR" Name="EGORRES" DataType="text" SASFieldName="EGORRES" Length="8" SignificantDigits="3" def:DisplayFormat="8.3" /><ItemDef OID="IT.EG.EGORRES.RHYNOS" Name="EGORRES" DataType="text" SASFieldName="EGORRES" Length="8" SignificantDigits="3" def:DisplayFormat="8.3" /><ItemDef OID="IT.EG.EGORRES.SNRARRY" Name="EGORRES" DataType="text" SASFieldName="EGORRES" Length="8" SignificantDigits="3" def:DisplayFormat="8.3" /><ItemDef OID="IT.EG.EGORRES.SPRARRY" Name="EGORRES" DataType="text" SASFieldName="EGORRES" Length="8" SignificantDigits="3" def:DisplayFormat="8.3" /><ItemDef OID="IT.EG.EGORRES.SPRTARRY" Name="EGORRES" DataType="text" SASFieldName="EGORRES" Length="8" SignificantDigits="3" def:DisplayFormat="8.3" /><ItemDef OID="IT.EG.EGORRES.VTARRY" Name="EGORRES" DataType="text" SASFieldName="EGORRES" Length="8" SignificantDigits="3" def:DisplayFormat="8.3" /><ItemDef OID="IT.EG.EGORRES.VTTARRY" Name="EGORRES" DataType="text" SASFieldName="EGORRES" Length="8" SignificantDigits="3" def:DisplayFormat="8.3" /><ItemDef OID="IT.EG.EGORRES.PRAG" Name="EGORRES" DataType="text" SASFieldName="EGORRES" Length="8" SignificantDigits="3" def:DisplayFormat="8.3" /><ItemDef OID="IT.EG.EGORRES.QRSAG" Name="EGORRES" DataType="text" SASFieldName="EGORRES" Length="8" SignificantDigits="3" def:DisplayFormat="8.3" /><ItemDef OID="IT.EG.EGORRES.QTAG" Name="EGORRES" DataType="text" SASFieldName="EGORRES" Length="8" SignificantDigits="3" def:DisplayFormat="8.3" /><ItemDef OID="IT.EG.EGORRES.QTCBAG" Name="EGORRES" DataType="text" SASFieldName="EGORRES" Length="8" SignificantDigits="3" def:DisplayFormat="8.3" /><ItemDef OID="IT.EG.EGORRES.QTCFAG" Name="EGORRES" DataType="text" SASFieldName="EGORRES" Length="8" SignificantDigits="3" def:DisplayFormat="8.3" /><ItemDef OID="IT.EG.EGORRES.RRAG" Name="EGORRES" DataType="text" SASFieldName="EGORRES" Length="8" SignificantDigits="3" def:DisplayFormat="8.3" /><ItemDef OID="IT.EG.EGORRES.EGHRMN" Name="EGORRES" DataType="text" SASFieldName="EGORRES" Length="8" SignificantDigits="3" def:DisplayFormat="8.3" /><ItemDef OID="IT.EG.EGORRES.QRS_AXIS" Name="EGORRES" DataType="text" SASFieldName="EGORRES" Length="8" SignificantDigits="3" def:DisplayFormat="8.3" /><ItemDef OID="IT.EG.EGORRESU.PRAG" Name="EGORRESU" DataType="text" SASFieldName="EGORRESU" Length="__PLACEHOLDER__" /><ItemDef OID="IT.EG.EGORRESU.QRSAG" Name="EGORRESU" DataType="text" SASFieldName="EGORRESU" Length="__PLACEHOLDER__" /><ItemDef OID="IT.EG.EGORRESU.QTAG" Name="EGORRESU" DataType="text" SASFieldName="EGORRESU" Length="__PLACEHOLDER__" /><ItemDef OID="IT.EG.EGORRESU.QTCBAG" Name="EGORRESU" DataType="text" SASFieldName="EGORRESU" Length="__PLACEHOLDER__" /><ItemDef OID="IT.EG.EGORRESU.QTCFAG" Name="EGORRESU" DataType="text" SASFieldName="EGORRESU" Length="__PLACEHOLDER__" /><ItemDef OID="IT.EG.EGORRESU.RRAG" Name="EGORRESU" DataType="text" SASFieldName="EGORRESU" Length="__PLACEHOLDER__" /><ItemDef OID="IT.EG.EGORRESU.EGHRMN" Name="EGORRESU" DataType="text" SASFieldName="EGORRESU" Length="__PLACEHOLDER__" /><ItemDef OID="IT.EG.EGORRESU.QRS_AXIS" Name="EGORRESU" DataType="text" SASFieldName="EGORRESU" Length="__PLACEHOLDER__" /><ItemDef OID="IT.CM.STUDYID" Name="STUDYID" DataType="text" SASFieldName="STUDYID" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Study Identifier</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.CM.DOMAIN" Name="DOMAIN" DataType="text" SASFieldName="DOMAIN" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.CM.USUBJID" Name="USUBJID" DataType="text" SASFieldName="USUBJID" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.CM.CMSEQ" Name="CMSEQ" DataType="integer" SASFieldName="CMSEQ" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Sequence Number</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.CM.CMTRT" Name="CMTRT" DataType="text" SASFieldName="CMTRT" Length="200"><Description><TranslatedText xml:lang="en">Reported Name of Drug, Med, or Therapy</TranslatedText></Description><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.CM.CMDECOD" Name="CMDECOD" DataType="text" SASFieldName="CMDECOD" Length="200"><Description><TranslatedText xml:lang="en">Standardized Medication Name</TranslatedText></Description><def:Origin Type="Assigned" Source="Sponsor" /></ItemDef><ItemDef OID="IT.CM.CMCAT" Name="CMCAT" DataType="text" SASFieldName="CMCAT" Length="200"><Description><TranslatedText xml:lang="en">Category for Medication</TranslatedText></Description><def:Origin Type="Assigned" Source="Sponsor" /></ItemDef><ItemDef OID="IT.CM.CMSCAT" Name="CMSCAT" DataType="text" SASFieldName="CMSCAT" Length="200"><Description><TranslatedText xml:lang="en">Subcategory for Medication</TranslatedText></Description><def:Origin Type="Assigned" Source="Sponsor" /></ItemDef><ItemDef OID="IT.CM.CMPRESP" Name="CMPRESP" DataType="text" SASFieldName="CMPRESP" Length="1"><Description><TranslatedText xml:lang="en">CM Pre-specified</TranslatedText></Description><CodeListRef CodeListOID="CL.NY" /><def:Origin Type="Assigned" Source="Sponsor" /></ItemDef><ItemDef OID="IT.CM.CMOCCUR" Name="CMOCCUR" DataType="text" SASFieldName="CMOCCUR" Length="1"><Description><TranslatedText xml:lang="en">CM Occurrence</TranslatedText></Description><CodeListRef CodeListOID="CL.NY" /><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.CM.CMINDC" Name="CMINDC" DataType="text" SASFieldName="CMINDC" Length="200"><Description><TranslatedText xml:lang="en">Indication</TranslatedText></Description><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.CM.CMDOSE" Name="CMDOSE" DataType="text" SASFieldName="CMDOSE" Length="40"><Description><TranslatedText xml:lang="en">Dose per Administration</TranslatedText></Description><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.CM.CMDOSU" Name="CMDOSU" DataType="text" SASFieldName="CMDOSU" Length="40"><Description><TranslatedText xml:lang="en">Dose Units</TranslatedText></Description><CodeListRef CodeListOID="CL.UNIT" /><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.CM.CMDOSFRM" Name="CMDOSFRM" DataType="text" SASFieldName="CMDOSFRM" Length="40"><Description><TranslatedText xml:lang="en">Dose Form</TranslatedText></Description><CodeListRef CodeListOID="CL.FRM" /><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.CM.CMROUTE" Name="CMROUTE" DataType="text" SASFieldName="CMROUTE" Length="200"><Description><TranslatedText xml:lang="en">Route of Administration</TranslatedText></Description><CodeListRef CodeListOID="CL.ROUTE" /><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.CM.CMSTDTC" Name="CMSTDTC" DataType="datetime" SASFieldName="CMSTDTC"><Description><TranslatedText xml:lang="en">Start Date/Time of Medication</TranslatedText></Description><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.CM.CMENDTC" Name="CMENDTC" DataType="datetime" SASFieldName="CMENDTC"><Description><TranslatedText xml:lang="en">End Date/Time of Medication</TranslatedText></Description><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.LB.STUDYID" Name="STUDYID" DataType="text" SASFieldName="STUDYID" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Study Identifier</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.LB.DOMAIN" Name="DOMAIN" DataType="text" SASFieldName="DOMAIN" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.LB.USUBJID" Name="USUBJID" DataType="text" SASFieldName="USUBJID" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.LB.LBSEQ" Name="LBSEQ" DataType="integer" SASFieldName="LBSEQ" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Sequence Number</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.LB.LBTESTCD" Name="LBTESTCD" DataType="text" SASFieldName="LBTESTCD" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Lab Test or Examination Short Name</TranslatedText></Description><CodeListRef CodeListOID="CL.LBTESTCD" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.LB.LBTEST" Name="LBTEST" DataType="text" SASFieldName="LBTEST" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Lab Test or Examination Name</TranslatedText></Description><CodeListRef CodeListOID="CL.LBTEST" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.LB.LBCAT" Name="LBCAT" DataType="text" SASFieldName="LBCAT" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Category for Lab Test</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.LB.LBORRES" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12" SignificantDigits="4" def:DisplayFormat="12.4"><Description><TranslatedText xml:lang="en">Result or Finding in Original Units</TranslatedText></Description><def:ValueListRef ValueListOID="VL.LB.LBORRES" /><def:Origin Type="Collected" Source="Vendor" /></ItemDef><ItemDef OID="IT.LB.LBORRESU" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Original Units</TranslatedText></Description><CodeListRef CodeListOID="CL.UNIT" /><def:ValueListRef ValueListOID="VL.LB.LBORRESU" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.LB.LBORNRLO" Name="LBORNRLO" DataType="text" SASFieldName="LBORNRLO" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Reference Range Lower Limit in Orig Unit</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.LB.LBORNRHI" Name="LBORNRHI" DataType="text" SASFieldName="LBORNRHI" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Reference Range Upper Limit in Orig Unit</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.LB.LBSTRESC" Name="LBSTRESC" DataType="float" SASFieldName="LBSTRESC" Length="12" SignificantDigits="4" def:DisplayFormat="12.4"><Description><TranslatedText xml:lang="en">Character Result/Finding in Std Format</TranslatedText></Description><CodeListRef CodeListOID="CL.LBSTRESC" /><def:Origin Type="Collected" Source="Vendor" /></ItemDef><ItemDef OID="IT.LB.LBSTRESN" Name="LBSTRESN" DataType="float" SASFieldName="LBSTRESN" Length="12" SignificantDigits="4" def:DisplayFormat="12.4"><Description><TranslatedText xml:lang="en">Numeric Result/Finding in Standard Units</TranslatedText></Description><def:Origin Type="Collected" Source="Vendor" /></ItemDef><ItemDef OID="IT.LB.LBSTRESU" Name="LBSTRESU" DataType="text" SASFieldName="LBSTRESU" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Standard Units</TranslatedText></Description><CodeListRef CodeListOID="CL.UNIT" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.LB.LBSTNRLO" Name="LBSTNRLO" DataType="integer" SASFieldName="LBSTNRLO" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Reference Range Lower Limit-Std Units</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.LB.LBSTNRHI" Name="LBSTNRHI" DataType="integer" SASFieldName="LBSTNRHI" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Reference Range Upper Limit-Std Units</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.LB.LBNRIND" Name="LBNRIND" DataType="text" SASFieldName="LBNRIND" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Reference Range Indicator</TranslatedText></Description><CodeListRef CodeListOID="CL.NRIND" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.LB.LBSPEC" Name="LBSPEC" DataType="text" SASFieldName="LBSPEC" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Specimen Type</TranslatedText></Description><CodeListRef CodeListOID="CL.SPECTYPE" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.LB.LBMETHOD" Name="LBMETHOD" DataType="text" SASFieldName="LBMETHOD" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Method of Test or Examination</TranslatedText></Description><CodeListRef CodeListOID="CL.METHOD" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.LB.LBLOBXFL" Name="LBLOBXFL" DataType="text" SASFieldName="LBLOBXFL" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Last Observation Before Exposure Flag</TranslatedText></Description><CodeListRef CodeListOID="CL.NY" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.LB.LBFAST" Name="LBFAST" DataType="text" SASFieldName="LBFAST" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Fasting Status</TranslatedText></Description><CodeListRef CodeListOID="CL.NY" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.LB.VISITNUM" Name="VISITNUM" DataType="integer" SASFieldName="VISITNUM" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Visit Number</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.LB.LBDTC" Name="LBDTC" DataType="datetime" SASFieldName="LBDTC"><Description><TranslatedText xml:lang="en">Date/Time of Specimen Collection</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.LB.LBORRES.HGB" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12" SignificantDigits="4" def:DisplayFormat="12.4"><def:Origin Type="Collected" Source="Vendor" /></ItemDef><ItemDef OID="IT.LB.LBORRES.HCT" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12" SignificantDigits="4" def:DisplayFormat="12.4"><def:Origin Type="Collected" Source="Vendor" /></ItemDef><ItemDef OID="IT.LB.LBORRES.RBC" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12" SignificantDigits="4" def:DisplayFormat="12.4"><def:Origin Type="Collected" Source="Vendor" /></ItemDef><ItemDef OID="IT.LB.LBORRES.MCH" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12" SignificantDigits="4" def:DisplayFormat="12.4"><def:Origin Type="Collected" Source="Vendor" /></ItemDef><ItemDef OID="IT.LB.LBORRES.MCHC" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12" SignificantDigits="4" def:DisplayFormat="12.4"><def:Origin Type="Collected" Source="Vendor" /></ItemDef><ItemDef OID="IT.LB.LBORRES.MCV" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12" SignificantDigits="4" def:DisplayFormat="12.4"><def:Origin Type="Collected" Source="Vendor" /></ItemDef><ItemDef OID="IT.LB.LBORRES.WBC" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12" SignificantDigits="4" def:DisplayFormat="12.4"><def:Origin Type="Collected" Source="Vendor" /></ItemDef><ItemDef OID="IT.LB.LBORRES.NEUTSG" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12" SignificantDigits="4" def:DisplayFormat="12.4"><def:Origin Type="Collected" Source="Vendor" /></ItemDef><ItemDef OID="IT.LB.LBORRES.NEUTB" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12" SignificantDigits="4" def:DisplayFormat="12.4"><def:Origin Type="Collected" Source="Vendor" /></ItemDef><ItemDef OID="IT.LB.LBORRES.NEUT" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12" SignificantDigits="4" def:DisplayFormat="12.4"><def:Origin Type="Collected" Source="Vendor" /></ItemDef><ItemDef OID="IT.LB.LBORRES.MONO" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12" SignificantDigits="4" def:DisplayFormat="12.4"><def:Origin Type="Collected" Source="Vendor" /></ItemDef><ItemDef OID="IT.LB.LBORRES.EOS" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12" SignificantDigits="4" def:DisplayFormat="12.4"><def:Origin Type="Collected" Source="Vendor" /></ItemDef><ItemDef OID="IT.LB.LBORRES.BASO" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12" SignificantDigits="4" def:DisplayFormat="12.4"><def:Origin Type="Collected" Source="Vendor" /></ItemDef><ItemDef OID="IT.LB.LBORRES.PLAT" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12" SignificantDigits="4" def:DisplayFormat="12.4"><def:Origin Type="Collected" Source="Vendor" /></ItemDef><ItemDef OID="IT.LB.LBORRES.MICROCY" Name="LBORRES" DataType="text" SASFieldName="LBORRES" Length="200"><def:Origin Type="Collected" Source="Vendor" /></ItemDef><ItemDef OID="IT.LB.LBORRES.MACROCY" Name="LBORRES" DataType="text" SASFieldName="LBORRES" Length="200"><def:Origin Type="Collected" Source="Vendor" /></ItemDef><ItemDef OID="IT.LB.LBORRES.ANISO" Name="LBORRES" DataType="text" SASFieldName="LBORRES" Length="200"><def:Origin Type="Collected" Source="Vendor" /></ItemDef><ItemDef OID="IT.LB.LBORRES.POIKILO" Name="LBORRES" DataType="text" SASFieldName="LBORRES" Length="200"><def:Origin Type="Collected" Source="Vendor" /></ItemDef><ItemDef OID="IT.LB.LBORRES.POLYCHR" Name="LBORRES" DataType="text" SASFieldName="LBORRES" Length="200"><def:Origin Type="Collected" Source="Vendor" /></ItemDef><ItemDef OID="IT.LB.LBORRES.ALT" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12" SignificantDigits="4" def:DisplayFormat="12.4"><def:Origin Type="Collected" Source="Vendor" /></ItemDef><ItemDef OID="IT.LB.LBORRES.ALB" Name="LBORRES" DataType="text" SASFieldName="LBORRES" Length="200" SignificantDigits="4"><def:Origin Type="Collected" Source="Vendor" /></ItemDef><ItemDef OID="IT.LB.LBORRES.ALP" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12" SignificantDigits="4" def:DisplayFormat="12.4"><def:Origin Type="Collected" Source="Vendor" /></ItemDef><ItemDef OID="IT.LB.LBORRES.AST" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12" SignificantDigits="4" def:DisplayFormat="12.4"><def:Origin Type="Collected" Source="Vendor" /></ItemDef><ItemDef OID="IT.LB.LBORRES.CREAT" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12" SignificantDigits="4" def:DisplayFormat="12.4"><def:Origin Type="Collected" Source="Vendor" /></ItemDef><ItemDef OID="IT.LB.LBORRES.K" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12" SignificantDigits="4" def:DisplayFormat="12.4"><def:Origin Type="Collected" Source="Vendor" /></ItemDef><ItemDef OID="IT.LB.LBORRES.SODIUM" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12" SignificantDigits="4" def:DisplayFormat="12.4"><def:Origin Type="Collected" Source="Vendor" /></ItemDef><ItemDef OID="IT.LB.LBORRES.UREAN" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12" SignificantDigits="4" def:DisplayFormat="12.4"><def:Origin Type="Collected" Source="Vendor" /></ItemDef><ItemDef OID="IT.LB.LBORRES.BICARB" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12" SignificantDigits="4" def:DisplayFormat="12.4"><def:Origin Type="Collected" Source="Vendor" /></ItemDef><ItemDef OID="IT.LB.LBORRES.CL" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12" SignificantDigits="4" def:DisplayFormat="12.4"><def:Origin Type="Collected" Source="Vendor" /></ItemDef><ItemDef OID="IT.LB.LBORRES.BILI" Name="LBORRES" DataType="text" SASFieldName="LBORRES" Length="200" SignificantDigits="4"><def:Origin Type="Collected" Source="Vendor" /></ItemDef><ItemDef OID="IT.LB.LBORRES.GGT" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12" SignificantDigits="4" def:DisplayFormat="12.4"><def:Origin Type="Collected" Source="Vendor" /></ItemDef><ItemDef OID="IT.LB.LBORRES.URATE" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12" SignificantDigits="4" def:DisplayFormat="12.4"><def:Origin Type="Collected" Source="Vendor" /></ItemDef><ItemDef OID="IT.LB.LBORRES.PHOS" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12" SignificantDigits="4" def:DisplayFormat="12.4"><def:Origin Type="Collected" Source="Vendor" /></ItemDef><ItemDef OID="IT.LB.LBORRES.CA" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12" SignificantDigits="4" def:DisplayFormat="12.4"><def:Origin Type="Collected" Source="Vendor" /></ItemDef><ItemDef OID="IT.LB.LBORRES.GLUC" Name="LBORRES" DataType="text" SASFieldName="LBORRES" Length="200" /><ItemDef OID="IT.LB.LBORRES.PROT" Name="LBORRES" DataType="text" SASFieldName="LBORRES" Length="200" SignificantDigits="4"><def:Origin Type="Collected" Source="Vendor" /></ItemDef><ItemDef OID="IT.LB.LBORRES.CHOL" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12" SignificantDigits="4" def:DisplayFormat="12.4"><def:Origin Type="Collected" Source="Vendor" /></ItemDef><ItemDef OID="IT.LB.LBORRES.T3UP" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12" SignificantDigits="4" def:DisplayFormat="12.4"><def:Origin Type="Collected" Source="Vendor" /></ItemDef><ItemDef OID="IT.LB.LBORRES.T3" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12" SignificantDigits="4" def:DisplayFormat="12.4"><def:Origin Type="Collected" Source="Vendor" /></ItemDef><ItemDef OID="IT.LB.LBORRES.T4FR" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12" SignificantDigits="4" def:DisplayFormat="12.4"><def:Origin Type="Collected" Source="Vendor" /></ItemDef><ItemDef OID="IT.LB.LBORRES.T4FRIDX" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12" SignificantDigits="4" def:DisplayFormat="12.4"><def:Origin Type="Collected" Source="Vendor" /></ItemDef><ItemDef OID="IT.LB.LBORRES.TSH" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12" SignificantDigits="4" def:DisplayFormat="12.4"><def:Origin Type="Collected" Source="Vendor" /></ItemDef><ItemDef OID="IT.LB.LBORRES.VITB9" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12" SignificantDigits="4" def:DisplayFormat="12.4"><def:Origin Type="Collected" Source="Vendor" /></ItemDef><ItemDef OID="IT.LB.LBORRES.VITB12" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12" SignificantDigits="4" def:DisplayFormat="12.4"><def:Origin Type="Collected" Source="Vendor" /></ItemDef><ItemDef OID="IT.LB.LBORRES.COLOR" Name="LBORRES" DataType="text" SASFieldName="LBORRES" Length="200"><def:Origin Type="Collected" Source="Vendor" /></ItemDef><ItemDef OID="IT.LB.LBORRES.SPGRAV" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12" SignificantDigits="4" def:DisplayFormat="12.4"><def:Origin Type="Collected" Source="Vendor" /></ItemDef><ItemDef OID="IT.LB.LBORRES.KETONES" Name="LBORRES" DataType="text" SASFieldName="LBORRES" Length="200" SignificantDigits="4"><def:Origin Type="Collected" Source="Vendor" /></ItemDef><ItemDef OID="IT.LB.LBORRES.UROBIL" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12" SignificantDigits="4" def:DisplayFormat="12.4"><def:Origin Type="Collected" Source="Vendor" /></ItemDef><ItemDef OID="IT.LB.LBORRES.OCCBLD" Name="LBORRES" DataType="text" SASFieldName="LBORRES" Length="200" SignificantDigits="4"><def:Origin Type="Collected" Source="Vendor" /></ItemDef><ItemDef OID="IT.LB.LBORRES.NITRITE" Name="LBORRES" DataType="text" SASFieldName="LBORRES" Length="200" SignificantDigits="4"><def:Origin Type="Collected" Source="Vendor" /></ItemDef><ItemDef OID="IT.LB.LBORRES.HBA1C" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12" SignificantDigits="4" def:DisplayFormat="12.4"><def:Origin Type="Collected" Source="Vendor" /></ItemDef><ItemDef OID="IT.LB.LBORRES.HBA1CHGB" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12" SignificantDigits="4" def:DisplayFormat="12.4"><def:Origin Type="Collected" Source="Vendor" /></ItemDef><ItemDef OID="IT.LB.LBORRESU.HGB" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU" Length="__PLACEHOLDER__" /><ItemDef OID="IT.LB.LBORRESU.HCT" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU" Length="__PLACEHOLDER__" /><ItemDef OID="IT.LB.LBORRESU.RBC" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU" Length="__PLACEHOLDER__" /><ItemDef OID="IT.LB.LBORRESU.MCH" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU" Length="__PLACEHOLDER__" /><ItemDef OID="IT.LB.LBORRESU.MCHC" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU" Length="__PLACEHOLDER__" /><ItemDef OID="IT.LB.LBORRESU.MCV" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU" Length="__PLACEHOLDER__" /><ItemDef OID="IT.LB.LBORRESU.WBC" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU" Length="__PLACEHOLDER__" /><ItemDef OID="IT.LB.LBORRESU.NEUTSG" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU" Length="__PLACEHOLDER__" /><ItemDef OID="IT.LB.LBORRESU.NEUTB" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU" Length="__PLACEHOLDER__" /><ItemDef OID="IT.LB.LBORRESU.NEUT" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU" Length="__PLACEHOLDER__" /><ItemDef OID="IT.LB.LBORRESU.MONO" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU" Length="__PLACEHOLDER__" /><ItemDef OID="IT.LB.LBORRESU.EOS" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU" Length="__PLACEHOLDER__" /><ItemDef OID="IT.LB.LBORRESU.BASO" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU" Length="__PLACEHOLDER__" /><ItemDef OID="IT.LB.LBORRESU.PLAT" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU" Length="__PLACEHOLDER__" /><ItemDef OID="IT.LB.LBORRESU.ALT" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU" Length="__PLACEHOLDER__" /><ItemDef OID="IT.LB.LBORRESU.ALP" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU" Length="__PLACEHOLDER__" /><ItemDef OID="IT.LB.LBORRESU.AST" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU" Length="__PLACEHOLDER__" /><ItemDef OID="IT.LB.LBORRESU.CREAT" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU" Length="__PLACEHOLDER__" /><ItemDef OID="IT.LB.LBORRESU.K" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU" Length="__PLACEHOLDER__" /><ItemDef OID="IT.LB.LBORRESU.SODIUM" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU" Length="__PLACEHOLDER__" /><ItemDef OID="IT.LB.LBORRESU.UREAN" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU" Length="__PLACEHOLDER__" /><ItemDef OID="IT.LB.LBORRESU.BICARB" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU" Length="__PLACEHOLDER__" /><ItemDef OID="IT.LB.LBORRESU.CL" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU" Length="__PLACEHOLDER__" /><ItemDef OID="IT.LB.LBORRESU.GGT" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU" Length="__PLACEHOLDER__" /><ItemDef OID="IT.LB.LBORRESU.URATE" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU" Length="__PLACEHOLDER__" /><ItemDef OID="IT.LB.LBORRESU.PHOS" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU" Length="__PLACEHOLDER__" /><ItemDef OID="IT.LB.LBORRESU.CA" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU" Length="__PLACEHOLDER__" /><ItemDef OID="IT.LB.LBORRESU.CHOL" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU" Length="__PLACEHOLDER__" /><ItemDef OID="IT.LB.LBORRESU.T3UP" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU" Length="__PLACEHOLDER__" /><ItemDef OID="IT.LB.LBORRESU.T3" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU" Length="__PLACEHOLDER__" /><ItemDef OID="IT.LB.LBORRESU.T4FR" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU" Length="__PLACEHOLDER__" /><ItemDef OID="IT.LB.LBORRESU.T4FRIDX" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU" Length="__PLACEHOLDER__" /><ItemDef OID="IT.LB.LBORRESU.TSH" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU" Length="__PLACEHOLDER__" /><ItemDef OID="IT.LB.LBORRESU.VITB9" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU" Length="__PLACEHOLDER__" /><ItemDef OID="IT.LB.LBORRESU.VITB12" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU" Length="__PLACEHOLDER__" /><ItemDef OID="IT.LB.LBORRESU.UROBIL" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU" Length="__PLACEHOLDER__" /><ItemDef OID="IT.LB.LBORRESU.HBA1C" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU" Length="__PLACEHOLDER__" /><ItemDef OID="IT.LB.LBORRESU.HBA1CHGB" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU" Length="__PLACEHOLDER__" /><ItemDef OID="IT.MB.STUDYID" Name="STUDYID" DataType="text" SASFieldName="STUDYID" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Study Identifier</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.MB.DOMAIN" Name="DOMAIN" DataType="text" SASFieldName="DOMAIN" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.MB.USUBJID" Name="USUBJID" DataType="text" SASFieldName="USUBJID" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.MB.MBSEQ" Name="MBSEQ" DataType="integer" SASFieldName="MBSEQ" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Sequence Number</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.MB.MBTESTCD" Name="MBTESTCD" DataType="text" SASFieldName="MBTESTCD" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Microbiology Test or Finding Short Name</TranslatedText></Description><CodeListRef CodeListOID="CL.MBTESTCD" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.MB.MBTEST" Name="MBTEST" DataType="text" SASFieldName="MBTEST" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Microbiology Test or Finding Name</TranslatedText></Description><CodeListRef CodeListOID="CL.MBTEST" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.MB.MBTSTDTL" Name="MBTSTDTL" DataType="text" SASFieldName="MBTSTDTL" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Measurement, Test or Examination Detail</TranslatedText></Description><CodeListRef CodeListOID="CL.MBFTSDTL" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.MB.MBORRES" Name="MBORRES" DataType="text" SASFieldName="MBORRES" Length="20"><Description><TranslatedText xml:lang="en">Result or Finding in Original Units</TranslatedText></Description><def:ValueListRef ValueListOID="VL.MB.MBORRES" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.MB.MBSTRESC" Name="MBSTRESC" DataType="text" SASFieldName="MBSTRESC" Length="20"><Description><TranslatedText xml:lang="en">Result or Finding in Standard Format</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.MB.MBSPEC" Name="MBSPEC" DataType="text" SASFieldName="MBSPEC" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Specimen Material Type</TranslatedText></Description><CodeListRef CodeListOID="CL.SPECTYPE" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.MB.MBMETHOD" Name="MBMETHOD" DataType="text" SASFieldName="MBMETHOD" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Method of Test or Examination</TranslatedText></Description><CodeListRef CodeListOID="CL.METHOD" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.MB.VISITNUM" Name="VISITNUM" DataType="integer" SASFieldName="VISITNUM" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Visit Number</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.MB.MBDTC" Name="MBDTC" DataType="datetime" SASFieldName="MBDTC"><Description><TranslatedText xml:lang="en">Date/Time of Collection</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.MB.MBORRES.TPLAB" Name="MBORRES" DataType="text" SASFieldName="MBORRES" Length="20" /><ItemDef OID="IT.MB.MBORRES.TPADNA" Name="MBORRES" DataType="text" SASFieldName="MBORRES" Length="20" /><ItemDef OID="IT.EC.STUDYID" Name="STUDYID" DataType="text" SASFieldName="STUDYID" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Study Identifier</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.EC.DOMAIN" Name="DOMAIN" DataType="text" SASFieldName="DOMAIN" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.EC.USUBJID" Name="USUBJID" DataType="text" SASFieldName="USUBJID" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.EC.ECSEQ" Name="ECSEQ" DataType="integer" SASFieldName="ECSEQ" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Sequence Number</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.EC.ECREFID" Name="ECREFID" DataType="text" SASFieldName="ECREFID" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Reference ID</TranslatedText></Description><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.EC.ECTRT" Name="ECTRT" DataType="text" SASFieldName="ECTRT" Length="200"><Description><TranslatedText xml:lang="en">Name of Treatment</TranslatedText></Description><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.EC.ECDOSE" Name="ECDOSE" DataType="integer" SASFieldName="ECDOSE" Length="20"><Description><TranslatedText xml:lang="en">Dose</TranslatedText></Description><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.EC.ECDOSTXT" Name="ECDOSTXT" DataType="text" SASFieldName="ECDOSTXT" Length="100"><Description><TranslatedText xml:lang="en">Dose Description</TranslatedText></Description><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.EC.ECDOSU" Name="ECDOSU" DataType="text" SASFieldName="ECDOSU" Length="200"><Description><TranslatedText xml:lang="en">Dose Units</TranslatedText></Description><CodeListRef CodeListOID="CL.UNIT" /><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.EC.ECDOSFRM" Name="ECDOSFRM" DataType="text" SASFieldName="ECDOSFRM" Length="200"><Description><TranslatedText xml:lang="en">Dose Form</TranslatedText></Description><CodeListRef CodeListOID="CL.FRM" /><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.EC.ECDOSFRQ" Name="ECDOSFRQ" DataType="text" SASFieldName="ECDOSFRQ" Length="200"><Description><TranslatedText xml:lang="en">Dosing Frequency per Interval</TranslatedText></Description><CodeListRef CodeListOID="CL.FREQ" /><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.EC.ECDOSRGM" Name="ECDOSRGM" DataType="text" SASFieldName="ECDOSRGM" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Intended Dose Regimen</TranslatedText></Description><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.EC.ECROUTE" Name="ECROUTE" DataType="text" SASFieldName="ECROUTE" Length="200"><Description><TranslatedText xml:lang="en">Route of Administration</TranslatedText></Description><CodeListRef CodeListOID="CL.ROUTE" /><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.EC.ECLOC" Name="ECLOC" DataType="text" SASFieldName="ECLOC" Length="200"><Description><TranslatedText xml:lang="en">Location of Dose Administration</TranslatedText></Description><CodeListRef CodeListOID="CL.LOC" /><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.EC.ECLAT" Name="ECLAT" DataType="text" SASFieldName="ECLAT" Length="200"><Description><TranslatedText xml:lang="en">Laterality</TranslatedText></Description><CodeListRef CodeListOID="CL.LAT" /><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.EC.ECDIR" Name="ECDIR" DataType="text" SASFieldName="ECDIR" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Directionality</TranslatedText></Description><CodeListRef CodeListOID="CL.DIR" /><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.EC.ECSTDTC" Name="ECSTDTC" DataType="datetime" SASFieldName="ECSTDTC"><Description><TranslatedText xml:lang="en">Start Date/Time of Treatment</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.EC.ECENDTC" Name="ECENDTC" DataType="datetime" SASFieldName="ECENDTC"><Description><TranslatedText xml:lang="en">End Date/Time of Treatment</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.AE.STUDYID" Name="STUDYID" DataType="text" SASFieldName="STUDYID" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Study Identifier</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.AE.DOMAIN" Name="DOMAIN" DataType="text" SASFieldName="DOMAIN" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.AE.USUBJID" Name="USUBJID" DataType="text" SASFieldName="USUBJID" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.AE.AESEQ" Name="AESEQ" DataType="integer" SASFieldName="AESEQ" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Sequence Number</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.AE.AETERM" Name="AETERM" DataType="text" SASFieldName="AETERM" Length="200"><Description><TranslatedText xml:lang="en">Reported Term for the Adverse Event</TranslatedText></Description><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.AE.AELLT" Name="AELLT" DataType="text" SASFieldName="AELLT" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Lowest Level Term</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.AE.AELLTCD" Name="AELLTCD" DataType="integer" SASFieldName="AELLTCD" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Lowest Level Term Code</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.AE.AEDECOD" Name="AEDECOD" DataType="text" SASFieldName="AEDECOD" Length="200"><Description><TranslatedText xml:lang="en">Dictionary-Derived Term</TranslatedText></Description><def:Origin Type="Assigned" Source="Sponsor" /></ItemDef><ItemDef OID="IT.AE.AEPTCD" Name="AEPTCD" DataType="integer" SASFieldName="AEPTCD" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Preferred Term Code</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.AE.AEHLT" Name="AEHLT" DataType="text" SASFieldName="AEHLT" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">High Level Term</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.AE.AEHLTCD" Name="AEHLTCD" DataType="integer" SASFieldName="AEHLTCD" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">High Level Term Code</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.AE.AEHLGT" Name="AEHLGT" DataType="text" SASFieldName="AEHLGT" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">High Level Group Term</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.AE.AEHLGTCD" Name="AEHLGTCD" DataType="integer" SASFieldName="AEHLGTCD" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">High Level Group Term Code</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.AE.AECAT" Name="AECAT" DataType="text" SASFieldName="AECAT" Length="200"><Description><TranslatedText xml:lang="en">Category for Adverse Event</TranslatedText></Description><def:Origin Type="Assigned" Source="Sponsor" /></ItemDef><ItemDef OID="IT.AE.AESCAT" Name="AESCAT" DataType="text" SASFieldName="AESCAT" Length="200"><Description><TranslatedText xml:lang="en">Subcategory for Adverse Event</TranslatedText></Description><def:Origin Type="Assigned" Source="Sponsor" /></ItemDef><ItemDef OID="IT.AE.AEPRESP" Name="AEPRESP" DataType="text" SASFieldName="AEPRESP" Length="1"><Description><TranslatedText xml:lang="en">Pre-Specified Adverse Event</TranslatedText></Description><CodeListRef CodeListOID="CL.NY" /><def:Origin Type="Assigned" Source="Sponsor" /></ItemDef><ItemDef OID="IT.AE.AEBODSYS" Name="AEBODSYS" DataType="text" SASFieldName="AEBODSYS" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Body System or Organ Class</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.AE.AEBDSYCD" Name="AEBDSYCD" DataType="integer" SASFieldName="AEBDSYCD" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Body System or Organ Class Code</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.AE.AESOC" Name="AESOC" DataType="text" SASFieldName="AESOC" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Primary System Organ Class</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.AE.AESOCCD" Name="AESOCCD" DataType="integer" SASFieldName="AESOCCD" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Primary System Organ Class Code</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.AE.AELOC" Name="AELOC" DataType="text" SASFieldName="AELOC" Length="200"><Description><TranslatedText xml:lang="en">Location of Event</TranslatedText></Description><CodeListRef CodeListOID="CL.LOC" /><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.AE.AESEV" Name="AESEV" DataType="text" SASFieldName="AESEV" Length="20"><Description><TranslatedText xml:lang="en">Severity/Intensity</TranslatedText></Description><CodeListRef CodeListOID="CL.AESEV" /><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.AE.AESER" Name="AESER" DataType="text" SASFieldName="AESER" Length="1"><Description><TranslatedText xml:lang="en">Serious Event</TranslatedText></Description><CodeListRef CodeListOID="CL.NY" /><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.AE.AEACN" Name="AEACN" DataType="text" SASFieldName="AEACN" Length="200"><Description><TranslatedText xml:lang="en">Action Taken with Study Treatment</TranslatedText></Description><CodeListRef CodeListOID="CL.ACN" /><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.AE.AEACNOTH" Name="AEACNOTH" DataType="text" SASFieldName="AEACNOTH" Length="200"><Description><TranslatedText xml:lang="en">Other Action Taken</TranslatedText></Description><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.AE.AEREL" Name="AEREL" DataType="text" SASFieldName="AEREL" Length="200"><Description><TranslatedText xml:lang="en">Causality</TranslatedText></Description><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.AE.AERELNST" Name="AERELNST" DataType="text" SASFieldName="AERELNST" Length="200"><Description><TranslatedText xml:lang="en">Relationship to Non-Study Treatment</TranslatedText></Description><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.AE.AEPATT" Name="AEPATT" DataType="text" SASFieldName="AEPATT" Length="200"><Description><TranslatedText xml:lang="en">Pattern of Adverse Event</TranslatedText></Description><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.AE.AEOUT" Name="AEOUT" DataType="text" SASFieldName="AEOUT" Length="200"><Description><TranslatedText xml:lang="en">Outcome of Adverse Event</TranslatedText></Description><CodeListRef CodeListOID="CL.OUT" /><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.AE.AESCAN" Name="AESCAN" DataType="text" SASFieldName="AESCAN" Length="1"><Description><TranslatedText xml:lang="en">Involves Cancer</TranslatedText></Description><CodeListRef CodeListOID="CL.NY" /><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.AE.AESCONG" Name="AESCONG" DataType="text" SASFieldName="AESCONG" Length="1"><Description><TranslatedText xml:lang="en">Congenital Anomaly or Birth Defect</TranslatedText></Description><CodeListRef CodeListOID="CL.NY" /><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.AE.AESDISAB" Name="AESDISAB" DataType="text" SASFieldName="AESDISAB" Length="1"><Description><TranslatedText xml:lang="en">Persist or Signif Disability/Incapacity</TranslatedText></Description><CodeListRef CodeListOID="CL.NY" /><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.AE.AESDTH" Name="AESDTH" DataType="text" SASFieldName="AESDTH" Length="1"><Description><TranslatedText xml:lang="en">Results in Death</TranslatedText></Description><CodeListRef CodeListOID="CL.NY" /><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.AE.AESHOSP" Name="AESHOSP" DataType="text" SASFieldName="AESHOSP" Length="1"><Description><TranslatedText xml:lang="en">Requires or Prolongs Hospitalization</TranslatedText></Description><CodeListRef CodeListOID="CL.NY" /><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.AE.AESLIFE" Name="AESLIFE" DataType="text" SASFieldName="AESLIFE" Length="1"><Description><TranslatedText xml:lang="en">Is Life Threatening</TranslatedText></Description><CodeListRef CodeListOID="CL.NY" /><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.AE.AESOD" Name="AESOD" DataType="text" SASFieldName="AESOD" Length="1"><Description><TranslatedText xml:lang="en">Occurred with Overdose</TranslatedText></Description><CodeListRef CodeListOID="CL.NY" /><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.AE.AESMIE" Name="AESMIE" DataType="text" SASFieldName="AESMIE" Length="1"><Description><TranslatedText xml:lang="en">Other Medically Important Serious Event</TranslatedText></Description><CodeListRef CodeListOID="CL.NY" /><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.AE.AECONTRT" Name="AECONTRT" DataType="text" SASFieldName="AECONTRT" Length="1"><Description><TranslatedText xml:lang="en">Concomitant or Additional Trtmnt Given</TranslatedText></Description><CodeListRef CodeListOID="CL.NY" /><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.AE.AETOXGR" Name="AETOXGR" DataType="text" SASFieldName="AETOXGR" Length="1"><Description><TranslatedText xml:lang="en">Standard Toxicity Grade</TranslatedText></Description><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.AE.AESTDTC" Name="AESTDTC" DataType="datetime" SASFieldName="AESTDTC"><Description><TranslatedText xml:lang="en">Start Date/Time of Adverse Event</TranslatedText></Description><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.AE.AEENDTC" Name="AEENDTC" DataType="datetime" SASFieldName="AEENDTC"><Description><TranslatedText xml:lang="en">End Date/Time of Adverse Event</TranslatedText></Description><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.AE.AEENRF" Name="AEENRF" DataType="text" SASFieldName="AEENRF" Length="20"><Description><TranslatedText xml:lang="en">End Relative to Reference Period</TranslatedText></Description><CodeListRef CodeListOID="CL.STENRF" /><def:Origin Type="Assigned" Source="Sponsor" /></ItemDef><ItemDef OID="IT.AE.AEENRTPT" Name="AEENRTPT" DataType="text" SASFieldName="AEENRTPT" Length="20"><Description><TranslatedText xml:lang="en">End Relative to Reference Time Point</TranslatedText></Description><CodeListRef CodeListOID="CL.STENRF" /><def:Origin Type="Assigned" Source="Sponsor" /></ItemDef><ItemDef OID="IT.AE.AEENTPT" Name="AEENTPT" DataType="text" SASFieldName="AEENTPT" Length="20"><Description><TranslatedText xml:lang="en">End Reference Time Point</TranslatedText></Description><def:Origin Type="Assigned" Source="Sponsor" /></ItemDef><ItemDef OID="IT.TS.STUDYID" Name="STUDYID" DataType="text" SASFieldName="STUDYID" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Study Identifier</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.TS.DOMAIN" Name="DOMAIN" DataType="text" SASFieldName="DOMAIN" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.TS.TSSEQ" Name="TSSEQ" DataType="integer" SASFieldName="TSSEQ" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Sequence Number</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.TS.TSPARMCD" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Trial Summary Parameter Short Name</TranslatedText></Description><CodeListRef CodeListOID="CL.TSPARMCD" /><def:ValueListRef ValueListOID="VL.TS.TSPARMCD" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.TS.TSPARM" Name="TSPARM" DataType="text" SASFieldName="TSPARM" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Trial Summary Parameter</TranslatedText></Description><CodeListRef CodeListOID="CL.TSPARM" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.TS.TSVAL" Name="TSVAL" DataType="text" SASFieldName="TSVAL" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Parameter Value</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.TS.TSVALCD" Name="TSVALCD" DataType="text" SASFieldName="TSVALCD" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Parameter Value Code</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.TS.TSVCDREF" Name="TSVCDREF" DataType="text" SASFieldName="TSVCDREF" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Name of the Reference Terminology</TranslatedText></Description><CodeListRef CodeListOID="CL.DICTNAM" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.TS.TSVCDVER" Name="TSVCDVER" DataType="text" SASFieldName="TSVCDVER" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Version of the Reference Terminology</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.TS.TSPARMCD.ADAPT" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="1"><CodeListRef CodeListOID="CL.NY" /><def:Origin Type="Protocol" Source="Sponsor" /></ItemDef><ItemDef OID="IT.TS.TSPARMCD.AGEMIN" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="200"><def:Origin Type="Protocol" Source="Sponsor" /></ItemDef><ItemDef OID="IT.TS.TSPARMCD.AGEMAX" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="200"><def:Origin Type="Protocol" Source="Sponsor" /></ItemDef><ItemDef OID="IT.TS.TSPARMCD.COMPTRT" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="200"><def:Origin Type="Protocol" Source="Sponsor" /></ItemDef><ItemDef OID="IT.TS.TSPARMCD.CRMDUR" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="200"><def:Origin Type="Protocol" Source="Sponsor" /></ItemDef><ItemDef OID="IT.TS.TSPARMCD.DOSE" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="200"><def:Origin Type="Protocol" Source="Sponsor" /></ItemDef><ItemDef OID="IT.TS.TSPARMCD.DOSFRQ" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="200"><def:Origin Type="Protocol" Source="Sponsor" /></ItemDef><ItemDef OID="IT.TS.TSPARMCD.DOSU" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="200"><def:Origin Type="Protocol" Source="Sponsor" /></ItemDef><ItemDef OID="IT.TS.TSPARMCD.INDIC" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="200"><def:Origin Type="Protocol" Source="Sponsor" /></ItemDef><ItemDef OID="IT.TS.TSPARMCD.INTMODEL" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="200"><def:Origin Type="Protocol" Source="Sponsor" /></ItemDef><ItemDef OID="IT.TS.TSPARMCD.INTTYPE" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="200"><def:Origin Type="Protocol" Source="Sponsor" /></ItemDef><ItemDef OID="IT.TS.TSPARMCD.NARMS" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="200"><def:Origin Type="Protocol" Source="Sponsor" /></ItemDef><ItemDef OID="IT.TS.TSPARMCD.OBJPRIM" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="200"><def:Origin Type="Protocol" Source="Sponsor" /></ItemDef><ItemDef OID="IT.TS.TSPARMCD.OBJSEC" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="200"><def:Origin Type="Protocol" Source="Sponsor" /></ItemDef><ItemDef OID="IT.TS.TSPARMCD.OUTMSPRI" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="200"><def:Origin Type="Protocol" Source="Sponsor" /></ItemDef><ItemDef OID="IT.TS.TSPARMCD.OUTMSSEC" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="200"><def:Origin Type="Protocol" Source="Sponsor" /></ItemDef><ItemDef OID="IT.TS.TSPARMCD.PLANSUB" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="200"><def:Origin Type="Protocol" Source="Sponsor" /></ItemDef><ItemDef OID="IT.TS.TSPARMCD.PTRTDUR" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="200"><def:Origin Type="Protocol" Source="Sponsor" /></ItemDef><ItemDef OID="IT.TS.TSPARMCD.ROUTE" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="200"><def:Origin Type="Protocol" Source="Sponsor" /></ItemDef><ItemDef OID="IT.TS.TSPARMCD.SEXPOP" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="200"><def:Origin Type="Protocol" Source="Sponsor" /></ItemDef><ItemDef OID="IT.TS.TSPARMCD.SPONSOR" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="200"><def:Origin Type="Protocol" Source="Sponsor" /></ItemDef><ItemDef OID="IT.TS.TSPARMCD.STYPE" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="200"><def:Origin Type="Protocol" Source="Sponsor" /></ItemDef><ItemDef OID="IT.TS.TSPARMCD.TBLIND" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="200"><def:Origin Type="Protocol" Source="Sponsor" /></ItemDef><ItemDef OID="IT.TS.TSPARMCD.THERAREA" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="200"><def:Origin Type="Protocol" Source="Sponsor" /></ItemDef><ItemDef OID="IT.TS.TSPARMCD.TINDTP" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="200"><def:Origin Type="Protocol" Source="Sponsor" /></ItemDef><ItemDef OID="IT.TS.TSPARMCD.TITLE" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="200"><def:Origin Type="Protocol" Source="Sponsor" /></ItemDef><ItemDef OID="IT.TS.TSPARMCD.TPHASE" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="200"><def:Origin Type="Protocol" Source="Sponsor" /></ItemDef><ItemDef OID="IT.TS.TSPARMCD.TRT" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="200"><def:Origin Type="Protocol" Source="Sponsor" /></ItemDef><ItemDef OID="IT.TS.TSPARMCD.TTYPE" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="200"><def:Origin Type="Protocol" Source="Sponsor" /></ItemDef><ItemDef OID="IT.TA.STUDYID" Name="STUDYID" DataType="text" SASFieldName="STUDYID" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Study Identifier</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.TA.DOMAIN" Name="DOMAIN" DataType="text" SASFieldName="DOMAIN" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.TA.ARMCD" Name="ARMCD" DataType="text" SASFieldName="ARMCD" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Planned Arm Code</TranslatedText></Description><CodeListRef CodeListOID="CL.ARMCD" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.TA.ARM" Name="ARM" DataType="text" SASFieldName="ARM" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Description of Planned Arm</TranslatedText></Description><CodeListRef CodeListOID="CL.ARM" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.TA.TAETORD" Name="TAETORD" DataType="integer" SASFieldName="TAETORD" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Planned Order of Element within Arm</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.TA.ETCD" Name="ETCD" DataType="text" SASFieldName="ETCD" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Element Code</TranslatedText></Description><CodeListRef CodeListOID="CL.ETCD" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.TA.ELEMENT" Name="ELEMENT" DataType="text" SASFieldName="ELEMENT" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Description of Element</TranslatedText></Description><CodeListRef CodeListOID="CL.ELEMENT" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.TA.TABRANCH" Name="TABRANCH" DataType="text" SASFieldName="TABRANCH" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Branch</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.TA.TATRANS" Name="TATRANS" DataType="text" SASFieldName="TATRANS" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Transition Rule</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.TA.EPOCH" Name="EPOCH" DataType="text" SASFieldName="EPOCH" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Epoch</TranslatedText></Description><CodeListRef CodeListOID="CL.EPOCH" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.TE.STUDYID" Name="STUDYID" DataType="text" SASFieldName="STUDYID" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Study Identifier</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.TE.DOMAIN" Name="DOMAIN" DataType="text" SASFieldName="DOMAIN" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.TE.ETCD" Name="ETCD" DataType="text" SASFieldName="ETCD" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Element Code</TranslatedText></Description><CodeListRef CodeListOID="CL.ETCD" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.TE.ELEMENT" Name="ELEMENT" DataType="text" SASFieldName="ELEMENT" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Description of Element</TranslatedText></Description><CodeListRef CodeListOID="CL.ELEMENT" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.TE.TESTRL" Name="TESTRL" DataType="text" SASFieldName="TESTRL" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Rule for Start of Element</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.TI.STUDYID" Name="STUDYID" DataType="text" SASFieldName="STUDYID" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Study Identifier</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.TI.DOMAIN" Name="DOMAIN" DataType="text" SASFieldName="DOMAIN" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.TI.IETESTCD" Name="IETESTCD" DataType="text" SASFieldName="IETESTCD" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Incl/Excl Criterion Short Name</TranslatedText></Description><CodeListRef CodeListOID="CL.IETESTCD" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.TI.IETEST" Name="IETEST" DataType="text" SASFieldName="IETEST" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Inclusion/Exclusion Criterion</TranslatedText></Description><CodeListRef CodeListOID="CL.IETEST" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.TI.IECAT" Name="IECAT" DataType="text" SASFieldName="IECAT" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Inclusion/Exclusion Category</TranslatedText></Description><CodeListRef CodeListOID="CL.IECAT" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.TV.STUDYID" Name="STUDYID" DataType="text" SASFieldName="STUDYID" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Study Identifier</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.TV.DOMAIN" Name="DOMAIN" DataType="text" SASFieldName="DOMAIN" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.TV.VISITNUM" Name="VISITNUM" DataType="integer" SASFieldName="VISITNUM" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Visit Number</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.TV.VISIT" Name="VISIT" DataType="text" SASFieldName="VISIT" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Visit Name</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.TV.VISITDY" Name="VISITDY" DataType="integer" SASFieldName="VISITDY" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Planned Study Day of Visit</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.TV.ARMCD" Name="ARMCD" DataType="text" SASFieldName="ARMCD" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Planned Arm Code</TranslatedText></Description><CodeListRef CodeListOID="CL.ARMCD" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.TV.ARM" Name="ARM" DataType="text" SASFieldName="ARM" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Description of Planned Arm</TranslatedText></Description><CodeListRef CodeListOID="CL.ARM" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.TV.TVSTRL" Name="TVSTRL" DataType="text" SASFieldName="TVSTRL" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Visit Start Rule</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.TV.TVENRL" Name="TVENRL" DataType="text" SASFieldName="TVENRL" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Visit End Rule</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.SV.STUDYID" Name="STUDYID" DataType="text" SASFieldName="STUDYID" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Study Identifier</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.SV.DOMAIN" Name="DOMAIN" DataType="text" SASFieldName="DOMAIN" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.SV.USUBJID" Name="USUBJID" DataType="text" SASFieldName="USUBJID" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.SV.VISITNUM" Name="VISITNUM" DataType="integer" SASFieldName="VISITNUM" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Visit Number</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.SV.VISIT" Name="VISIT" DataType="text" SASFieldName="VISIT" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Visit Name</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.SV.SVPRESP" Name="SVPRESP" DataType="text" SASFieldName="SVPRESP" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Pre-specified</TranslatedText></Description><CodeListRef CodeListOID="CL.NY" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.SV.SVOCCUR" Name="SVOCCUR" DataType="text" SASFieldName="SVOCCUR" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Occurrence</TranslatedText></Description><CodeListRef CodeListOID="CL.NY" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.SV.SVCNTMOD" Name="SVCNTMOD" DataType="text" SASFieldName="SVCNTMOD" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Contact Mode</TranslatedText></Description><CodeListRef CodeListOID="CL.CNTMODE" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.SV.SVSTDTC" Name="SVSTDTC" DataType="datetime" SASFieldName="SVSTDTC"><Description><TranslatedText xml:lang="en">Start Date/Time of Observation</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.SV.SVENDTC" Name="SVENDTC" DataType="datetime" SASFieldName="SVENDTC"><Description><TranslatedText xml:lang="en">End Date/Time of Observation</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.IE.STUDYID" Name="STUDYID" DataType="text" SASFieldName="STUDYID" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Study Identifier</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.IE.DOMAIN" Name="DOMAIN" DataType="text" SASFieldName="DOMAIN" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.IE.USUBJID" Name="USUBJID" DataType="text" SASFieldName="USUBJID" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.IE.IESEQ" Name="IESEQ" DataType="integer" SASFieldName="IESEQ" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Sequence Number</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.IE.IETESTCD" Name="IETESTCD" DataType="text" SASFieldName="IETESTCD" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Inclusion/Exclusion Criterion Short Name</TranslatedText></Description><CodeListRef CodeListOID="CL.IETESTCD" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.IE.IETEST" Name="IETEST" DataType="text" SASFieldName="IETEST" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Inclusion/Exclusion Criterion</TranslatedText></Description><CodeListRef CodeListOID="CL.IETEST" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.IE.IECAT" Name="IECAT" DataType="text" SASFieldName="IECAT" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Inclusion/Exclusion Category</TranslatedText></Description><CodeListRef CodeListOID="CL.IECAT" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.IE.IEORRES" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">I/E Criterion Original Result</TranslatedText></Description><CodeListRef CodeListOID="CL.NY" /><def:ValueListRef ValueListOID="VL.IE.IEORRES" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.IE.IESTRESC" Name="IESTRESC" DataType="text" SASFieldName="IESTRESC" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">I/E Criterion Result in Std Format</TranslatedText></Description><CodeListRef CodeListOID="CL.NY" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.IE.IEORRES.IN01" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1"><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.IE.IEORRES.IN02" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1"><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.IE.IEORRES.IN03" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1"><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.IE.IEORRES.IN04" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1"><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.IE.IEORRES.IN05" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1"><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.IE.IEORRES.IN06" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1"><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.IE.IEORRES.IN07" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1"><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.IE.IEORRES.IN08" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1"><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.IE.IEORRES.EX01" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1"><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.IE.IEORRES.EX02" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1"><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.IE.IEORRES.EX03" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1"><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.IE.IEORRES.EX04" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1"><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.IE.IEORRES.EX05" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1"><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.IE.IEORRES.EX06" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1"><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.IE.IEORRES.EX07" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1"><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.IE.IEORRES.EX08" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1"><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.IE.IEORRES.EX09" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1"><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.IE.IEORRES.EX10" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1"><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.IE.IEORRES.EX11" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1"><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.IE.IEORRES.EX12" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1"><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.IE.IEORRES.EX13" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1"><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.IE.IEORRES.EX14" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1"><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.IE.IEORRES.EX15" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1"><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.IE.IEORRES.EX16" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1"><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.IE.IEORRES.EX17" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1"><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.IE.IEORRES.EX18" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1"><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.IE.IEORRES.EX19" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1"><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.IE.IEORRES.EX20" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1"><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.IE.IEORRES.EX21" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1"><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.IE.IEORRES.EX22" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1"><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.IE.IEORRES.EX23" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1"><def:Origin Type="Collected" Source="Investigator"><def:DocumentRef leafID="LF.acrf"><def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef" /></def:DocumentRef></def:Origin></ItemDef><ItemDef OID="IT.SE.STUDYID" Name="STUDYID" DataType="text" SASFieldName="STUDYID" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Study Identifier</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.SE.DOMAIN" Name="DOMAIN" DataType="text" SASFieldName="DOMAIN" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.SE.USUBJID" Name="USUBJID" DataType="text" SASFieldName="USUBJID" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.SE.SESEQ" Name="SESEQ" DataType="integer" SASFieldName="SESEQ" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Sequence Number</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.SE.ETCD" Name="ETCD" DataType="text" SASFieldName="ETCD" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Element Code</TranslatedText></Description><CodeListRef CodeListOID="CL.ETCD" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.SE.ELEMENT" Name="ELEMENT" DataType="text" SASFieldName="ELEMENT" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Description of Element</TranslatedText></Description><CodeListRef CodeListOID="CL.ELEMENT" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.SE.EPOCH" Name="EPOCH" DataType="text" SASFieldName="EPOCH" Length="__PLACEHOLDER__"><Description><TranslatedText xml:lang="en">Epoch</TranslatedText></Description><CodeListRef CodeListOID="CL.EPOCH" /><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.SE.SESTDTC" Name="SESTDTC" DataType="datetime" SASFieldName="SESTDTC"><Description><TranslatedText xml:lang="en">Start Date/Time of Element</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><ItemDef OID="IT.SE.SEENDTC" Name="SEENDTC" DataType="datetime" SASFieldName="SEENDTC"><Description><TranslatedText xml:lang="en">End Date/Time of Element</TranslatedText></Description><def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__" /></ItemDef><CodeList OID="CL.ARMCD" Name="ARM Code" DataType="text" def:IsNonStandard="Yes"><EnumeratedItem CodedValue="Placebo" /><EnumeratedItem CodedValue="Xanomeline Low Dose" /><EnumeratedItem CodedValue="Xanomeline High Dose" /></CodeList><CodeList OID="CL.ARM" Name="ARM" DataType="text" def:IsNonStandard="Yes"><EnumeratedItem CodedValue="Placebo" /><EnumeratedItem CodedValue="Xanomeline Low Dose" /><EnumeratedItem CodedValue="Xanomeline High Dose" /></CodeList><CodeList OID="CL.IETEST" Name="Inclusion/Exclusion Test Name" DataType="text" def:IsNonStandard="Yes"><EnumeratedItem CodedValue="Age greater than 50" /><EnumeratedItem CodedValue="Diagnosis of Alzheimer's" /><EnumeratedItem CodedValue="MMSE Score" /><EnumeratedItem CodedValue="Hachinski Ischemic Score" /><EnumeratedItem CodedValue="CNS imaging comptaible with Alzheimer's" /><EnumeratedItem CodedValue="Informed consent criteria" /><EnumeratedItem CodedValue="Geographic proximity criteria" /><EnumeratedItem CodedValue="Reliable caregiver criteria" /><EnumeratedItem CodedValue="Previous study criteria" /><EnumeratedItem CodedValue="Other Alzheimer's therapy criteria" /><EnumeratedItem CodedValue="Serious illness criteria" /><EnumeratedItem CodedValue="Serious neurolocal conditions criteria" /><EnumeratedItem CodedValue="Depression criteria" /><EnumeratedItem CodedValue="Schizophrenia, Bipolar, Ethanol or psychoactive abuse criteria" /><EnumeratedItem CodedValue="Syncope criteria" /><EnumeratedItem CodedValue="ECG Criteria" /><EnumeratedItem CodedValue="Cardiovascular criteria" /><EnumeratedItem CodedValue="Gastrointensinal criteria" /><EnumeratedItem CodedValue="Endocrine criteria" /><EnumeratedItem CodedValue="Resporatory criteria" /><EnumeratedItem CodedValue="Genitourinary criteria" /><EnumeratedItem CodedValue="Rheumatologic criteria" /><EnumeratedItem CodedValue="HIV criteria" /><EnumeratedItem CodedValue="Neurosyphilis, Meningitis,Encephalitis criteria" /><EnumeratedItem CodedValue="Malignant disease criteria" /><EnumeratedItem CodedValue="Ability to participate in study criteria" /><EnumeratedItem CodedValue="Laboratory values criteria" /><EnumeratedItem CodedValue="Central laboratory values criteria" /><EnumeratedItem CodedValue="Syphilia criteria" /><EnumeratedItem CodedValue="Hemoglobin criteria" /><EnumeratedItem CodedValue="Medications Criteria" /></CodeList><CodeList OID="CL.IETESTCD" Name="Inclusion/Exclusion Test Code" DataType="text" def:IsNonStandard="Yes"><CodeListItem CodedValue="IN01"><Decode><TranslatedText xml:lang="en">Age greater than 50</TranslatedText></Decode></CodeListItem><CodeListItem CodedValue="IN02"><Decode><TranslatedText xml:lang="en">Diagnosis of Alzheimer's</TranslatedText></Decode></CodeListItem><CodeListItem CodedValue="IN03"><Decode><TranslatedText xml:lang="en">MMSE Score</TranslatedText></Decode></CodeListItem><CodeListItem CodedValue="IN04"><Decode><TranslatedText xml:lang="en">Hachinski Ischemic Score</TranslatedText></Decode></CodeListItem><CodeListItem CodedValue="IN05"><Decode><TranslatedText xml:lang="en">CNS imaging comptaible with Alzheimer's</TranslatedText></Decode></CodeListItem><CodeListItem CodedValue="IN06"><Decode><TranslatedText xml:lang="en">Informed consent criteria</TranslatedText></Decode></CodeListItem><CodeListItem CodedValue="IN07"><Decode><TranslatedText xml:lang="en">Geographic proximity criteria</TranslatedText></Decode></CodeListItem><CodeListItem CodedValue="IN08"><Decode><TranslatedText xml:lang="en">Reliable caregiver criteria</TranslatedText></Decode></CodeListItem><CodeListItem CodedValue="EX01"><Decode><TranslatedText xml:lang="en">Previous study criteria</TranslatedText></Decode></CodeListItem><CodeListItem CodedValue="EX02"><Decode><TranslatedText xml:lang="en">Other Alzheimer's therapy criteria</TranslatedText></Decode></CodeListItem><CodeListItem CodedValue="EX03"><Decode><TranslatedText xml:lang="en">Serious illness criteria</TranslatedText></Decode></CodeListItem><CodeListItem CodedValue="EX04"><Decode><TranslatedText xml:lang="en">Serious neurolocal conditions criteria</TranslatedText></Decode></CodeListItem><CodeListItem CodedValue="EX05"><Decode><TranslatedText xml:lang="en">Depression criteria</TranslatedText></Decode></CodeListItem><CodeListItem CodedValue="EX06"><Decode><TranslatedText xml:lang="en">Schizophrenia, Bipolar, Ethanol or psychoactive abuse criteria</TranslatedText></Decode></CodeListItem><CodeListItem CodedValue="EX07"><Decode><TranslatedText xml:lang="en">Syncope criteria</TranslatedText></Decode></CodeListItem><CodeListItem CodedValue="EX08"><Decode><TranslatedText xml:lang="en">ECG Criteria</TranslatedText></Decode></CodeListItem><CodeListItem CodedValue="EX09"><Decode><TranslatedText xml:lang="en">Cardiovascular criteria</TranslatedText></Decode></CodeListItem><CodeListItem CodedValue="EX10"><Decode><TranslatedText xml:lang="en">Gastrointensinal criteria</TranslatedText></Decode></CodeListItem><CodeListItem CodedValue="EX11"><Decode><TranslatedText xml:lang="en">Endocrine criteria</TranslatedText></Decode></CodeListItem><CodeListItem CodedValue="EX12"><Decode><TranslatedText xml:lang="en">Resporatory criteria</TranslatedText></Decode></CodeListItem><CodeListItem CodedValue="EX13"><Decode><TranslatedText xml:lang="en">Genitourinary criteria</TranslatedText></Decode></CodeListItem><CodeListItem CodedValue="EX14"><Decode><TranslatedText xml:lang="en">Rheumatologic criteria</TranslatedText></Decode></CodeListItem><CodeListItem CodedValue="EX15"><Decode><TranslatedText xml:lang="en">HIV criteria</TranslatedText></Decode></CodeListItem><CodeListItem CodedValue="EX16"><Decode><TranslatedText xml:lang="en">Neurosyphilis, Meningitis,Encephalitis criteria</TranslatedText></Decode></CodeListItem><CodeListItem CodedValue="EX17"><Decode><TranslatedText xml:lang="en">Malignant disease criteria</TranslatedText></Decode></CodeListItem><CodeListItem CodedValue="EX18"><Decode><TranslatedText xml:lang="en">Ability to participate in study criteria</TranslatedText></Decode></CodeListItem><CodeListItem CodedValue="EX19"><Decode><TranslatedText xml:lang="en">Laboratory values criteria</TranslatedText></Decode></CodeListItem><CodeListItem CodedValue="EX20"><Decode><TranslatedText xml:lang="en">Central laboratory values criteria</TranslatedText></Decode></CodeListItem><CodeListItem CodedValue="EX21"><Decode><TranslatedText xml:lang="en">Syphilia criteria</TranslatedText></Decode></CodeListItem><CodeListItem CodedValue="EX22"><Decode><TranslatedText xml:lang="en">Hemoglobin criteria</TranslatedText></Decode></CodeListItem><CodeListItem CodedValue="EX23"><Decode><TranslatedText xml:lang="en">Medications Criteria</TranslatedText></Decode></CodeListItem></CodeList><CodeList OID="CL.ELEMENT" Name="Description of Element" DataType="text" def:IsNonStandard="Yes"><EnumeratedItem CodedValue="Screening" /><EnumeratedItem CodedValue="Placebo" /><EnumeratedItem CodedValue="Follow up" /><EnumeratedItem CodedValue="Low" /><EnumeratedItem CodedValue="High - Start" /><EnumeratedItem CodedValue="High - Middle" /><EnumeratedItem CodedValue="High - End" /></CodeList><CodeList OID="CL.ETCD" Name="Element Code" DataType="text" def:IsNonStandard="Yes"><CodeListItem CodedValue="EL1"><Decode><TranslatedText xml:lang="en">Screening</TranslatedText></Decode></CodeListItem><CodeListItem CodedValue="EL2"><Decode><TranslatedText xml:lang="en">Placebo</TranslatedText></Decode></CodeListItem><CodeListItem CodedValue="EL7"><Decode><TranslatedText xml:lang="en">Follow up</TranslatedText></Decode></CodeListItem><CodeListItem CodedValue="EL3"><Decode><TranslatedText xml:lang="en">Low</TranslatedText></Decode></CodeListItem><CodeListItem CodedValue="EL4"><Decode><TranslatedText xml:lang="en">High - Start</TranslatedText></Decode></CodeListItem><CodeListItem CodedValue="EL5"><Decode><TranslatedText xml:lang="en">High - Middle</TranslatedText></Decode></CodeListItem><CodeListItem CodedValue="EL6"><Decode><TranslatedText xml:lang="en">High - End</TranslatedText></Decode></CodeListItem></CodeList><CodeList OID="CL.EPOCH" Name="Epoch" DataType="text" def:StandardOID="STD.SDTMCT"><EnumeratedItem CodedValue="Screening"><Alias Context="nci:ExtCodeID" Name="C202487" /></EnumeratedItem><EnumeratedItem CodedValue="Treatment 1"><Alias Context="nci:ExtCodeID" Name="C101526" /></EnumeratedItem><EnumeratedItem CodedValue="Treatment 2"><Alias Context="nci:ExtCodeID" Name="C101526" /></EnumeratedItem><EnumeratedItem CodedValue="Treatment 3"><Alias Context="nci:ExtCodeID" Name="C101526" /></EnumeratedItem><EnumeratedItem CodedValue="Follow-Up"><Alias Context="nci:ExtCodeID" Name="C202578" /></EnumeratedItem><Alias Context="nci:ExtCodeID" Name="C99079" /></CodeList><CodeList OID="CL.NCOMPLT" Name="Completion/Reason for Non-Completion" DataType="text" def:StandardOID="STD.SDTMCT"><CodeListItem CodedValue="__PLACEHOLDER__"><Decode><TranslatedText xml:lang="en">__PLACEHOLDER__</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="__PLACEHOLDER__" /></CodeListItem><Alias Context="nci:ExtCodeID" Name="C66727" /></CodeList><CodeList OID="CL.DSCAT" Name="Category of Disposition Event" DataType="text" def:StandardOID="STD.SDTMCT"><CodeListItem CodedValue="__PLACEHOLDER__"><Decode><TranslatedText xml:lang="en">__PLACEHOLDER__</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="__PLACEHOLDER__" /></CodeListItem><Alias Context="nci:ExtCodeID" Name="C74558" /></CodeList><CodeList OID="CL.DSSCAT" Name="Subcategory for Disposition Event" DataType="text" def:StandardOID="STD.SDTMCT"><CodeListItem CodedValue="__PLACEHOLDER__"><Decode><TranslatedText xml:lang="en">__PLACEHOLDER__</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="__PLACEHOLDER__" /></CodeListItem><Alias Context="nci:ExtCodeID" Name="C170443" /></CodeList><CodeList OID="CL.NY" Name="No Yes Response" DataType="text" def:StandardOID="STD.SDTMCT"><CodeListItem CodedValue="N"><Decode><TranslatedText xml:lang="en">No</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C49487" /></CodeListItem><CodeListItem CodedValue="Y"><Decode><TranslatedText xml:lang="en">Yes</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C49488" /></CodeListItem><Alias Context="nci:ExtCodeID" Name="C66742" /></CodeList><CodeList OID="CL.AGEU" Name="Age Unit" DataType="text" def:StandardOID="STD.SDTMCT"><CodeListItem CodedValue="__PLACEHOLDER__"><Decode><TranslatedText xml:lang="en">__PLACEHOLDER__</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="__PLACEHOLDER__" /></CodeListItem><Alias Context="nci:ExtCodeID" Name="C66781" /></CodeList><CodeList OID="CL.SEX" Name="Sex" DataType="text" def:StandardOID="STD.SDTMCT"><CodeListItem CodedValue="F"><Decode><TranslatedText xml:lang="en">Female</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C16576" /></CodeListItem><CodeListItem CodedValue="M"><Decode><TranslatedText xml:lang="en">Male</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C20197" /></CodeListItem><Alias Context="nci:ExtCodeID" Name="C66731" /></CodeList><CodeList OID="CL.RACE" Name="Race" DataType="text" def:StandardOID="STD.SDTMCT"><CodeListItem CodedValue="__PLACEHOLDER__"><Decode><TranslatedText xml:lang="en">__PLACEHOLDER__</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="__PLACEHOLDER__" /></CodeListItem><Alias Context="nci:ExtCodeID" Name="C74457" /></CodeList><CodeList OID="CL.ETHNIC" Name="Ethnic Group" DataType="text" def:StandardOID="STD.SDTMCT"><CodeListItem CodedValue="__PLACEHOLDER__"><Decode><TranslatedText xml:lang="en">__PLACEHOLDER__</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="__PLACEHOLDER__" /></CodeListItem><Alias Context="nci:ExtCodeID" Name="C66790" /></CodeList><CodeList OID="CL.ARMNULRS" Name="Arm Null Reason" DataType="text" def:StandardOID="STD.SDTMCT"><CodeListItem CodedValue="__PLACEHOLDER__"><Decode><TranslatedText xml:lang="en">__PLACEHOLDER__</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="__PLACEHOLDER__" /></CodeListItem><Alias Context="nci:ExtCodeID" Name="C142179" /></CodeList><CodeList OID="CL.SCTESTCD" Name="Subject Characteristic Test Code" DataType="text" def:StandardOID="STD.SDTMCT"><CodeListItem CodedValue="EDULEVEL"><Decode><TranslatedText xml:lang="en">Level of Education Attained</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C17953" /></CodeListItem><CodeListItem CodedValue="EDUYRNUM"><Decode><TranslatedText xml:lang="en">Number of Years of Education</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C122393" /></CodeListItem><Alias Context="nci:ExtCodeID" Name="C74559" /></CodeList><CodeList OID="CL.SCTEST" Name="Subject Characteristic Test Name" DataType="text" def:StandardOID="STD.SDTMCT"><CodeListItem CodedValue="Level of Education Attained"><Decode><TranslatedText xml:lang="en">Level of Education Attained</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C17953" /></CodeListItem><CodeListItem CodedValue="Number of Years of Education"><Decode><TranslatedText xml:lang="en">Number of Years of Education</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C122393" /></CodeListItem><Alias Context="nci:ExtCodeID" Name="C103330" /></CodeList><CodeList OID="CL.UNIT" Name="Unit" DataType="text" def:StandardOID="STD.SDTMCT"><CodeListItem CodedValue="%"><Decode><TranslatedText xml:lang="en">Percentage</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C25613" /></CodeListItem><CodeListItem CodedValue="10^12/L"><Decode><TranslatedText xml:lang="en">/pL</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C67308" /></CodeListItem><CodeListItem CodedValue="10^6/L"><Decode><TranslatedText xml:lang="en">/mm3</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C67452" /></CodeListItem><CodeListItem CodedValue="10^9/L"><Decode><TranslatedText xml:lang="en">/nL</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C67255" /></CodeListItem><CodeListItem CodedValue="CIGAR"><Decode><TranslatedText xml:lang="en">Cigar Dosing Unit</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C116244" /></CodeListItem><CodeListItem CodedValue="CIGARETTE"><Decode><TranslatedText xml:lang="en">Cigarette Dosing Unit</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C116245" /></CodeListItem><CodeListItem CodedValue="DRINK"><Decode><TranslatedText xml:lang="en">Drink Dosing Unit</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C161487" /></CodeListItem><CodeListItem CodedValue="EU"><Decode><TranslatedText xml:lang="en">Ehrlich Units</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C96599" /></CodeListItem><CodeListItem CodedValue="fmol"><Decode><TranslatedText xml:lang="en">Femtomole</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C68854" /></CodeListItem><CodeListItem CodedValue="fraction of 1"><Decode><TranslatedText xml:lang="en">Proportion of 1</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C105484" /></CodeListItem><CodeListItem CodedValue="g"><Decode><TranslatedText xml:lang="en">Gram</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C48155" /></CodeListItem><CodeListItem CodedValue="g/dL"><Decode><TranslatedText xml:lang="en">g%</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64783" /></CodeListItem><CodeListItem CodedValue="g/L"><Decode><TranslatedText xml:lang="en">g/L</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C42576" /></CodeListItem><CodeListItem CodedValue="GLASS"><Decode><TranslatedText xml:lang="en">Glass Dosing Unit</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C198391" /></CodeListItem><CodeListItem CodedValue="IU/L"><Decode><TranslatedText xml:lang="en">IE/L</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C67376" /></CodeListItem><CodeListItem CodedValue="kg/m2"><Decode><TranslatedText xml:lang="en">Kilogram per Square Meter</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C49671" /></CodeListItem><CodeListItem CodedValue="L"><Decode><TranslatedText xml:lang="en">Liter</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C48505" /></CodeListItem><CodeListItem CodedValue="mEq/dL"><Decode><TranslatedText xml:lang="en">Milliequivalent per Deciliter</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C67473" /></CodeListItem><CodeListItem CodedValue="mEq/L"><Decode><TranslatedText xml:lang="en">Milliequivalent Per Liter</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C67474" /></CodeListItem><CodeListItem CodedValue="mg"><Decode><TranslatedText xml:lang="en">Milligram</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C28253" /></CodeListItem><CodeListItem CodedValue="mg/dL"><Decode><TranslatedText xml:lang="en">mg%</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C67015" /></CodeListItem><CodeListItem CodedValue="mg/L"><Decode><TranslatedText xml:lang="en">g/m3</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64572" /></CodeListItem><CodeListItem CodedValue="mIU/L"><Decode><TranslatedText xml:lang="en">mcIU/mL</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C67405" /></CodeListItem><CodeListItem CodedValue="mL"><Decode><TranslatedText xml:lang="en">cc</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C28254" /></CodeListItem><CodeListItem CodedValue="mmol/L"><Decode><TranslatedText xml:lang="en">mcmol/mL</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64387" /></CodeListItem><CodeListItem CodedValue="ms"><Decode><TranslatedText xml:lang="en">Millisecond</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C41140" /></CodeListItem><CodeListItem CodedValue="mU/L"><Decode><TranslatedText xml:lang="en">uU/mL</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C67408" /></CodeListItem><CodeListItem CodedValue="ng/dL"><Decode><TranslatedText xml:lang="en">Nanogram per Deciliter</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C67326" /></CodeListItem><CodeListItem CodedValue="ng/L"><Decode><TranslatedText xml:lang="en">Microgram per Cubic Meter</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C67327" /></CodeListItem><CodeListItem CodedValue="nkat/L"><Decode><TranslatedText xml:lang="en">Nanokatal per Liter</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C70510" /></CodeListItem><CodeListItem CodedValue="nmol/L"><Decode><TranslatedText xml:lang="en">Nanomole per Liter</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C67432" /></CodeListItem><CodeListItem CodedValue="oz"><Decode><TranslatedText xml:lang="en">Ounce</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C48519" /></CodeListItem><CodeListItem CodedValue="PACK"><Decode><TranslatedText xml:lang="en">PACK</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C62653" /></CodeListItem><CodeListItem CodedValue="pg"><Decode><TranslatedText xml:lang="en">Picogram</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64551" /></CodeListItem><CodeListItem CodedValue="PIPE"><Decode><TranslatedText xml:lang="en">Pipe Dosing Unit</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C116246" /></CodeListItem><CodeListItem CodedValue="pmol/L"><Decode><TranslatedText xml:lang="en">Femtomole per Milliliter</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C67434" /></CodeListItem><CodeListItem CodedValue="psi"><Decode><TranslatedText xml:lang="en">Pounds per Square Inch</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C67334" /></CodeListItem><CodeListItem CodedValue="s"><Decode><TranslatedText xml:lang="en">sec</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C42535" /></CodeListItem><CodeListItem CodedValue="U/L"><Decode><TranslatedText xml:lang="en">mU/mL</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C67456" /></CodeListItem><CodeListItem CodedValue="ug/dL"><Decode><TranslatedText xml:lang="en">Microgram per Deciliter</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C67305" /></CodeListItem><CodeListItem CodedValue="ug/L"><Decode><TranslatedText xml:lang="en">mcg/L</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C67306" /></CodeListItem><CodeListItem CodedValue="ukat/L"><Decode><TranslatedText xml:lang="en">mckat/L</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C67397" /></CodeListItem><CodeListItem CodedValue="umol/L"><Decode><TranslatedText xml:lang="en">nmol/mL</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C48508" /></CodeListItem><Alias Context="nci:ExtCodeID" Name="C71620" /></CodeList><CodeList OID="CL.STENRF" Name="Relation to Reference Period" DataType="text" def:StandardOID="STD.SDTMCT"><CodeListItem CodedValue="__PLACEHOLDER__"><Decode><TranslatedText xml:lang="en">__PLACEHOLDER__</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="__PLACEHOLDER__" /></CodeListItem><Alias Context="nci:ExtCodeID" Name="C66728" /></CodeList><CodeList OID="CL.FREQ" Name="Frequency" DataType="text" def:StandardOID="STD.SDTMCT"><CodeListItem CodedValue="Q7D"><Decode><TranslatedText xml:lang="en">Every 7 Days</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C139177" /></CodeListItem><CodeListItem CodedValue="QD"><Decode><TranslatedText xml:lang="en">/day</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C25473" /></CodeListItem><Alias Context="nci:ExtCodeID" Name="C71113" /></CodeList><CodeList OID="CL.PROCEDUR" Name="Procedure" DataType="text" def:StandardOID="STD.SDTMCT"><CodeListItem CodedValue="__PLACEHOLDER__"><Decode><TranslatedText xml:lang="en">__PLACEHOLDER__</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="__PLACEHOLDER__" /></CodeListItem><Alias Context="nci:ExtCodeID" Name="C101858" /></CodeList><CodeList OID="CL.LOC" Name="Anatomical Location" DataType="text" def:StandardOID="STD.SDTMCT"><CodeListItem CodedValue="ARM"><Decode><TranslatedText xml:lang="en">Arm</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C32141" /></CodeListItem><CodeListItem CodedValue="AXILLA"><Decode><TranslatedText xml:lang="en">Armpit</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C12674" /></CodeListItem><CodeListItem CodedValue="BACK"><Decode><TranslatedText xml:lang="en">Back</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C13062" /></CodeListItem><CodeListItem CodedValue="BRACHIAL ARTERY"><Decode><TranslatedText xml:lang="en">BRACHIAL ARTERY</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C12681" /></CodeListItem><CodeListItem CodedValue="BUTTOCK"><Decode><TranslatedText xml:lang="en">Buttock</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C89806" /></CodeListItem><CodeListItem CodedValue="CAROTID ARTERY"><Decode><TranslatedText xml:lang="en">Common Carotid Artery</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C12687" /></CodeListItem><CodeListItem CodedValue="CEREBRAL ARTERY"><Decode><TranslatedText xml:lang="en">CEREBRAL ARTERY</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C12691" /></CodeListItem><CodeListItem CodedValue="CHEST"><Decode><TranslatedText xml:lang="en">Chest</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C25389" /></CodeListItem><CodeListItem CodedValue="DORSALIS PEDIS ARTERY"><Decode><TranslatedText xml:lang="en">Dorsal Pedal Artery</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C32478" /></CodeListItem><CodeListItem CodedValue="EAR"><Decode><TranslatedText xml:lang="en">EAR</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C12394" /></CodeListItem><CodeListItem CodedValue="FEMORAL ARTERY"><Decode><TranslatedText xml:lang="en">FEMORAL ARTERY</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C12715" /></CodeListItem><CodeListItem CodedValue="FINGER"><Decode><TranslatedText xml:lang="en">Finger</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C32608" /></CodeListItem><CodeListItem CodedValue="FOREHEAD"><Decode><TranslatedText xml:lang="en">Forehead</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C89803" /></CodeListItem><CodeListItem CodedValue="ORAL CAVITY"><Decode><TranslatedText xml:lang="en">Buccal cavity</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C12421" /></CodeListItem><CodeListItem CodedValue="RADIAL ARTERY"><Decode><TranslatedText xml:lang="en">Radial Artery</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C12838" /></CodeListItem><CodeListItem CodedValue="RECTUM"><Decode><TranslatedText xml:lang="en">RECTUM</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C12390" /></CodeListItem><CodeListItem CodedValue="THIGH"><Decode><TranslatedText xml:lang="en">Thigh</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C33763" /></CodeListItem><Alias Context="nci:ExtCodeID" Name="C74456" /></CodeList><CodeList OID="CL.VSTESTCD" Name="Vital Signs Test Code" DataType="text" def:StandardOID="STD.SDTMCT"><CodeListItem CodedValue="BMI"><Decode><TranslatedText xml:lang="en">Body Mass Index</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C16358" /></CodeListItem><CodeListItem CodedValue="DIABP"><Decode><TranslatedText xml:lang="en">Diastolic Blood Pressure</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C25299" /></CodeListItem><CodeListItem CodedValue="HEIGHT"><Decode><TranslatedText xml:lang="en">Height</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C25347" /></CodeListItem><CodeListItem CodedValue="HR"><Decode><TranslatedText xml:lang="en">Heart Rate</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C49677" /></CodeListItem><CodeListItem CodedValue="PULSE"><Decode><TranslatedText xml:lang="en">Pulse Rate</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C49676" /></CodeListItem><CodeListItem CodedValue="RESP"><Decode><TranslatedText xml:lang="en">Respiratory Rate</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C49678" /></CodeListItem><CodeListItem CodedValue="SYSBP"><Decode><TranslatedText xml:lang="en">Systolic Blood Pressure</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C25298" /></CodeListItem><CodeListItem CodedValue="TEMP"><Decode><TranslatedText xml:lang="en">Body Temperature</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C174446" /></CodeListItem><CodeListItem CodedValue="WEIGHT"><Decode><TranslatedText xml:lang="en">Weight</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C25208" /></CodeListItem><Alias Context="nci:ExtCodeID" Name="C66741" /></CodeList><CodeList OID="CL.VSTEST" Name="Vital Signs Test Name" DataType="text" def:StandardOID="STD.SDTMCT"><CodeListItem CodedValue="Body Mass Index"><Decode><TranslatedText xml:lang="en">Body Mass Index</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C16358" /></CodeListItem><CodeListItem CodedValue="Diastolic Blood Pressure"><Decode><TranslatedText xml:lang="en">Diastolic Blood Pressure</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C25299" /></CodeListItem><CodeListItem CodedValue="Heart Rate"><Decode><TranslatedText xml:lang="en">Heart Rate</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C49677" /></CodeListItem><CodeListItem CodedValue="Height"><Decode><TranslatedText xml:lang="en">Height</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C25347" /></CodeListItem><CodeListItem CodedValue="Pulse Rate"><Decode><TranslatedText xml:lang="en">Pulse Rate</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C49676" /></CodeListItem><CodeListItem CodedValue="Respiratory Rate"><Decode><TranslatedText xml:lang="en">Respiratory Rate</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C49678" /></CodeListItem><CodeListItem CodedValue="Systolic Blood Pressure"><Decode><TranslatedText xml:lang="en">Systolic Blood Pressure</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C25298" /></CodeListItem><CodeListItem CodedValue="Temperature"><Decode><TranslatedText xml:lang="en">Body Temperature</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C174446" /></CodeListItem><CodeListItem CodedValue="Weight"><Decode><TranslatedText xml:lang="en">Weight</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C25208" /></CodeListItem><Alias Context="nci:ExtCodeID" Name="C67153" /></CodeList><CodeList OID="CL.POSITION" Name="Position" DataType="text" def:StandardOID="STD.SDTMCT"><CodeListItem CodedValue="PRONE"><Decode><TranslatedText xml:lang="en">Prone</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C62165" /></CodeListItem><CodeListItem CodedValue="SEMI-RECUMBENT"><Decode><TranslatedText xml:lang="en">Semi-Supine</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C111310" /></CodeListItem><CodeListItem CodedValue="SITTING"><Decode><TranslatedText xml:lang="en">Sitting</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C62122" /></CodeListItem><CodeListItem CodedValue="STANDING"><Decode><TranslatedText xml:lang="en">Orthostatic</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C62166" /></CodeListItem><CodeListItem CodedValue="SUPINE"><Decode><TranslatedText xml:lang="en">Supine</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C62167" /></CodeListItem><Alias Context="nci:ExtCodeID" Name="C71148" /></CodeList><CodeList OID="CL.VSRESU" Name="Units for Vital Signs Results" DataType="text" def:StandardOID="STD.SDTMCT"><CodeListItem CodedValue="C"><Decode><TranslatedText xml:lang="en">Degree Celsius</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C42559" /></CodeListItem><CodeListItem CodedValue="cm"><Decode><TranslatedText xml:lang="en">Centimeter</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C49668" /></CodeListItem><CodeListItem CodedValue="F"><Decode><TranslatedText xml:lang="en">Degree Fahrenheit</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C44277" /></CodeListItem><CodeListItem CodedValue="g"><Decode><TranslatedText xml:lang="en">Gram</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C48155" /></CodeListItem><CodeListItem CodedValue="in"><Decode><TranslatedText xml:lang="en">Inch</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C48500" /></CodeListItem><CodeListItem CodedValue="K"><Decode><TranslatedText xml:lang="en">Kelvin</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C42537" /></CodeListItem><CodeListItem CodedValue="kg"><Decode><TranslatedText xml:lang="en">Kilogram</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C28252" /></CodeListItem><CodeListItem CodedValue="LB"><Decode><TranslatedText xml:lang="en">lb</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C48531" /></CodeListItem><CodeListItem CodedValue="m"><Decode><TranslatedText xml:lang="en">Meter</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C41139" /></CodeListItem><CodeListItem CodedValue="kg/m2"><Decode><TranslatedText xml:lang="en">Kilogram per Square Meter</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C49671" /></CodeListItem><Alias Context="nci:ExtCodeID" Name="C66770" /></CodeList><CodeList OID="CL.LAT" Name="Laterality" DataType="text" def:StandardOID="STD.SDTMCT"><CodeListItem CodedValue="LEFT"><Decode><TranslatedText xml:lang="en">LEFT</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C25229" /></CodeListItem><CodeListItem CodedValue="RIGHT"><Decode><TranslatedText xml:lang="en">RIGHT</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C25228" /></CodeListItem><Alias Context="nci:ExtCodeID" Name="C99073" /></CodeList><CodeList OID="CL.EGTESTCD" Name="ECG Test Code" DataType="text" def:StandardOID="STD.SDTMCT"><CodeListItem CodedValue="AVCOND"><Decode><TranslatedText xml:lang="en">Atrioventricular Conduction</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C111131" /></CodeListItem><CodeListItem CodedValue="AXISVOLT"><Decode><TranslatedText xml:lang="en">Axis and Voltage</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C111132" /></CodeListItem><CodeListItem CodedValue="CHYPTENL"><Decode><TranslatedText xml:lang="en">Chamber Hypertrophy or Enlargement</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C111155" /></CodeListItem><CodeListItem CodedValue="EGHRMN"><Decode><TranslatedText xml:lang="en">ECG Mean Heart Rate</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C119259" /></CodeListItem><CodeListItem CodedValue="INTP"><Decode><TranslatedText xml:lang="en">Interpretation</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C41255" /></CodeListItem><CodeListItem CodedValue="IVTIACD"><Decode><TranslatedText xml:lang="en">Intraventricular-Intraatrial Conduction</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C111238" /></CodeListItem><CodeListItem CodedValue="PACEMAKR"><Decode><TranslatedText xml:lang="en">Pacemaker</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C111285" /></CodeListItem><CodeListItem CodedValue="PRAG"><Decode><TranslatedText xml:lang="en">PQ Interval, Aggregate</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C117773" /></CodeListItem><CodeListItem CodedValue="QRS_AXIS"><Decode><TranslatedText xml:lang="en">QRS Axis</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C118165" /></CodeListItem><CodeListItem CodedValue="QRSAG"><Decode><TranslatedText xml:lang="en">QRS Duration, Aggregate</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C117779" /></CodeListItem><CodeListItem CodedValue="QTAG"><Decode><TranslatedText xml:lang="en">QT Interval, Aggregate</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C117783" /></CodeListItem><CodeListItem CodedValue="QTCBAG"><Decode><TranslatedText xml:lang="en">QTcB Interval, Aggregate</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C117784" /></CodeListItem><CodeListItem CodedValue="QTCFAG"><Decode><TranslatedText xml:lang="en">QTcF Interval, Aggregate</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C117786" /></CodeListItem><CodeListItem CodedValue="RHYNOS"><Decode><TranslatedText xml:lang="en">Rhythm Not Otherwise Specified</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C111307" /></CodeListItem><CodeListItem CodedValue="RRAG"><Decode><TranslatedText xml:lang="en">RR Interval, Aggregate</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C117791" /></CodeListItem><CodeListItem CodedValue="SNRARRY"><Decode><TranslatedText xml:lang="en">Sinus Node Rhythms and Arrhythmias</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C111312" /></CodeListItem><CodeListItem CodedValue="SPRARRY"><Decode><TranslatedText xml:lang="en">Supraventricular Arrhythmias</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C111320" /></CodeListItem><CodeListItem CodedValue="SPRTARRY"><Decode><TranslatedText xml:lang="en">Supraventricular Tachyarrhythmias</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C111321" /></CodeListItem><CodeListItem CodedValue="TECHQUAL"><Decode><TranslatedText xml:lang="en">Technical Quality</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C117807" /></CodeListItem><CodeListItem CodedValue="VTARRY"><Decode><TranslatedText xml:lang="en">Ventricular Arrhythmias</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C111330" /></CodeListItem><CodeListItem CodedValue="VTTARRY"><Decode><TranslatedText xml:lang="en">Ventricular Tachyarrhythmias</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C111331" /></CodeListItem><Alias Context="nci:ExtCodeID" Name="C71153" /></CodeList><CodeList OID="CL.EGTEST" Name="ECG Test Name" DataType="text" def:StandardOID="STD.SDTMCT"><CodeListItem CodedValue="Atrioventricular Conduction"><Decode><TranslatedText xml:lang="en">Atrioventricular Conduction</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C111131" /></CodeListItem><CodeListItem CodedValue="Axis and Voltage"><Decode><TranslatedText xml:lang="en">Axis and Voltage</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C111132" /></CodeListItem><CodeListItem CodedValue="Chamber Hypertrophy or Enlargement"><Decode><TranslatedText xml:lang="en">Chamber Hypertrophy or Enlargement</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C111155" /></CodeListItem><CodeListItem CodedValue="ECG Mean Heart Rate"><Decode><TranslatedText xml:lang="en">ECG Mean Heart Rate</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C119259" /></CodeListItem><CodeListItem CodedValue="Interpretation"><Decode><TranslatedText xml:lang="en">Interpretation</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C41255" /></CodeListItem><CodeListItem CodedValue="Intraventricular-Intraatrial Conduction"><Decode><TranslatedText xml:lang="en">Intraventricular-Intraatrial Conduction</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C111238" /></CodeListItem><CodeListItem CodedValue="Pacemaker"><Decode><TranslatedText xml:lang="en">Pacemaker</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C111285" /></CodeListItem><CodeListItem CodedValue="PR Interval, Aggregate"><Decode><TranslatedText xml:lang="en">PQ Interval, Aggregate</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C117773" /></CodeListItem><CodeListItem CodedValue="QRS Axis"><Decode><TranslatedText xml:lang="en">QRS Axis</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C118165" /></CodeListItem><CodeListItem CodedValue="QRS Duration, Aggregate"><Decode><TranslatedText xml:lang="en">QRS Duration, Aggregate</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C117779" /></CodeListItem><CodeListItem CodedValue="QT Interval, Aggregate"><Decode><TranslatedText xml:lang="en">QT Interval, Aggregate</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C117783" /></CodeListItem><CodeListItem CodedValue="QTcB Interval, Aggregate"><Decode><TranslatedText xml:lang="en">QTcB Interval, Aggregate</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C117784" /></CodeListItem><CodeListItem CodedValue="QTcF Interval, Aggregate"><Decode><TranslatedText xml:lang="en">QTcF Interval, Aggregate</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C117786" /></CodeListItem><CodeListItem CodedValue="Rhythm Not Otherwise Specified"><Decode><TranslatedText xml:lang="en">Rhythm Not Otherwise Specified</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C111307" /></CodeListItem><CodeListItem CodedValue="RR Interval, Aggregate"><Decode><TranslatedText xml:lang="en">RR Interval, Aggregate</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C117791" /></CodeListItem><CodeListItem CodedValue="Sinus Node Rhythms and Arrhythmias"><Decode><TranslatedText xml:lang="en">Sinus Node Rhythms and Arrhythmias</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C111312" /></CodeListItem><CodeListItem CodedValue="Supraventricular Arrhythmias"><Decode><TranslatedText xml:lang="en">Supraventricular Arrhythmias</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C111320" /></CodeListItem><CodeListItem CodedValue="Supraventricular Tachyarrhythmias"><Decode><TranslatedText xml:lang="en">Supraventricular Tachyarrhythmias</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C111321" /></CodeListItem><CodeListItem CodedValue="Technical Quality"><Decode><TranslatedText xml:lang="en">Technical Quality</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C117807" /></CodeListItem><CodeListItem CodedValue="Ventricular Arrhythmias"><Decode><TranslatedText xml:lang="en">Ventricular Arrhythmias</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C111330" /></CodeListItem><CodeListItem CodedValue="Ventricular Tachyarrhythmias"><Decode><TranslatedText xml:lang="en">Ventricular Tachyarrhythmias</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C111331" /></CodeListItem><Alias Context="nci:ExtCodeID" Name="C71152" /></CodeList><CodeList OID="CL.EGSTRESC" Name="ECG Result" DataType="text" def:StandardOID="STD.SDTMCT"><CodeListItem CodedValue="__PLACEHOLDER__"><Decode><TranslatedText xml:lang="en">__PLACEHOLDER__</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="__PLACEHOLDER__" /></CodeListItem><Alias Context="nci:ExtCodeID" Name="C71150" /></CodeList><CodeList OID="CL.EGMETHOD" Name="ECG Test Method" DataType="text" def:StandardOID="STD.SDTMCT"><CodeListItem CodedValue="__PLACEHOLDER__"><Decode><TranslatedText xml:lang="en">__PLACEHOLDER__</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="__PLACEHOLDER__" /></CodeListItem><Alias Context="nci:ExtCodeID" Name="C71151" /></CodeList><CodeList OID="CL.EVAL" Name="Evaluator" DataType="text" def:StandardOID="STD.SDTMCT"><CodeListItem CodedValue="ADJUDICATION COMMITTEE"><Decode><TranslatedText xml:lang="en">ADJUDICATION COMMITTEE</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C78726" /></CodeListItem><CodeListItem CodedValue="INDEPENDENT ASSESSOR"><Decode><TranslatedText xml:lang="en">INDEPENDENT ASSESSOR</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C78720" /></CodeListItem><CodeListItem CodedValue="INVESTIGATOR"><Decode><TranslatedText xml:lang="en">INVESTIGATOR</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C25936" /></CodeListItem><CodeListItem CodedValue="VENDOR"><Decode><TranslatedText xml:lang="en">VENDOR</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C68608" /></CodeListItem><Alias Context="nci:ExtCodeID" Name="C78735" /></CodeList><CodeList OID="CL.FRM" Name="Dosage Form" DataType="text" def:StandardOID="STD.SDTMCT"><CodeListItem CodedValue="__PLACEHOLDER__"><Decode><TranslatedText xml:lang="en">__PLACEHOLDER__</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="__PLACEHOLDER__" /></CodeListItem><Alias Context="nci:ExtCodeID" Name="C66726" /></CodeList><CodeList OID="CL.ROUTE" Name="Route of Administration Response" DataType="text" def:StandardOID="STD.SDTMCT"><CodeListItem CodedValue="__PLACEHOLDER__"><Decode><TranslatedText xml:lang="en">__PLACEHOLDER__</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="__PLACEHOLDER__" /></CodeListItem><Alias Context="nci:ExtCodeID" Name="C66729" /></CodeList><CodeList OID="CL.LBTESTCD" Name="Laboratory Test Code" DataType="text" def:StandardOID="STD.SDTMCT"><CodeListItem CodedValue="ALB"><Decode><TranslatedText xml:lang="en">Albumin</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64431" /></CodeListItem><CodeListItem CodedValue="ALP"><Decode><TranslatedText xml:lang="en">Alkaline Phosphatase</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64432" /></CodeListItem><CodeListItem CodedValue="ALT"><Decode><TranslatedText xml:lang="en">Alanine Aminotransferase</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64433" /></CodeListItem><CodeListItem CodedValue="ANISO"><Decode><TranslatedText xml:lang="en">Anisocytes</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C74797" /></CodeListItem><CodeListItem CodedValue="AST"><Decode><TranslatedText xml:lang="en">Aspartate Aminotransferase</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64467" /></CodeListItem><CodeListItem CodedValue="BASO"><Decode><TranslatedText xml:lang="en">Basophils</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64470" /></CodeListItem><CodeListItem CodedValue="BICARB"><Decode><TranslatedText xml:lang="en">Bicarbonate</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C74667" /></CodeListItem><CodeListItem CodedValue="BILI"><Decode><TranslatedText xml:lang="en">Bilirubin</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C38037" /></CodeListItem><CodeListItem CodedValue="CA"><Decode><TranslatedText xml:lang="en">Calcium</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64488" /></CodeListItem><CodeListItem CodedValue="CHOL"><Decode><TranslatedText xml:lang="en">Cholesterol</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C105586" /></CodeListItem><CodeListItem CodedValue="CL"><Decode><TranslatedText xml:lang="en">Chloride</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64495" /></CodeListItem><CodeListItem CodedValue="COLOR"><Decode><TranslatedText xml:lang="en">Color</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64546" /></CodeListItem><CodeListItem CodedValue="CREAT"><Decode><TranslatedText xml:lang="en">Creatinine</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64547" /></CodeListItem><CodeListItem CodedValue="EOS"><Decode><TranslatedText xml:lang="en">Eosinophils</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64550" /></CodeListItem><CodeListItem CodedValue="GGT"><Decode><TranslatedText xml:lang="en">Gamma Glutamyl Transferase</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64847" /></CodeListItem><CodeListItem CodedValue="GLUC"><Decode><TranslatedText xml:lang="en">Glucose</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C105585" /></CodeListItem><CodeListItem CodedValue="HBA1C"><Decode><TranslatedText xml:lang="en">HbA1c</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64849" /></CodeListItem><CodeListItem CodedValue="HBA1CHGB"><Decode><TranslatedText xml:lang="en">Hemoglobin A1C/Hemoglobin</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C111207" /></CodeListItem><CodeListItem CodedValue="HCT"><Decode><TranslatedText xml:lang="en">Erythrocyte Volume Fraction</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64796" /></CodeListItem><CodeListItem CodedValue="HGB"><Decode><TranslatedText xml:lang="en">Hemoglobin</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64848" /></CodeListItem><CodeListItem CodedValue="K"><Decode><TranslatedText xml:lang="en">Potassium</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64853" /></CodeListItem><CodeListItem CodedValue="KETONES"><Decode><TranslatedText xml:lang="en">Ketones</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64854" /></CodeListItem><CodeListItem CodedValue="MACROCY"><Decode><TranslatedText xml:lang="en">Macrocytes</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64821" /></CodeListItem><CodeListItem CodedValue="MCH"><Decode><TranslatedText xml:lang="en">Ery. Mean Corpuscular Hemoglobin</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64797" /></CodeListItem><CodeListItem CodedValue="MCHC"><Decode><TranslatedText xml:lang="en">Ery. Mean Corpuscular HGB Concentration</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64798" /></CodeListItem><CodeListItem CodedValue="MCV"><Decode><TranslatedText xml:lang="en">Ery. Mean Corpuscular Volume</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64799" /></CodeListItem><CodeListItem CodedValue="MICROCY"><Decode><TranslatedText xml:lang="en">Microcytes</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64822" /></CodeListItem><CodeListItem CodedValue="MONO"><Decode><TranslatedText xml:lang="en">Monocytes</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64823" /></CodeListItem><CodeListItem CodedValue="NEUT"><Decode><TranslatedText xml:lang="en">Neutrophils</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C63321" /></CodeListItem><CodeListItem CodedValue="NEUTB"><Decode><TranslatedText xml:lang="en">Neutrophils Band Form</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64830" /></CodeListItem><CodeListItem CodedValue="NEUTSG"><Decode><TranslatedText xml:lang="en">Neutrophils, Segmented</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C81997" /></CodeListItem><CodeListItem CodedValue="NITRITE"><Decode><TranslatedText xml:lang="en">Nitrite</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64810" /></CodeListItem><CodeListItem CodedValue="OCCBLD"><Decode><TranslatedText xml:lang="en">Occult Blood</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C74686" /></CodeListItem><CodeListItem CodedValue="PHOS"><Decode><TranslatedText xml:lang="en">Inorganic Phosphate</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64857" /></CodeListItem><CodeListItem CodedValue="PLAT"><Decode><TranslatedText xml:lang="en">Platelets</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C51951" /></CodeListItem><CodeListItem CodedValue="POIKILO"><Decode><TranslatedText xml:lang="en">Poikilocytes</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C79602" /></CodeListItem><CodeListItem CodedValue="POLYCHR"><Decode><TranslatedText xml:lang="en">Polychromasia</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64803" /></CodeListItem><CodeListItem CodedValue="PROT"><Decode><TranslatedText xml:lang="en">Protein</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64858" /></CodeListItem><CodeListItem CodedValue="RBC"><Decode><TranslatedText xml:lang="en">Erythrocytes</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C51946" /></CodeListItem><CodeListItem CodedValue="SODIUM"><Decode><TranslatedText xml:lang="en">Sodium</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64809" /></CodeListItem><CodeListItem CodedValue="SPGRAV"><Decode><TranslatedText xml:lang="en">Specific Gravity</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64832" /></CodeListItem><CodeListItem CodedValue="T3"><Decode><TranslatedText xml:lang="en">Total T3</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C74747" /></CodeListItem><CodeListItem CodedValue="T3UP"><Decode><TranslatedText xml:lang="en">T3RU</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C74748" /></CodeListItem><CodeListItem CodedValue="T4FR"><Decode><TranslatedText xml:lang="en">Free T4</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C74786" /></CodeListItem><CodeListItem CodedValue="T4FRIDX"><Decode><TranslatedText xml:lang="en">Thyroxine, Free Index</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C170598" /></CodeListItem><CodeListItem CodedValue="TSH"><Decode><TranslatedText xml:lang="en">Thyroid Stimulating Hormone</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64813" /></CodeListItem><CodeListItem CodedValue="URATE"><Decode><TranslatedText xml:lang="en">Urate</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64814" /></CodeListItem><CodeListItem CodedValue="UREAN"><Decode><TranslatedText xml:lang="en">Urea Nitrogen</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C125949" /></CodeListItem><CodeListItem CodedValue="UROBIL"><Decode><TranslatedText xml:lang="en">Urobilinogen</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64816" /></CodeListItem><CodeListItem CodedValue="VITB12"><Decode><TranslatedText xml:lang="en">Cobalamin</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64817" /></CodeListItem><CodeListItem CodedValue="VITB9"><Decode><TranslatedText xml:lang="en">Folate</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C74676" /></CodeListItem><CodeListItem CodedValue="WBC"><Decode><TranslatedText xml:lang="en">Leukocytes</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C51948" /></CodeListItem><Alias Context="nci:ExtCodeID" Name="C65047" /></CodeList><CodeList OID="CL.LBTEST" Name="Laboratory Test Name" DataType="text" def:StandardOID="STD.SDTMCT"><CodeListItem CodedValue="Alanine Aminotransferase"><Decode><TranslatedText xml:lang="en">Alanine Aminotransferase</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64433" /></CodeListItem><CodeListItem CodedValue="Albumin"><Decode><TranslatedText xml:lang="en">Albumin</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64431" /></CodeListItem><CodeListItem CodedValue="Alkaline Phosphatase"><Decode><TranslatedText xml:lang="en">Alkaline Phosphatase</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64432" /></CodeListItem><CodeListItem CodedValue="Anisocytes"><Decode><TranslatedText xml:lang="en">Anisocytes</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C74797" /></CodeListItem><CodeListItem CodedValue="Aspartate Aminotransferase"><Decode><TranslatedText xml:lang="en">Aspartate Aminotransferase</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64467" /></CodeListItem><CodeListItem CodedValue="Basophils"><Decode><TranslatedText xml:lang="en">Basophils</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64470" /></CodeListItem><CodeListItem CodedValue="Bicarbonate"><Decode><TranslatedText xml:lang="en">Bicarbonate</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C74667" /></CodeListItem><CodeListItem CodedValue="Bilirubin"><Decode><TranslatedText xml:lang="en">Bilirubin</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C38037" /></CodeListItem><CodeListItem CodedValue="Calcium"><Decode><TranslatedText xml:lang="en">Calcium</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64488" /></CodeListItem><CodeListItem CodedValue="Chloride"><Decode><TranslatedText xml:lang="en">Chloride</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64495" /></CodeListItem><CodeListItem CodedValue="Cholesterol"><Decode><TranslatedText xml:lang="en">Cholesterol</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C105586" /></CodeListItem><CodeListItem CodedValue="Color"><Decode><TranslatedText xml:lang="en">Color</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64546" /></CodeListItem><CodeListItem CodedValue="Creatinine"><Decode><TranslatedText xml:lang="en">Creatinine</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64547" /></CodeListItem><CodeListItem CodedValue="Eosinophils"><Decode><TranslatedText xml:lang="en">Eosinophils</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64550" /></CodeListItem><CodeListItem CodedValue="Ery. Mean Corpuscular Hemoglobin"><Decode><TranslatedText xml:lang="en">Ery. Mean Corpuscular Hemoglobin</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64797" /></CodeListItem><CodeListItem CodedValue="Ery. Mean Corpuscular HGB Concentration"><Decode><TranslatedText xml:lang="en">Ery. Mean Corpuscular HGB Concentration</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64798" /></CodeListItem><CodeListItem CodedValue="Ery. Mean Corpuscular Volume"><Decode><TranslatedText xml:lang="en">Ery. Mean Corpuscular Volume</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64799" /></CodeListItem><CodeListItem CodedValue="Erythrocytes"><Decode><TranslatedText xml:lang="en">Erythrocytes</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C51946" /></CodeListItem><CodeListItem CodedValue="Gamma Glutamyl Transferase"><Decode><TranslatedText xml:lang="en">Gamma Glutamyl Transferase</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64847" /></CodeListItem><CodeListItem CodedValue="Glucose"><Decode><TranslatedText xml:lang="en">Glucose</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C105585" /></CodeListItem><CodeListItem CodedValue="Hematocrit"><Decode><TranslatedText xml:lang="en">Erythrocyte Volume Fraction</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64796" /></CodeListItem><CodeListItem CodedValue="Hemoglobin A1C"><Decode><TranslatedText xml:lang="en">HbA1c</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64849" /></CodeListItem><CodeListItem CodedValue="Hemoglobin A1C/Hemoglobin"><Decode><TranslatedText xml:lang="en">Hemoglobin A1C/Hemoglobin</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C111207" /></CodeListItem><CodeListItem CodedValue="Hemoglobin"><Decode><TranslatedText xml:lang="en">Hemoglobin</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64848" /></CodeListItem><CodeListItem CodedValue="Ketones"><Decode><TranslatedText xml:lang="en">Ketones</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64854" /></CodeListItem><CodeListItem CodedValue="Leukocytes"><Decode><TranslatedText xml:lang="en">Leukocytes</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C51948" /></CodeListItem><CodeListItem CodedValue="Macrocytes"><Decode><TranslatedText xml:lang="en">Macrocytes</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64821" /></CodeListItem><CodeListItem CodedValue="Microcytes"><Decode><TranslatedText xml:lang="en">Microcytes</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64822" /></CodeListItem><CodeListItem CodedValue="Monocytes"><Decode><TranslatedText xml:lang="en">Monocytes</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64823" /></CodeListItem><CodeListItem CodedValue="Neutrophils Band Form"><Decode><TranslatedText xml:lang="en">Neutrophils Band Form</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64830" /></CodeListItem><CodeListItem CodedValue="Neutrophils"><Decode><TranslatedText xml:lang="en">Neutrophils</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C63321" /></CodeListItem><CodeListItem CodedValue="Neutrophils, Segmented"><Decode><TranslatedText xml:lang="en">Neutrophils, Segmented</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C81997" /></CodeListItem><CodeListItem CodedValue="Nitrite"><Decode><TranslatedText xml:lang="en">Nitrite</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64810" /></CodeListItem><CodeListItem CodedValue="Occult Blood"><Decode><TranslatedText xml:lang="en">Occult Blood</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C74686" /></CodeListItem><CodeListItem CodedValue="Phosphate"><Decode><TranslatedText xml:lang="en">Inorganic Phosphate</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64857" /></CodeListItem><CodeListItem CodedValue="Platelets"><Decode><TranslatedText xml:lang="en">Platelets</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C51951" /></CodeListItem><CodeListItem CodedValue="Poikilocytes"><Decode><TranslatedText xml:lang="en">Poikilocytes</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C79602" /></CodeListItem><CodeListItem CodedValue="Polychromasia"><Decode><TranslatedText xml:lang="en">Polychromasia</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64803" /></CodeListItem><CodeListItem CodedValue="Potassium"><Decode><TranslatedText xml:lang="en">Potassium</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64853" /></CodeListItem><CodeListItem CodedValue="Protein"><Decode><TranslatedText xml:lang="en">Protein</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64858" /></CodeListItem><CodeListItem CodedValue="Sodium"><Decode><TranslatedText xml:lang="en">Sodium</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64809" /></CodeListItem><CodeListItem CodedValue="Specific Gravity"><Decode><TranslatedText xml:lang="en">Specific Gravity</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64832" /></CodeListItem><CodeListItem CodedValue="Thyrotropin"><Decode><TranslatedText xml:lang="en">Thyroid Stimulating Hormone</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64813" /></CodeListItem><CodeListItem CodedValue="Thyroxine, Free Index"><Decode><TranslatedText xml:lang="en">Thyroxine, Free Index</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C170598" /></CodeListItem><CodeListItem CodedValue="Thyroxine, Free"><Decode><TranslatedText xml:lang="en">Free T4</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C74786" /></CodeListItem><CodeListItem CodedValue="Triiodothyronine Uptake"><Decode><TranslatedText xml:lang="en">T3RU</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C74748" /></CodeListItem><CodeListItem CodedValue="Triiodothyronine"><Decode><TranslatedText xml:lang="en">Total T3</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C74747" /></CodeListItem><CodeListItem CodedValue="Urate"><Decode><TranslatedText xml:lang="en">Urate</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64814" /></CodeListItem><CodeListItem CodedValue="Urea Nitrogen"><Decode><TranslatedText xml:lang="en">Urea Nitrogen</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C125949" /></CodeListItem><CodeListItem CodedValue="Urobilinogen"><Decode><TranslatedText xml:lang="en">Urobilinogen</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64816" /></CodeListItem><CodeListItem CodedValue="Vitamin B12"><Decode><TranslatedText xml:lang="en">Cobalamin</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C64817" /></CodeListItem><CodeListItem CodedValue="Vitamin B9"><Decode><TranslatedText xml:lang="en">Folate</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C74676" /></CodeListItem><Alias Context="nci:ExtCodeID" Name="C67154" /></CodeList><CodeList OID="CL.LBSTRESC" Name="Laboratory Test Standard Character Result" DataType="text" def:StandardOID="STD.SDTMCT"><CodeListItem CodedValue="__PLACEHOLDER__"><Decode><TranslatedText xml:lang="en">__PLACEHOLDER__</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="__PLACEHOLDER__" /></CodeListItem><Alias Context="nci:ExtCodeID" Name="C102580" /></CodeList><CodeList OID="CL.NRIND" Name="Reference Range Indicator" DataType="text" def:StandardOID="STD.SDTMCT"><CodeListItem CodedValue="__PLACEHOLDER__"><Decode><TranslatedText xml:lang="en">__PLACEHOLDER__</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="__PLACEHOLDER__" /></CodeListItem><Alias Context="nci:ExtCodeID" Name="C78736" /></CodeList><CodeList OID="CL.SPECTYPE" Name="Specimen Type" DataType="text" def:StandardOID="STD.SDTMCT"><CodeListItem CodedValue="BLOOD"><Decode><TranslatedText xml:lang="en">Peripheral Blood</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C12434" /></CodeListItem><CodeListItem CodedValue="ERYTHROCYTES"><Decode><TranslatedText xml:lang="en">RBC</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C12521" /></CodeListItem><CodeListItem CodedValue="SERUM OR PLASMA"><Decode><TranslatedText xml:lang="en">Ser/Plas</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C105706" /></CodeListItem><CodeListItem CodedValue="STOOL"><Decode><TranslatedText xml:lang="en">Feces</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C13234" /></CodeListItem><CodeListItem CodedValue="URINE SEDIMENT"><Decode><TranslatedText xml:lang="en">URINE SEDIMENT</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C158282" /></CodeListItem><CodeListItem CodedValue="URINE"><Decode><TranslatedText xml:lang="en">URINE</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C13283" /></CodeListItem><CodeListItem CodedValue="CEREBROSPINAL FLUID"><Decode><TranslatedText xml:lang="en">CSF</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C12692" /></CodeListItem><CodeListItem CodedValue="FLUID"><Decode><TranslatedText xml:lang="en">FLUID</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C13236" /></CodeListItem><CodeListItem CodedValue="SERUM"><Decode><TranslatedText xml:lang="en">Sera</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C13325" /></CodeListItem><CodeListItem CodedValue="SWABBED MATERIAL"><Decode><TranslatedText xml:lang="en">SWABBED MATERIAL</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C150895" /></CodeListItem><Alias Context="nci:ExtCodeID" Name="C78734" /></CodeList><CodeList OID="CL.METHOD" Name="Method" DataType="text" def:StandardOID="STD.SDTMCT"><CodeListItem CodedValue="DIPSTICK MEASUREMENT METHOD"><Decode><TranslatedText xml:lang="en">DIPSTICK MEASUREMENT METHOD</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C178142" /></CodeListItem><CodeListItem CodedValue="CHEMILUMINESCENT MICROPARTICLE IMMUNOASSAY"><Decode><TranslatedText xml:lang="en">Chemiluminescent Magnetic Microparticle Immunoassay</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C172557" /></CodeListItem><CodeListItem CodedValue="FLUORESCENT IMMUNOASSAY"><Decode><TranslatedText xml:lang="en">Fluorescent Antibody Assay</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C17370" /></CodeListItem><CodeListItem CodedValue="HEMAGGLUTINATION ASSAY"><Decode><TranslatedText xml:lang="en">HEMAGGLUTINATION ASSAY</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C130173" /></CodeListItem><CodeListItem CodedValue="IMMUNOBLOT"><Decode><TranslatedText xml:lang="en">IMMUNOBLOT</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C17638" /></CodeListItem><CodeListItem CodedValue="LINE PROBE ASSAY"><Decode><TranslatedText xml:lang="en">LiPA</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C102656" /></CodeListItem><CodeListItem CodedValue="POLYMERASE CHAIN REACTION"><Decode><TranslatedText xml:lang="en">PCR</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C17003" /></CodeListItem><CodeListItem CodedValue="RAPID IMMUNOASSAY"><Decode><TranslatedText xml:lang="en">RAPID IMMUNOASSAY</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C178031" /></CodeListItem><Alias Context="nci:ExtCodeID" Name="C85492" /></CodeList><CodeList OID="CL.MBTESTCD" Name="Microbiology Test Code" DataType="text" def:StandardOID="STD.SDTMCT"><CodeListItem CodedValue="TPADNA"><Decode><TranslatedText xml:lang="en">Treponema pallidum DNA</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C198341" /></CodeListItem><CodeListItem CodedValue="TPLAB"><Decode><TranslatedText xml:lang="en">TPLAB</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="__PLACEHOLDER__" /></CodeListItem><Alias Context="nci:ExtCodeID" Name="C120527" /></CodeList><CodeList OID="CL.MBTEST" Name="Microbiology Test Name" DataType="text" def:StandardOID="STD.SDTMCT"><CodeListItem CodedValue="Treponema pallidum DNA"><Decode><TranslatedText xml:lang="en">Treponema pallidum DNA</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C198341" /></CodeListItem><Alias Context="nci:ExtCodeID" Name="C120528" /></CodeList><CodeList OID="CL.MBFTSDTL" Name="Microbiology Findings Test Details" DataType="text" def:StandardOID="STD.SDTMCT"><CodeListItem CodedValue="DETECTION"><Decode><TranslatedText xml:lang="en">DETECTION</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C174330" /></CodeListItem><Alias Context="nci:ExtCodeID" Name="C174225" /></CodeList><CodeList OID="CL.DIR" Name="Directionality" DataType="text" def:StandardOID="STD.SDTMCT"><CodeListItem CodedValue="LOWER"><Decode><TranslatedText xml:lang="en">LOWER</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C25309" /></CodeListItem><CodeListItem CodedValue="MIDLINE"><Decode><TranslatedText xml:lang="en">MIDLINE</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C81170" /></CodeListItem><CodeListItem CodedValue="UPPER"><Decode><TranslatedText xml:lang="en">UPPER</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C25355" /></CodeListItem><Alias Context="nci:ExtCodeID" Name="C99074" /></CodeList><CodeList OID="CL.AESEV" Name="Severity/Intensity Scale for Adverse Events" DataType="text" def:StandardOID="STD.SDTMCT"><CodeListItem CodedValue="__PLACEHOLDER__"><Decode><TranslatedText xml:lang="en">__PLACEHOLDER__</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="__PLACEHOLDER__" /></CodeListItem><Alias Context="nci:ExtCodeID" Name="C66769" /></CodeList><CodeList OID="CL.ACN" Name="Action Taken with Study Treatment" DataType="text" def:StandardOID="STD.SDTMCT"><CodeListItem CodedValue="__PLACEHOLDER__"><Decode><TranslatedText xml:lang="en">__PLACEHOLDER__</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="__PLACEHOLDER__" /></CodeListItem><Alias Context="nci:ExtCodeID" Name="C66767" /></CodeList><CodeList OID="CL.OUT" Name="Outcome of Event" DataType="text" def:StandardOID="STD.SDTMCT"><CodeListItem CodedValue="__PLACEHOLDER__"><Decode><TranslatedText xml:lang="en">__PLACEHOLDER__</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="__PLACEHOLDER__" /></CodeListItem><Alias Context="nci:ExtCodeID" Name="C66768" /></CodeList><CodeList OID="CL.TSPARMCD" Name="Trial Summary Parameter Test Code" DataType="text" def:StandardOID="STD.SDTMCT"><CodeListItem CodedValue="ADAPT"><Decode><TranslatedText xml:lang="en">Adaptive Design</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C146995" /></CodeListItem><CodeListItem CodedValue="AGEMAX"><Decode><TranslatedText xml:lang="en">Planned Maximum Age of Subjects</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C49694" /></CodeListItem><CodeListItem CodedValue="AGEMIN"><Decode><TranslatedText xml:lang="en">Planned Minimum Age of Subjects</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C49693" /></CodeListItem><CodeListItem CodedValue="COMPTRT"><Decode><TranslatedText xml:lang="en">Comparative Treatment Name</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C68612" /></CodeListItem><CodeListItem CodedValue="CRMDUR"><Decode><TranslatedText xml:lang="en">Confirmed Response Minimum Duration</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C98715" /></CodeListItem><CodeListItem CodedValue="DOSE"><Decode><TranslatedText xml:lang="en">Dose Level</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C25488" /></CodeListItem><CodeListItem CodedValue="DOSFRQ"><Decode><TranslatedText xml:lang="en">Dosing Frequency</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C89081" /></CodeListItem><CodeListItem CodedValue="DOSU"><Decode><TranslatedText xml:lang="en">Dose Units</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C73558" /></CodeListItem><CodeListItem CodedValue="INDIC"><Decode><TranslatedText xml:lang="en">Indication for Use</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C112038" /></CodeListItem><CodeListItem CodedValue="INTMODEL"><Decode><TranslatedText xml:lang="en">Intervention Model</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C98746" /></CodeListItem><CodeListItem CodedValue="INTTYPE"><Decode><TranslatedText xml:lang="en">Intervention Type</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C98747" /></CodeListItem><CodeListItem CodedValue="NARMS"><Decode><TranslatedText xml:lang="en">Planned Number of Arms</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C98771" /></CodeListItem><CodeListItem CodedValue="OBJPRIM"><Decode><TranslatedText xml:lang="en">Study Primary Objective</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C85826" /></CodeListItem><CodeListItem CodedValue="OBJSEC"><Decode><TranslatedText xml:lang="en">Study Secondary Objective</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C85827" /></CodeListItem><CodeListItem CodedValue="OUTMSPRI"><Decode><TranslatedText xml:lang="en">Primary Outcome Measure</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C98772" /></CodeListItem><CodeListItem CodedValue="OUTMSSEC"><Decode><TranslatedText xml:lang="en">Secondary Outcome Measure</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C98781" /></CodeListItem><CodeListItem CodedValue="PLANSUB"><Decode><TranslatedText xml:lang="en">Anticipated Enrollment</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C49692" /></CodeListItem><CodeListItem CodedValue="PTRTDUR"><Decode><TranslatedText xml:lang="en">Planned Treatment Duration</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C139276" /></CodeListItem><CodeListItem CodedValue="ROUTE"><Decode><TranslatedText xml:lang="en">Route of Administration</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C38114" /></CodeListItem><CodeListItem CodedValue="SEXPOP"><Decode><TranslatedText xml:lang="en">Sex of Participants</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C49696" /></CodeListItem><CodeListItem CodedValue="SPONSOR"><Decode><TranslatedText xml:lang="en">Clinical Study Sponsor</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C70793" /></CodeListItem><CodeListItem CodedValue="STYPE"><Decode><TranslatedText xml:lang="en">Study Type</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C142175" /></CodeListItem><CodeListItem CodedValue="TBLIND"><Decode><TranslatedText xml:lang="en">Study Blinding Design</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C49658" /></CodeListItem><CodeListItem CodedValue="THERAREA"><Decode><TranslatedText xml:lang="en">Therapeutic Area</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C101302" /></CodeListItem><CodeListItem CodedValue="TINDTP"><Decode><TranslatedText xml:lang="en">Trial Intent Type</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C49652" /></CodeListItem><CodeListItem CodedValue="TITLE"><Decode><TranslatedText xml:lang="en">Official Study Title</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C49802" /></CodeListItem><CodeListItem CodedValue="TPHASE"><Decode><TranslatedText xml:lang="en">Trial Phase</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C48281" /></CodeListItem><CodeListItem CodedValue="TRT"><Decode><TranslatedText xml:lang="en">Investigational Interventional</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C41161" /></CodeListItem><CodeListItem CodedValue="TTYPE"><Decode><TranslatedText xml:lang="en">Trial Scope</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C49660" /></CodeListItem><Alias Context="nci:ExtCodeID" Name="C66738" /></CodeList><CodeList OID="CL.TSPARM" Name="Trial Summary Parameter Test Name" DataType="text" def:StandardOID="STD.SDTMCT"><CodeListItem CodedValue="Adaptive Design"><Decode><TranslatedText xml:lang="en">Adaptive Design</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C146995" /></CodeListItem><CodeListItem CodedValue="Clinical Study Sponsor"><Decode><TranslatedText xml:lang="en">Clinical Study Sponsor</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C70793" /></CodeListItem><CodeListItem CodedValue="Comparative Treatment Name"><Decode><TranslatedText xml:lang="en">Comparative Treatment Name</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C68612" /></CodeListItem><CodeListItem CodedValue="Confirmed Response Minimum Duration"><Decode><TranslatedText xml:lang="en">Confirmed Response Minimum Duration</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C98715" /></CodeListItem><CodeListItem CodedValue="Dose per Administration"><Decode><TranslatedText xml:lang="en">Dose Level</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C25488" /></CodeListItem><CodeListItem CodedValue="Dose Units"><Decode><TranslatedText xml:lang="en">Dose Units</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C73558" /></CodeListItem><CodeListItem CodedValue="Dosing Frequency"><Decode><TranslatedText xml:lang="en">Dosing Frequency</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C89081" /></CodeListItem><CodeListItem CodedValue="Intervention Model"><Decode><TranslatedText xml:lang="en">Intervention Model</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C98746" /></CodeListItem><CodeListItem CodedValue="Intervention Type"><Decode><TranslatedText xml:lang="en">Intervention Type</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C98747" /></CodeListItem><CodeListItem CodedValue="Investigational Therapy or Treatment"><Decode><TranslatedText xml:lang="en">Investigational Interventional</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C41161" /></CodeListItem><CodeListItem CodedValue="Planned Maximum Age of Subjects"><Decode><TranslatedText xml:lang="en">Planned Maximum Age of Subjects</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C49694" /></CodeListItem><CodeListItem CodedValue="Planned Minimum Age of Subjects"><Decode><TranslatedText xml:lang="en">Planned Minimum Age of Subjects</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C49693" /></CodeListItem><CodeListItem CodedValue="Planned Number of Arms"><Decode><TranslatedText xml:lang="en">Planned Number of Arms</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C98771" /></CodeListItem><CodeListItem CodedValue="Planned Number of Subjects"><Decode><TranslatedText xml:lang="en">Anticipated Enrollment</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C49692" /></CodeListItem><CodeListItem CodedValue="Planned Treatment Duration"><Decode><TranslatedText xml:lang="en">Planned Treatment Duration</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C139276" /></CodeListItem><CodeListItem CodedValue="Primary Outcome Measure"><Decode><TranslatedText xml:lang="en">Primary Outcome Measure</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C98772" /></CodeListItem><CodeListItem CodedValue="Route of Administration"><Decode><TranslatedText xml:lang="en">Route of Administration</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C38114" /></CodeListItem><CodeListItem CodedValue="Secondary Outcome Measure"><Decode><TranslatedText xml:lang="en">Secondary Outcome Measure</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C98781" /></CodeListItem><CodeListItem CodedValue="Sex of Participants"><Decode><TranslatedText xml:lang="en">Sex of Participants</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C49696" /></CodeListItem><CodeListItem CodedValue="Study Type"><Decode><TranslatedText xml:lang="en">Study Type</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C142175" /></CodeListItem><CodeListItem CodedValue="Therapeutic Area"><Decode><TranslatedText xml:lang="en">Therapeutic Area</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C101302" /></CodeListItem><CodeListItem CodedValue="Trial Blinding Schema"><Decode><TranslatedText xml:lang="en">Study Blinding Design</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C49658" /></CodeListItem><CodeListItem CodedValue="Trial Disease/Condition Indication"><Decode><TranslatedText xml:lang="en">Indication for Use</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C112038" /></CodeListItem><CodeListItem CodedValue="Trial Intent Type"><Decode><TranslatedText xml:lang="en">Trial Intent Type</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C49652" /></CodeListItem><CodeListItem CodedValue="Trial Phase Classification"><Decode><TranslatedText xml:lang="en">Trial Phase</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C48281" /></CodeListItem><CodeListItem CodedValue="Trial Primary Objective"><Decode><TranslatedText xml:lang="en">Study Primary Objective</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C85826" /></CodeListItem><CodeListItem CodedValue="Trial Secondary Objective"><Decode><TranslatedText xml:lang="en">Study Secondary Objective</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C85827" /></CodeListItem><CodeListItem CodedValue="Trial Title"><Decode><TranslatedText xml:lang="en">Official Study Title</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C49802" /></CodeListItem><CodeListItem CodedValue="Trial Type"><Decode><TranslatedText xml:lang="en">Trial Scope</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C49660" /></CodeListItem><Alias Context="nci:ExtCodeID" Name="C67152" /></CodeList><CodeList OID="CL.DICTNAM" Name="Dictionary Name" DataType="text" def:StandardOID="STD.SDTMCT"><CodeListItem CodedValue="__PLACEHOLDER__"><Decode><TranslatedText xml:lang="en">__PLACEHOLDER__</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="__PLACEHOLDER__" /></CodeListItem><Alias Context="nci:ExtCodeID" Name="C66788" /></CodeList><CodeList OID="CL.IECAT" Name="Category of Inclusion/Exclusion" DataType="text" def:StandardOID="STD.SDTMCT"><CodeListItem CodedValue="__PLACEHOLDER__"><Decode><TranslatedText xml:lang="en">__PLACEHOLDER__</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="__PLACEHOLDER__" /></CodeListItem><Alias Context="nci:ExtCodeID" Name="C66797" /></CodeList><CodeList OID="CL.CNTMODE" Name="Mode of Subject Contact" DataType="text" def:StandardOID="STD.SDTMCT"><CodeListItem CodedValue="IN PERSON"><Decode><TranslatedText xml:lang="en">In-Person</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C175574" /></CodeListItem><CodeListItem CodedValue="TELEPHONE CALL"><Decode><TranslatedText xml:lang="en">TELEPHONE CALL</TranslatedText></Decode><Alias Context="nci:ExtCodeID" Name="C171537" /></CodeListItem><Alias Context="nci:ExtCodeID" Name="C171445" /></CodeList><MethodDef OID="MT.VS.VSORRES.BMI" Name="Derive VSORRES BMI" Type="Computation"><Description><TranslatedText xml:lang="en">__PLACEHOLDER__ for derivation of VSORRES BMI</TranslatedText></Description></MethodDef><def:leaf ID="LF.acrf" xlink:href="acrf.pdf"><def:title>Annotated CRF</def:title></def:leaf></MetaDataVersion></Study></ODM>
+<ODM FileOID="ODM.DEFINE21.271279e4-1905-4c6b-87ee-b66a812090d6" AsOfDateTime="2026-06-15T14:06:09.066716+00:00"
+     CreationDateTime="2026-06-15T14:06:09.066725+00:00" ODMVersion="1.3.2" FileType="Snapshot"
+     Originator="360i Define-XML Team" SourceSystem="odmlib" SourceSystemVersion="0.2" def:Context="Other"
+     xmlns="http://www.cdisc.org/ns/odm/v1.3" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xmlns:xml="http://www.w3.org/XML/1998/namespace" xmlns:xlink="http://www.w3.org/1999/xlink"
+     xmlns:def="http://www.cdisc.org/ns/def/v2.1">
+    <Study OID="ODM.LZZT - NEW.Version1.Design1">
+        <GlobalVariables>
+            <StudyName>LZZT - NEW</StudyName>
+            <StudyDescription>Safety and Efficacy of the Xanomeline Transdermal Therapeutic System (TTS) in Patients
+                with Mild to Moderate Alzheimer's Disease
+            </StudyDescription>
+            <ProtocolName>LZZT - NEW</ProtocolName>
+        </GlobalVariables>
+        <MetaDataVersion OID="MDV.LZZT---NEW" Name="MDV LZZT - NEW" Description="Data Definitions for LZZT - NEW"
+                         def:DefineVersion="2.1.0">
+            <def:Standards>
+                <def:Standard OID="STD.SDTMIG" Name="SDTMIG" Type="IG" Version="3.4" Status="FINAL"/>
+                <def:Standard OID="STD.SDTMCT" Name="CDISC/NCI" Type="CT" Version="2025-03-28" Status="FINAL"
+                              PublishingSet="SDTM"/>
+            </def:Standards>
+            <def:AnnotatedCRF>
+                <def:DocumentRef leafID="LF.acrf"/>
+            </def:AnnotatedCRF>
+            <def:ValueListDef OID="VL.SC.SCORRES">
+                <ItemRef ItemOID="IT.SC.SCORRES.EDULEVEL" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.SC.48924878"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.SC.SCORRES.EDUYRNUM" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.SC.e7173a71"/>
+                </ItemRef>
+            </def:ValueListDef>
+            <def:ValueListDef OID="VL.SC.SCORRESU">
+                <ItemRef ItemOID="IT.SC.SCORRESU.EDUYRNUM" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.SC.5fc4562e"/>
+                </ItemRef>
+            </def:ValueListDef>
+            <def:ValueListDef OID="VL.VS.VSORRES">
+                <ItemRef ItemOID="IT.VS.VSORRES.TEMP" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.VS.df8e6ed8"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.VS.VSORRES.WEIGHT" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.VS.362bc1cf"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.VS.VSORRES.HEIGHT" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.VS.22da90ca"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.VS.VSORRES.PULSE" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.VS.90269389"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.VS.VSORRES.RESP" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.VS.02e0f161"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.VS.VSORRES.BMI" Mandatory="No" MethodOID="MT.VS.VSORRES.BMI">
+                    <def:WhereClauseRef WhereClauseOID="WC.VS.ba9d17a7"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.VS.VSORRES.SYSBP" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.VS.037b6848"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.VS.VSORRES.DIABP" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.VS.fe755a11"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.VS.VSORRES.HR" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.VS.324e0cc0"/>
+                </ItemRef>
+            </def:ValueListDef>
+            <def:ValueListDef OID="VL.VS.VSORRESU">
+                <ItemRef ItemOID="IT.VS.VSORRESU.TEMP" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.VS.dea56915"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.VS.VSORRESU.WEIGHT" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.VS.ef959fbb"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.VS.VSORRESU.HEIGHT" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.VS.97262f9f"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.VS.VSORRESU.PULSE" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.VS.2fad3005"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.VS.VSORRESU.RESP" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.VS.f296848d"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.VS.VSORRESU.BMI" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.VS.ca4251ba"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.VS.VSORRESU.SYSBP" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.VS.301c7ee3"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.VS.VSORRESU.DIABP" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.VS.714dfc07"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.VS.VSORRESU.HR" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.VS.5a9c1ab0"/>
+                </ItemRef>
+            </def:ValueListDef>
+            <def:ValueListDef OID="VL.EG.EGORRES">
+                <ItemRef ItemOID="IT.EG.EGORRES.INTP" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.EG.f60b99cb"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.EG.EGORRES.AVCOND" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.EG.d30401ba"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.EG.EGORRES.AXISVOLT" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.EG.0764363d"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.EG.EGORRES.CHYPTENL" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.EG.c7ca2c0d"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.EG.EGORRES.TECHQUAL" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.EG.0110957e"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.EG.EGORRES.IVTIACD" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.EG.7a2cbb17"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.EG.EGORRES.PACEMAKR" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.EG.c82f004b"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.EG.EGORRES.RHYNOS" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.EG.aaf51dd5"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.EG.EGORRES.SNRARRY" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.EG.0a478649"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.EG.EGORRES.SPRARRY" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.EG.44c12ce4"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.EG.EGORRES.SPRTARRY" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.EG.7c9fb72d"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.EG.EGORRES.VTARRY" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.EG.3a146a53"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.EG.EGORRES.VTTARRY" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.EG.5571a969"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.EG.EGORRES.PRAG" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.EG.13a9fd00"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.EG.EGORRES.QRSAG" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.EG.72304c3a"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.EG.EGORRES.QTAG" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.EG.6f155b1d"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.EG.EGORRES.QTCBAG" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.EG.dff815c6"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.EG.EGORRES.QTCFAG" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.EG.e967e1e7"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.EG.EGORRES.RRAG" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.EG.64f26102"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.EG.EGORRES.EGHRMN" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.EG.2ecbdce2"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.EG.EGORRES.QRS_AXIS" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.EG.9ce29aa6"/>
+                </ItemRef>
+            </def:ValueListDef>
+            <def:ValueListDef OID="VL.EG.EGORRESU">
+                <ItemRef ItemOID="IT.EG.EGORRESU.PRAG" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.EG.cec16291"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.EG.EGORRESU.QRSAG" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.EG.5a1ab0f5"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.EG.EGORRESU.QTAG" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.EG.ddb86367"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.EG.EGORRESU.QTCBAG" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.EG.e847517c"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.EG.EGORRESU.QTCFAG" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.EG.7f463007"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.EG.EGORRESU.RRAG" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.EG.3d1ba9c3"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.EG.EGORRESU.EGHRMN" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.EG.a40eb46d"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.EG.EGORRESU.QRS_AXIS" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.EG.02ebb46f"/>
+                </ItemRef>
+            </def:ValueListDef>
+            <def:ValueListDef OID="VL.LB.LBORRES">
+                <ItemRef ItemOID="IT.LB.LBORRES.HGB" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.c192b07f"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRES.HCT" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.82b97100"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRES.RBC" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.87582e25"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRES.MCH" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.95f4de22"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRES.MCHC" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.92bd1f17"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRES.MCV" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.24c0e2bc"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRES.WBC" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.351df44b"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRES.NEUTSG" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.5f2a0bab"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRES.NEUTB" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.eea0ae49"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRES.NEUT" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.550c7a01"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRES.MONO" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.de4c119b"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRES.EOS" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.a5684311"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRES.BASO" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.7b86c15b"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRES.PLAT" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.3a9d73e1"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRES.MICROCY" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.ddc3319f"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRES.MACROCY" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.116f85e4"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRES.ANISO" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.84ceb0ad"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRES.POIKILO" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.b622c728"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRES.POLYCHR" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.87b1b367"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRES.ALT" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.5412b298"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRES.ALB" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.e42a3c09"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRES.ALP" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.cdac7fcc"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRES.AST" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.b9d7ddba"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRES.CREAT" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.969c1a6d"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRES.K" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.7ce691fd"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRES.SODIUM" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.88601b52"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRES.UREAN" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.42392cd1"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRES.BICARB" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.9279ec22"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRES.CL" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.8b779a3b"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRES.BILI" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.cfe14422"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRES.GGT" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.8285c765"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRES.URATE" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.37c7b4ba"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRES.PHOS" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.e4e81dc5"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRES.CA" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.470def9b"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRES.GLUC" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.c891c160"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRES.PROT" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.abcfd20c"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRES.CHOL" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.5a1bca67"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRES.T3UP" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.4226ee02"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRES.T3" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.df33e99e"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRES.T4FR" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.30f3d8b3"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRES.T4FRIDX" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.f59f4529"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRES.TSH" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.c54221c6"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRES.VITB9" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.cb02cad8"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRES.VITB12" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.d0f49556"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRES.COLOR" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.4987b41e"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRES.SPGRAV" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.cbf789d8"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRES.KETONES" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.3239d7a3"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRES.UROBIL" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.59366afe"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRES.OCCBLD" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.3adc4566"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRES.NITRITE" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.59074de1"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRES.HBA1C" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.c1765eee"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRES.HBA1CHGB" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.dd459ec6"/>
+                </ItemRef>
+            </def:ValueListDef>
+            <def:ValueListDef OID="VL.LB.LBORRESU">
+                <ItemRef ItemOID="IT.LB.LBORRESU.HGB" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.e9a1c33d"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRESU.HCT" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.7f0975c7"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRESU.RBC" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.f7f1de35"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRESU.MCH" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.c32acb17"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRESU.MCHC" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.eb7f048a"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRESU.MCV" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.e881d4b5"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRESU.WBC" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.41785be6"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRESU.NEUTSG" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.a68e5eaa"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRESU.NEUTB" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.aad6dbd6"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRESU.NEUT" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.d13d6578"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRESU.MONO" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.00e6d228"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRESU.EOS" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.ef654de1"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRESU.BASO" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.b6fa6e8d"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRESU.PLAT" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.90eedf3b"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRESU.ALT" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.8914eb45"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRESU.ALP" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.6660e11c"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRESU.AST" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.37e389df"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRESU.CREAT" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.549f5ae4"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRESU.K" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.ee634517"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRESU.SODIUM" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.07a8daa1"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRESU.UREAN" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.91d1c3d5"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRESU.BICARB" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.9df0845c"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRESU.CL" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.cc8b6004"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRESU.GGT" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.3c564f36"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRESU.URATE" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.13fbb1a5"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRESU.PHOS" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.3749493c"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRESU.CA" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.38f9f39d"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRESU.CHOL" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.516f3664"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRESU.T3UP" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.dcbcbe57"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRESU.T3" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.b7b215a1"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRESU.T4FR" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.0f071538"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRESU.T4FRIDX" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.258e657c"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRESU.TSH" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.d675561c"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRESU.VITB9" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.e81938d6"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRESU.VITB12" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.54dda2d1"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRESU.UROBIL" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.e6a434ec"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRESU.HBA1C" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.9e9118c8"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.LB.LBORRESU.HBA1CHGB" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.LB.8644d9ca"/>
+                </ItemRef>
+            </def:ValueListDef>
+            <def:ValueListDef OID="VL.MB.MBORRES">
+                <ItemRef ItemOID="IT.MB.MBORRES.TPLAB" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.MB.49773274"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.MB.MBORRES.TPADNA" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.MB.e698c5a2"/>
+                </ItemRef>
+            </def:ValueListDef>
+            <def:ValueListDef OID="VL.TS.TSPARMCD">
+                <ItemRef ItemOID="IT.TS.TSPARMCD.ADAPT" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.TS.08ebd0ce"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.TS.TSPARMCD.AGEMIN" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.TS.a7d24f4a"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.TS.TSPARMCD.AGEMAX" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.TS.4ac86c98"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.TS.TSPARMCD.COMPTRT" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.TS.54cd02f1"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.TS.TSPARMCD.CRMDUR" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.TS.f9fa8745"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.TS.TSPARMCD.DOSE" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.TS.7fc6c3e6"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.TS.TSPARMCD.DOSFRQ" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.TS.5cd14c68"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.TS.TSPARMCD.DOSU" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.TS.4053f56c"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.TS.TSPARMCD.INDIC" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.TS.9cdae039"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.TS.TSPARMCD.INTMODEL" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.TS.2c83b5d9"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.TS.TSPARMCD.INTTYPE" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.TS.e3ae16cd"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.TS.TSPARMCD.NARMS" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.TS.89c0d243"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.TS.TSPARMCD.OBJPRIM" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.TS.7a056c75"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.TS.TSPARMCD.OBJSEC" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.TS.36721696"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.TS.TSPARMCD.OUTMSPRI" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.TS.d8b84608"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.TS.TSPARMCD.OUTMSSEC" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.TS.1d3cd461"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.TS.TSPARMCD.PLANSUB" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.TS.3a1c5c3c"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.TS.TSPARMCD.PTRTDUR" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.TS.2b2d70bc"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.TS.TSPARMCD.ROUTE" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.TS.3c4a8bf2"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.TS.TSPARMCD.SEXPOP" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.TS.4f0c74c2"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.TS.TSPARMCD.SPONSOR" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.TS.51236927"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.TS.TSPARMCD.STYPE" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.TS.f4cb41bb"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.TS.TSPARMCD.TBLIND" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.TS.9e101607"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.TS.TSPARMCD.THERAREA" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.TS.d8c1ac4c"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.TS.TSPARMCD.TINDTP" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.TS.e423672b"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.TS.TSPARMCD.TITLE" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.TS.43684533"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.TS.TSPARMCD.TPHASE" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.TS.22640600"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.TS.TSPARMCD.TRT" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.TS.1948fed3"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.TS.TSPARMCD.TTYPE" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.TS.29af0670"/>
+                </ItemRef>
+            </def:ValueListDef>
+            <def:ValueListDef OID="VL.IE.IEORRES">
+                <ItemRef ItemOID="IT.IE.IEORRES.IN01" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.IE.1d2bb25f"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.IE.IEORRES.IN02" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.IE.fa688bf3"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.IE.IEORRES.IN03" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.IE.f276b607"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.IE.IEORRES.IN04" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.IE.cd528448"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.IE.IEORRES.IN05" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.IE.c1db3fd3"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.IE.IEORRES.IN06" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.IE.c2ec614b"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.IE.IEORRES.IN07" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.IE.2ef341aa"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.IE.IEORRES.IN08" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.IE.5d85184b"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.IE.IEORRES.EX01" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.IE.8579104c"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.IE.IEORRES.EX02" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.IE.74eacc45"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.IE.IEORRES.EX03" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.IE.ce0e8d09"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.IE.IEORRES.EX04" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.IE.945bafbd"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.IE.IEORRES.EX05" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.IE.afbec960"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.IE.IEORRES.EX06" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.IE.cac0d3f4"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.IE.IEORRES.EX07" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.IE.cabd9be0"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.IE.IEORRES.EX08" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.IE.fbae7983"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.IE.IEORRES.EX09" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.IE.0952c014"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.IE.IEORRES.EX10" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.IE.5b8b02b2"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.IE.IEORRES.EX11" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.IE.70a941e7"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.IE.IEORRES.EX12" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.IE.611f5d7b"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.IE.IEORRES.EX13" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.IE.8abff918"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.IE.IEORRES.EX14" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.IE.b089a2a0"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.IE.IEORRES.EX15" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.IE.39cb2456"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.IE.IEORRES.EX16" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.IE.2cdb5c18"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.IE.IEORRES.EX17" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.IE.b415f3a9"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.IE.IEORRES.EX18" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.IE.5c29f970"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.IE.IEORRES.EX19" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.IE.9fe9a358"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.IE.IEORRES.EX20" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.IE.e36b210b"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.IE.IEORRES.EX21" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.IE.743b4fb5"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.IE.IEORRES.EX22" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.IE.76a82754"/>
+                </ItemRef>
+                <ItemRef ItemOID="IT.IE.IEORRES.EX23" Mandatory="No">
+                    <def:WhereClauseRef WhereClauseOID="WC.IE.fbeb5a1e"/>
+                </ItemRef>
+            </def:ValueListDef>
+            <def:WhereClauseDef OID="WC.SC.48924878">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.SC.SCTESTCD" Comparator="EQ">
+                    <CheckValue>EDULEVEL</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.SC.e7173a71">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.SC.SCTESTCD" Comparator="EQ">
+                    <CheckValue>EDUYRNUM</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.SC.5fc4562e">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.SC.SCTESTCD" Comparator="EQ">
+                    <CheckValue>EDUYRNUM</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.VS.df8e6ed8">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSTESTCD" Comparator="EQ">
+                    <CheckValue>TEMP</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSLOC" Comparator="IN">
+                    <CheckValue>AXILLA</CheckValue>
+                    <CheckValue>EAR</CheckValue>
+                    <CheckValue>FOREHEAD</CheckValue>
+                    <CheckValue>ORAL CAVITY</CheckValue>
+                    <CheckValue>RECTUM</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.VS.362bc1cf">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSTESTCD" Comparator="EQ">
+                    <CheckValue>WEIGHT</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.VS.22da90ca">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSTESTCD" Comparator="EQ">
+                    <CheckValue>HEIGHT</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.VS.90269389">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSTESTCD" Comparator="EQ">
+                    <CheckValue>PULSE</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSPOS" Comparator="IN">
+                    <CheckValue>PRONE</CheckValue>
+                    <CheckValue>SEMI-RECUMBENT</CheckValue>
+                    <CheckValue>SITTING</CheckValue>
+                    <CheckValue>STANDING</CheckValue>
+                    <CheckValue>SUPINE</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSLOC" Comparator="IN">
+                    <CheckValue>BRACHIAL ARTERY</CheckValue>
+                    <CheckValue>CAROTID ARTERY</CheckValue>
+                    <CheckValue>CEREBRAL ARTERY</CheckValue>
+                    <CheckValue>DORSALIS PEDIS ARTERY</CheckValue>
+                    <CheckValue>FEMORAL ARTERY</CheckValue>
+                    <CheckValue>RADIAL ARTERY</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSLAT" Comparator="IN">
+                    <CheckValue>LEFT</CheckValue>
+                    <CheckValue>RIGHT</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.VS.02e0f161">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSTESTCD" Comparator="EQ">
+                    <CheckValue>RESP</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.VS.ba9d17a7">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSTESTCD" Comparator="EQ">
+                    <CheckValue>BMI</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.VS.037b6848">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSTESTCD" Comparator="EQ">
+                    <CheckValue>SYSBP</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSPOS" Comparator="IN">
+                    <CheckValue>PRONE</CheckValue>
+                    <CheckValue>SEMI-RECUMBENT</CheckValue>
+                    <CheckValue>SITTING</CheckValue>
+                    <CheckValue>STANDING</CheckValue>
+                    <CheckValue>SUPINE</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSLOC" Comparator="IN">
+                    <CheckValue>BRACHIAL ARTERY</CheckValue>
+                    <CheckValue>CAROTID ARTERY</CheckValue>
+                    <CheckValue>DORSALIS PEDIS ARTERY</CheckValue>
+                    <CheckValue>FEMORAL ARTERY</CheckValue>
+                    <CheckValue>FINGER</CheckValue>
+                    <CheckValue>RADIAL ARTERY</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSLAT" Comparator="IN">
+                    <CheckValue>LEFT</CheckValue>
+                    <CheckValue>RIGHT</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.VS.fe755a11">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSTESTCD" Comparator="EQ">
+                    <CheckValue>DIABP</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSPOS" Comparator="IN">
+                    <CheckValue>PRONE</CheckValue>
+                    <CheckValue>SEMI-RECUMBENT</CheckValue>
+                    <CheckValue>SITTING</CheckValue>
+                    <CheckValue>STANDING</CheckValue>
+                    <CheckValue>SUPINE</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSLOC" Comparator="IN">
+                    <CheckValue>BRACHIAL ARTERY</CheckValue>
+                    <CheckValue>CAROTID ARTERY</CheckValue>
+                    <CheckValue>DORSALIS PEDIS ARTERY</CheckValue>
+                    <CheckValue>FEMORAL ARTERY</CheckValue>
+                    <CheckValue>FINGER</CheckValue>
+                    <CheckValue>RADIAL ARTERY</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSLAT" Comparator="IN">
+                    <CheckValue>LEFT</CheckValue>
+                    <CheckValue>RIGHT</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.VS.324e0cc0">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSTESTCD" Comparator="EQ">
+                    <CheckValue>HR</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSPOS" Comparator="IN">
+                    <CheckValue>PRONE</CheckValue>
+                    <CheckValue>SEMI-RECUMBENT</CheckValue>
+                    <CheckValue>SITTING</CheckValue>
+                    <CheckValue>STANDING</CheckValue>
+                    <CheckValue>SUPINE</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSLOC" Comparator="IN">
+                    <CheckValue>BRACHIAL ARTERY</CheckValue>
+                    <CheckValue>CAROTID ARTERY</CheckValue>
+                    <CheckValue>CEREBRAL ARTERY</CheckValue>
+                    <CheckValue>DORSALIS PEDIS ARTERY</CheckValue>
+                    <CheckValue>FEMORAL ARTERY</CheckValue>
+                    <CheckValue>RADIAL ARTERY</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSLAT" Comparator="IN">
+                    <CheckValue>LEFT</CheckValue>
+                    <CheckValue>RIGHT</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.VS.dea56915">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSTESTCD" Comparator="EQ">
+                    <CheckValue>TEMP</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSLOC" Comparator="IN">
+                    <CheckValue>AXILLA</CheckValue>
+                    <CheckValue>EAR</CheckValue>
+                    <CheckValue>FOREHEAD</CheckValue>
+                    <CheckValue>ORAL CAVITY</CheckValue>
+                    <CheckValue>RECTUM</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.VS.ef959fbb">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSTESTCD" Comparator="EQ">
+                    <CheckValue>WEIGHT</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.VS.97262f9f">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSTESTCD" Comparator="EQ">
+                    <CheckValue>HEIGHT</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.VS.2fad3005">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSTESTCD" Comparator="EQ">
+                    <CheckValue>PULSE</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSPOS" Comparator="IN">
+                    <CheckValue>PRONE</CheckValue>
+                    <CheckValue>SEMI-RECUMBENT</CheckValue>
+                    <CheckValue>SITTING</CheckValue>
+                    <CheckValue>STANDING</CheckValue>
+                    <CheckValue>SUPINE</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSLOC" Comparator="IN">
+                    <CheckValue>BRACHIAL ARTERY</CheckValue>
+                    <CheckValue>CAROTID ARTERY</CheckValue>
+                    <CheckValue>CEREBRAL ARTERY</CheckValue>
+                    <CheckValue>DORSALIS PEDIS ARTERY</CheckValue>
+                    <CheckValue>FEMORAL ARTERY</CheckValue>
+                    <CheckValue>RADIAL ARTERY</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSLAT" Comparator="IN">
+                    <CheckValue>LEFT</CheckValue>
+                    <CheckValue>RIGHT</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.VS.f296848d">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSTESTCD" Comparator="EQ">
+                    <CheckValue>RESP</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.VS.ca4251ba">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSTESTCD" Comparator="EQ">
+                    <CheckValue>BMI</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.VS.301c7ee3">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSTESTCD" Comparator="EQ">
+                    <CheckValue>SYSBP</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSPOS" Comparator="IN">
+                    <CheckValue>PRONE</CheckValue>
+                    <CheckValue>SEMI-RECUMBENT</CheckValue>
+                    <CheckValue>SITTING</CheckValue>
+                    <CheckValue>STANDING</CheckValue>
+                    <CheckValue>SUPINE</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSLOC" Comparator="IN">
+                    <CheckValue>BRACHIAL ARTERY</CheckValue>
+                    <CheckValue>CAROTID ARTERY</CheckValue>
+                    <CheckValue>DORSALIS PEDIS ARTERY</CheckValue>
+                    <CheckValue>FEMORAL ARTERY</CheckValue>
+                    <CheckValue>FINGER</CheckValue>
+                    <CheckValue>RADIAL ARTERY</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSLAT" Comparator="IN">
+                    <CheckValue>LEFT</CheckValue>
+                    <CheckValue>RIGHT</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.VS.714dfc07">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSTESTCD" Comparator="EQ">
+                    <CheckValue>DIABP</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSPOS" Comparator="IN">
+                    <CheckValue>PRONE</CheckValue>
+                    <CheckValue>SEMI-RECUMBENT</CheckValue>
+                    <CheckValue>SITTING</CheckValue>
+                    <CheckValue>STANDING</CheckValue>
+                    <CheckValue>SUPINE</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSLOC" Comparator="IN">
+                    <CheckValue>BRACHIAL ARTERY</CheckValue>
+                    <CheckValue>CAROTID ARTERY</CheckValue>
+                    <CheckValue>DORSALIS PEDIS ARTERY</CheckValue>
+                    <CheckValue>FEMORAL ARTERY</CheckValue>
+                    <CheckValue>FINGER</CheckValue>
+                    <CheckValue>RADIAL ARTERY</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSLAT" Comparator="IN">
+                    <CheckValue>LEFT</CheckValue>
+                    <CheckValue>RIGHT</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.VS.5a9c1ab0">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSTESTCD" Comparator="EQ">
+                    <CheckValue>HR</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSPOS" Comparator="IN">
+                    <CheckValue>PRONE</CheckValue>
+                    <CheckValue>SEMI-RECUMBENT</CheckValue>
+                    <CheckValue>SITTING</CheckValue>
+                    <CheckValue>STANDING</CheckValue>
+                    <CheckValue>SUPINE</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSLOC" Comparator="IN">
+                    <CheckValue>BRACHIAL ARTERY</CheckValue>
+                    <CheckValue>CAROTID ARTERY</CheckValue>
+                    <CheckValue>CEREBRAL ARTERY</CheckValue>
+                    <CheckValue>DORSALIS PEDIS ARTERY</CheckValue>
+                    <CheckValue>FEMORAL ARTERY</CheckValue>
+                    <CheckValue>RADIAL ARTERY</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSLAT" Comparator="IN">
+                    <CheckValue>LEFT</CheckValue>
+                    <CheckValue>RIGHT</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.EG.f60b99cb">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ">
+                    <CheckValue>INTP</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN">
+                    <CheckValue>ADJUDICATION COMMITTEE</CheckValue>
+                    <CheckValue>INDEPENDENT ASSESSOR</CheckValue>
+                    <CheckValue>INVESTIGATOR</CheckValue>
+                    <CheckValue>VENDOR</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.EG.d30401ba">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ">
+                    <CheckValue>AVCOND</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN">
+                    <CheckValue>ADJUDICATION COMMITTEE</CheckValue>
+                    <CheckValue>INDEPENDENT ASSESSOR</CheckValue>
+                    <CheckValue>INVESTIGATOR</CheckValue>
+                    <CheckValue>VENDOR</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.EG.0764363d">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ">
+                    <CheckValue>AXISVOLT</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN">
+                    <CheckValue>ADJUDICATION COMMITTEE</CheckValue>
+                    <CheckValue>INDEPENDENT ASSESSOR</CheckValue>
+                    <CheckValue>INVESTIGATOR</CheckValue>
+                    <CheckValue>VENDOR</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.EG.c7ca2c0d">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ">
+                    <CheckValue>CHYPTENL</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN">
+                    <CheckValue>ADJUDICATION COMMITTEE</CheckValue>
+                    <CheckValue>INDEPENDENT ASSESSOR</CheckValue>
+                    <CheckValue>INVESTIGATOR</CheckValue>
+                    <CheckValue>VENDOR</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.EG.0110957e">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ">
+                    <CheckValue>TECHQUAL</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN">
+                    <CheckValue>ADJUDICATION COMMITTEE</CheckValue>
+                    <CheckValue>INDEPENDENT ASSESSOR</CheckValue>
+                    <CheckValue>INVESTIGATOR</CheckValue>
+                    <CheckValue>VENDOR</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.EG.7a2cbb17">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ">
+                    <CheckValue>IVTIACD</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN">
+                    <CheckValue>ADJUDICATION COMMITTEE</CheckValue>
+                    <CheckValue>INDEPENDENT ASSESSOR</CheckValue>
+                    <CheckValue>INVESTIGATOR</CheckValue>
+                    <CheckValue>VENDOR</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.EG.c82f004b">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ">
+                    <CheckValue>PACEMAKR</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN">
+                    <CheckValue>ADJUDICATION COMMITTEE</CheckValue>
+                    <CheckValue>INDEPENDENT ASSESSOR</CheckValue>
+                    <CheckValue>INVESTIGATOR</CheckValue>
+                    <CheckValue>VENDOR</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.EG.aaf51dd5">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ">
+                    <CheckValue>RHYNOS</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN">
+                    <CheckValue>ADJUDICATION COMMITTEE</CheckValue>
+                    <CheckValue>INDEPENDENT ASSESSOR</CheckValue>
+                    <CheckValue>INVESTIGATOR</CheckValue>
+                    <CheckValue>VENDOR</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.EG.0a478649">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ">
+                    <CheckValue>SNRARRY</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN">
+                    <CheckValue>ADJUDICATION COMMITTEE</CheckValue>
+                    <CheckValue>INDEPENDENT ASSESSOR</CheckValue>
+                    <CheckValue>INVESTIGATOR</CheckValue>
+                    <CheckValue>VENDOR</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.EG.44c12ce4">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ">
+                    <CheckValue>SPRARRY</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN">
+                    <CheckValue>ADJUDICATION COMMITTEE</CheckValue>
+                    <CheckValue>INDEPENDENT ASSESSOR</CheckValue>
+                    <CheckValue>INVESTIGATOR</CheckValue>
+                    <CheckValue>VENDOR</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.EG.7c9fb72d">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ">
+                    <CheckValue>SPRTARRY</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN">
+                    <CheckValue>ADJUDICATION COMMITTEE</CheckValue>
+                    <CheckValue>INDEPENDENT ASSESSOR</CheckValue>
+                    <CheckValue>INVESTIGATOR</CheckValue>
+                    <CheckValue>VENDOR</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.EG.3a146a53">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ">
+                    <CheckValue>VTARRY</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN">
+                    <CheckValue>ADJUDICATION COMMITTEE</CheckValue>
+                    <CheckValue>INDEPENDENT ASSESSOR</CheckValue>
+                    <CheckValue>INVESTIGATOR</CheckValue>
+                    <CheckValue>VENDOR</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.EG.5571a969">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ">
+                    <CheckValue>VTTARRY</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN">
+                    <CheckValue>ADJUDICATION COMMITTEE</CheckValue>
+                    <CheckValue>INDEPENDENT ASSESSOR</CheckValue>
+                    <CheckValue>INVESTIGATOR</CheckValue>
+                    <CheckValue>VENDOR</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.EG.13a9fd00">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ">
+                    <CheckValue>PRAG</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN">
+                    <CheckValue>ADJUDICATION COMMITTEE</CheckValue>
+                    <CheckValue>INDEPENDENT ASSESSOR</CheckValue>
+                    <CheckValue>INVESTIGATOR</CheckValue>
+                    <CheckValue>VENDOR</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.EG.72304c3a">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ">
+                    <CheckValue>QRSAG</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN">
+                    <CheckValue>ADJUDICATION COMMITTEE</CheckValue>
+                    <CheckValue>INDEPENDENT ASSESSOR</CheckValue>
+                    <CheckValue>INVESTIGATOR</CheckValue>
+                    <CheckValue>VENDOR</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.EG.6f155b1d">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ">
+                    <CheckValue>QTAG</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN">
+                    <CheckValue>ADJUDICATION COMMITTEE</CheckValue>
+                    <CheckValue>INDEPENDENT ASSESSOR</CheckValue>
+                    <CheckValue>INVESTIGATOR</CheckValue>
+                    <CheckValue>VENDOR</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.EG.dff815c6">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ">
+                    <CheckValue>QTCBAG</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN">
+                    <CheckValue>ADJUDICATION COMMITTEE</CheckValue>
+                    <CheckValue>INDEPENDENT ASSESSOR</CheckValue>
+                    <CheckValue>INVESTIGATOR</CheckValue>
+                    <CheckValue>VENDOR</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.EG.e967e1e7">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ">
+                    <CheckValue>QTCFAG</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN">
+                    <CheckValue>ADJUDICATION COMMITTEE</CheckValue>
+                    <CheckValue>INDEPENDENT ASSESSOR</CheckValue>
+                    <CheckValue>INVESTIGATOR</CheckValue>
+                    <CheckValue>VENDOR</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.EG.64f26102">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ">
+                    <CheckValue>RRAG</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN">
+                    <CheckValue>ADJUDICATION COMMITTEE</CheckValue>
+                    <CheckValue>INDEPENDENT ASSESSOR</CheckValue>
+                    <CheckValue>INVESTIGATOR</CheckValue>
+                    <CheckValue>VENDOR</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.EG.2ecbdce2">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ">
+                    <CheckValue>EGHRMN</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN">
+                    <CheckValue>ADJUDICATION COMMITTEE</CheckValue>
+                    <CheckValue>INDEPENDENT ASSESSOR</CheckValue>
+                    <CheckValue>INVESTIGATOR</CheckValue>
+                    <CheckValue>VENDOR</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.EG.9ce29aa6">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ">
+                    <CheckValue>QRS_AXIS</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN">
+                    <CheckValue>ADJUDICATION COMMITTEE</CheckValue>
+                    <CheckValue>INDEPENDENT ASSESSOR</CheckValue>
+                    <CheckValue>INVESTIGATOR</CheckValue>
+                    <CheckValue>VENDOR</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.EG.cec16291">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ">
+                    <CheckValue>PRAG</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN">
+                    <CheckValue>ADJUDICATION COMMITTEE</CheckValue>
+                    <CheckValue>INDEPENDENT ASSESSOR</CheckValue>
+                    <CheckValue>INVESTIGATOR</CheckValue>
+                    <CheckValue>VENDOR</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.EG.5a1ab0f5">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ">
+                    <CheckValue>QRSAG</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN">
+                    <CheckValue>ADJUDICATION COMMITTEE</CheckValue>
+                    <CheckValue>INDEPENDENT ASSESSOR</CheckValue>
+                    <CheckValue>INVESTIGATOR</CheckValue>
+                    <CheckValue>VENDOR</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.EG.ddb86367">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ">
+                    <CheckValue>QTAG</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN">
+                    <CheckValue>ADJUDICATION COMMITTEE</CheckValue>
+                    <CheckValue>INDEPENDENT ASSESSOR</CheckValue>
+                    <CheckValue>INVESTIGATOR</CheckValue>
+                    <CheckValue>VENDOR</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.EG.e847517c">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ">
+                    <CheckValue>QTCBAG</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN">
+                    <CheckValue>ADJUDICATION COMMITTEE</CheckValue>
+                    <CheckValue>INDEPENDENT ASSESSOR</CheckValue>
+                    <CheckValue>INVESTIGATOR</CheckValue>
+                    <CheckValue>VENDOR</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.EG.7f463007">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ">
+                    <CheckValue>QTCFAG</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN">
+                    <CheckValue>ADJUDICATION COMMITTEE</CheckValue>
+                    <CheckValue>INDEPENDENT ASSESSOR</CheckValue>
+                    <CheckValue>INVESTIGATOR</CheckValue>
+                    <CheckValue>VENDOR</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.EG.3d1ba9c3">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ">
+                    <CheckValue>RRAG</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN">
+                    <CheckValue>ADJUDICATION COMMITTEE</CheckValue>
+                    <CheckValue>INDEPENDENT ASSESSOR</CheckValue>
+                    <CheckValue>INVESTIGATOR</CheckValue>
+                    <CheckValue>VENDOR</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.EG.a40eb46d">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ">
+                    <CheckValue>EGHRMN</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN">
+                    <CheckValue>ADJUDICATION COMMITTEE</CheckValue>
+                    <CheckValue>INDEPENDENT ASSESSOR</CheckValue>
+                    <CheckValue>INVESTIGATOR</CheckValue>
+                    <CheckValue>VENDOR</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.EG.02ebb46f">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ">
+                    <CheckValue>QRS_AXIS</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGEVAL" Comparator="IN">
+                    <CheckValue>ADJUDICATION COMMITTEE</CheckValue>
+                    <CheckValue>INDEPENDENT ASSESSOR</CheckValue>
+                    <CheckValue>INVESTIGATOR</CheckValue>
+                    <CheckValue>VENDOR</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.c192b07f">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>HGB</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>BLOOD</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBMETHOD" Comparator="EQ">
+                    <CheckValue>DIPSTICK MEASUREMENT METHOD</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.82b97100">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>HCT</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>BLOOD</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.87582e25">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>RBC</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>BLOOD</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.95f4de22">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>MCH</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>ERYTHROCYTES</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.92bd1f17">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>MCHC</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>ERYTHROCYTES</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.24c0e2bc">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>MCV</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>ERYTHROCYTES</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.351df44b">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>WBC</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>BLOOD</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.5f2a0bab">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>NEUTSG</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>BLOOD</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.eea0ae49">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>NEUTB</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>BLOOD</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.550c7a01">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>NEUT</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>BLOOD</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.de4c119b">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>MONO</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>BLOOD</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.a5684311">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>EOS</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>BLOOD</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.7b86c15b">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>BASO</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>BLOOD</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.3a9d73e1">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>PLAT</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>BLOOD</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.ddc3319f">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>MICROCY</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>URINE SEDIMENT</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.116f85e4">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>MACROCY</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>URINE SEDIMENT</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.84ceb0ad">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>ANISO</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>BLOOD</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.b622c728">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>POIKILO</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>BLOOD</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.87b1b367">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>POLYCHR</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>BLOOD</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.5412b298">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>ALT</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>SERUM OR PLASMA</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.e42a3c09">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>ALB</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>URINE</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.cdac7fcc">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>ALP</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>SERUM OR PLASMA</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.b9d7ddba">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>AST</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>SERUM OR PLASMA</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.969c1a6d">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>CREAT</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>URINE</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.7ce691fd">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>K</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>URINE</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.88601b52">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>SODIUM</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>URINE</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.42392cd1">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>UREAN</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>SERUM OR PLASMA</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.9279ec22">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>BICARB</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>BLOOD</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.8b779a3b">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>CL</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>SERUM OR PLASMA</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.cfe14422">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>BILI</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>URINE</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.8285c765">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>GGT</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>SERUM OR PLASMA</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.37c7b4ba">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>URATE</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>SERUM OR PLASMA</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.e4e81dc5">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>PHOS</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>SERUM OR PLASMA</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.470def9b">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>CA</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>SERUM OR PLASMA</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.c891c160">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>GLUC</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>URINE</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.abcfd20c">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>PROT</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>URINE</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.5a1bca67">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>CHOL</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>SERUM OR PLASMA</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.4226ee02">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>T3UP</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>SERUM OR PLASMA</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.df33e99e">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>T3</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>SERUM OR PLASMA</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.30f3d8b3">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>T4FR</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>SERUM OR PLASMA</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.f59f4529">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>T4FRIDX</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>SERUM OR PLASMA</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.c54221c6">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>TSH</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>SERUM OR PLASMA</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.cb02cad8">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>VITB9</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>SERUM OR PLASMA</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.d0f49556">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>VITB12</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>SERUM OR PLASMA</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.4987b41e">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>COLOR</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>URINE</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.cbf789d8">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>SPGRAV</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>URINE</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.3239d7a3">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>KETONES</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>URINE</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.59366afe">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>UROBIL</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>URINE</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.3adc4566">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>OCCBLD</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>STOOL</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.59074de1">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>NITRITE</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>URINE</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.c1765eee">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>HBA1C</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>BLOOD</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.dd459ec6">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>HBA1CHGB</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>BLOOD</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.e9a1c33d">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>HGB</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>BLOOD</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBMETHOD" Comparator="EQ">
+                    <CheckValue>DIPSTICK MEASUREMENT METHOD</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.7f0975c7">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>HCT</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>BLOOD</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.f7f1de35">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>RBC</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>BLOOD</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.c32acb17">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>MCH</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>ERYTHROCYTES</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.eb7f048a">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>MCHC</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>ERYTHROCYTES</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.e881d4b5">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>MCV</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>ERYTHROCYTES</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.41785be6">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>WBC</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>BLOOD</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.a68e5eaa">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>NEUTSG</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>BLOOD</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.aad6dbd6">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>NEUTB</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>BLOOD</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.d13d6578">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>NEUT</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>BLOOD</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.00e6d228">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>MONO</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>BLOOD</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.ef654de1">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>EOS</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>BLOOD</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.b6fa6e8d">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>BASO</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>BLOOD</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.90eedf3b">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>PLAT</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>BLOOD</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.8914eb45">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>ALT</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>SERUM OR PLASMA</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.6660e11c">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>ALP</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>SERUM OR PLASMA</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.37e389df">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>AST</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>SERUM OR PLASMA</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.549f5ae4">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>CREAT</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>URINE</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.ee634517">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>K</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>URINE</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.07a8daa1">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>SODIUM</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>URINE</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.91d1c3d5">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>UREAN</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>SERUM OR PLASMA</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.9df0845c">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>BICARB</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>BLOOD</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.cc8b6004">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>CL</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>SERUM OR PLASMA</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.3c564f36">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>GGT</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>SERUM OR PLASMA</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.13fbb1a5">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>URATE</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>SERUM OR PLASMA</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.3749493c">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>PHOS</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>SERUM OR PLASMA</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.38f9f39d">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>CA</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>SERUM OR PLASMA</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.516f3664">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>CHOL</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>SERUM OR PLASMA</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.dcbcbe57">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>T3UP</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>SERUM OR PLASMA</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.b7b215a1">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>T3</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>SERUM OR PLASMA</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.0f071538">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>T4FR</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>SERUM OR PLASMA</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.258e657c">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>T4FRIDX</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>SERUM OR PLASMA</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.d675561c">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>TSH</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>SERUM OR PLASMA</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.e81938d6">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>VITB9</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>SERUM OR PLASMA</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.54dda2d1">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>VITB12</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>SERUM OR PLASMA</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.e6a434ec">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>UROBIL</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>URINE</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.9e9118c8">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>HBA1C</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>BLOOD</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.LB.8644d9ca">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+                    <CheckValue>HBA1CHGB</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+                    <CheckValue>BLOOD</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.MB.49773274">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.MB.MBTESTCD" Comparator="EQ">
+                    <CheckValue>TPLAB</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.MB.MBTSTDTL" Comparator="EQ">
+                    <CheckValue>DETECTION</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.MB.MBSPEC" Comparator="EQ">
+                    <CheckValue>SERUM</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.MB.MBMETHOD" Comparator="IN">
+                    <CheckValue>FLUORESCENT IMMUNOASSAY</CheckValue>
+                    <CheckValue>HEMAGGLUTINATION ASSAY</CheckValue>
+                    <CheckValue>CHEMILUMINESCENT MICROPARTICLE IMMUNOASSAY</CheckValue>
+                    <CheckValue>POLYMERASE CHAIN REACTION</CheckValue>
+                    <CheckValue>IMMUNOBLOT</CheckValue>
+                    <CheckValue>RAPID IMMUNOASSAY</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.MB.e698c5a2">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.MB.MBTESTCD" Comparator="EQ">
+                    <CheckValue>TPADNA</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.MB.MBTSTDTL" Comparator="EQ">
+                    <CheckValue>DETECTION</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.MB.MBSPEC" Comparator="IN">
+                    <CheckValue>BLOOD</CheckValue>
+                    <CheckValue>CEREBROSPINAL FLUID</CheckValue>
+                    <CheckValue>FLUID</CheckValue>
+                    <CheckValue>SWABBED MATERIAL</CheckValue>
+                    <CheckValue>URINE</CheckValue>
+                </RangeCheck>
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.MB.MBMETHOD" Comparator="EQ">
+                    <CheckValue>LINE PROBE ASSAY</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.TS.08ebd0ce">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ">
+                    <CheckValue>ADAPT</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.TS.a7d24f4a">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ">
+                    <CheckValue>AGEMIN</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.TS.4ac86c98">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ">
+                    <CheckValue>AGEMAX</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.TS.54cd02f1">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ">
+                    <CheckValue>COMPTRT</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.TS.f9fa8745">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ">
+                    <CheckValue>CRMDUR</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.TS.7fc6c3e6">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ">
+                    <CheckValue>DOSE</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.TS.5cd14c68">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ">
+                    <CheckValue>DOSFRQ</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.TS.4053f56c">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ">
+                    <CheckValue>DOSU</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.TS.9cdae039">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ">
+                    <CheckValue>INDIC</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.TS.2c83b5d9">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ">
+                    <CheckValue>INTMODEL</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.TS.e3ae16cd">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ">
+                    <CheckValue>INTTYPE</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.TS.89c0d243">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ">
+                    <CheckValue>NARMS</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.TS.7a056c75">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ">
+                    <CheckValue>OBJPRIM</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.TS.36721696">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ">
+                    <CheckValue>OBJSEC</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.TS.d8b84608">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ">
+                    <CheckValue>OUTMSPRI</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.TS.1d3cd461">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ">
+                    <CheckValue>OUTMSSEC</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.TS.3a1c5c3c">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ">
+                    <CheckValue>PLANSUB</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.TS.2b2d70bc">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ">
+                    <CheckValue>PTRTDUR</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.TS.3c4a8bf2">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ">
+                    <CheckValue>ROUTE</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.TS.4f0c74c2">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ">
+                    <CheckValue>SEXPOP</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.TS.51236927">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ">
+                    <CheckValue>SPONSOR</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.TS.f4cb41bb">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ">
+                    <CheckValue>STYPE</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.TS.9e101607">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ">
+                    <CheckValue>TBLIND</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.TS.d8c1ac4c">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ">
+                    <CheckValue>THERAREA</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.TS.e423672b">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ">
+                    <CheckValue>TINDTP</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.TS.43684533">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ">
+                    <CheckValue>TITLE</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.TS.22640600">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ">
+                    <CheckValue>TPHASE</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.TS.1948fed3">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ">
+                    <CheckValue>TRT</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.TS.29af0670">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ">
+                    <CheckValue>TTYPE</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.IE.1d2bb25f">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ">
+                    <CheckValue>IN01</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.IE.fa688bf3">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ">
+                    <CheckValue>IN02</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.IE.f276b607">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ">
+                    <CheckValue>IN03</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.IE.cd528448">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ">
+                    <CheckValue>IN04</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.IE.c1db3fd3">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ">
+                    <CheckValue>IN05</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.IE.c2ec614b">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ">
+                    <CheckValue>IN06</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.IE.2ef341aa">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ">
+                    <CheckValue>IN07</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.IE.5d85184b">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ">
+                    <CheckValue>IN08</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.IE.8579104c">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ">
+                    <CheckValue>EX01</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.IE.74eacc45">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ">
+                    <CheckValue>EX02</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.IE.ce0e8d09">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ">
+                    <CheckValue>EX03</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.IE.945bafbd">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ">
+                    <CheckValue>EX04</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.IE.afbec960">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ">
+                    <CheckValue>EX05</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.IE.cac0d3f4">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ">
+                    <CheckValue>EX06</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.IE.cabd9be0">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ">
+                    <CheckValue>EX07</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.IE.fbae7983">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ">
+                    <CheckValue>EX08</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.IE.0952c014">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ">
+                    <CheckValue>EX09</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.IE.5b8b02b2">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ">
+                    <CheckValue>EX10</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.IE.70a941e7">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ">
+                    <CheckValue>EX11</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.IE.611f5d7b">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ">
+                    <CheckValue>EX12</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.IE.8abff918">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ">
+                    <CheckValue>EX13</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.IE.b089a2a0">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ">
+                    <CheckValue>EX14</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.IE.39cb2456">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ">
+                    <CheckValue>EX15</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.IE.2cdb5c18">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ">
+                    <CheckValue>EX16</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.IE.b415f3a9">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ">
+                    <CheckValue>EX17</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.IE.5c29f970">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ">
+                    <CheckValue>EX18</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.IE.9fe9a358">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ">
+                    <CheckValue>EX19</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.IE.e36b210b">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ">
+                    <CheckValue>EX20</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.IE.743b4fb5">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ">
+                    <CheckValue>EX21</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.IE.76a82754">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ">
+                    <CheckValue>EX22</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <def:WhereClauseDef OID="WC.IE.fbeb5a1e">
+                <RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ">
+                    <CheckValue>EX23</CheckValue>
+                </RangeCheck>
+            </def:WhereClauseDef>
+            <ItemGroupDef OID="IG.DS" Name="DS" Domain="DS" SASDatasetName="DS"
+                          def:Structure="One record per disposition status or protocol milestone per subject"
+                          IsReferenceData="No" Repeating="Yes" Purpose="Tabulation" def:StandardOID="STD.SDTMIG">
+                <Description>
+                    <TranslatedText xml:lang="en">Disposition</TranslatedText>
+                </Description>
+                <ItemRef ItemOID="IT.DS.STUDYID" Mandatory="Yes" OrderNumber="1" Role="Identifier"/>
+                <ItemRef ItemOID="IT.DS.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier"/>
+                <ItemRef ItemOID="IT.DS.USUBJID" Mandatory="Yes" OrderNumber="3" Role="Identifier"/>
+                <ItemRef ItemOID="IT.DS.DSSEQ" Mandatory="Yes" OrderNumber="4" Role="Identifier"/>
+                <ItemRef ItemOID="IT.DS.DSTERM" Mandatory="Yes" OrderNumber="5" Role="Topic"/>
+                <ItemRef ItemOID="IT.DS.DSDECOD" Mandatory="Yes" OrderNumber="6" Role="Synonym Qualifier"/>
+                <ItemRef ItemOID="IT.DS.DSCAT" Mandatory="No" OrderNumber="7" Role="Grouping Qualifier"/>
+                <ItemRef ItemOID="IT.DS.DSSCAT" Mandatory="No" OrderNumber="8" Role="Grouping Qualifier"/>
+                <ItemRef ItemOID="IT.DS.DSSTDTC" Mandatory="No" OrderNumber="9" Role="Timing"/>
+                <ItemRef ItemOID="IT.DS.DSSTDY" Mandatory="No" OrderNumber="10" Role="Timing"/>
+                <def:Class Name="EVENTS"/>
+                <def:leaf ID="LF.DS" xlink:href="ds.ndjson">
+                    <def:title>ds.ndjson</def:title>
+                </def:leaf>
+            </ItemGroupDef>
+            <ItemGroupDef OID="IG.DM" Name="DM" Domain="DM" SASDatasetName="DM" def:Structure="One record per subject"
+                          IsReferenceData="No" Repeating="No" Purpose="Tabulation" def:StandardOID="STD.SDTMIG">
+                <Description>
+                    <TranslatedText xml:lang="en">Demographics</TranslatedText>
+                </Description>
+                <ItemRef ItemOID="IT.DM.STUDYID" Mandatory="Yes" OrderNumber="1" Role="Identifier"/>
+                <ItemRef ItemOID="IT.DM.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier"/>
+                <ItemRef ItemOID="IT.DM.USUBJID" Mandatory="Yes" OrderNumber="3" Role="Identifier"/>
+                <ItemRef ItemOID="IT.DM.SUBJID" Mandatory="Yes" OrderNumber="4" Role="Topic"/>
+                <ItemRef ItemOID="IT.DM.RFSTDTC" Mandatory="No" OrderNumber="5" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.DM.RFENDTC" Mandatory="No" OrderNumber="6" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.DM.RFXSTDTC" Mandatory="No" OrderNumber="7" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.DM.RFXENDTC" Mandatory="No" OrderNumber="8" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.DM.RFICDTC" Mandatory="No" OrderNumber="9" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.DM.RFPENDTC" Mandatory="No" OrderNumber="10" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.DM.DTHDTC" Mandatory="No" OrderNumber="11" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.DM.DTHFL" Mandatory="No" OrderNumber="12" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.DM.SITEID" Mandatory="Yes" OrderNumber="13" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.DM.AGE" Mandatory="No" OrderNumber="14" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.DM.AGEU" Mandatory="No" OrderNumber="15" Role="Variable Qualifier"/>
+                <ItemRef ItemOID="IT.DM.SEX" Mandatory="Yes" OrderNumber="16" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.DM.RACE" Mandatory="No" OrderNumber="17" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.DM.ETHNIC" Mandatory="No" OrderNumber="18" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.DM.ARMCD" Mandatory="No" OrderNumber="19" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.DM.ARM" Mandatory="No" OrderNumber="20" Role="Synonym Qualifier"/>
+                <ItemRef ItemOID="IT.DM.ACTARMCD" Mandatory="No" OrderNumber="21" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.DM.ACTARM" Mandatory="No" OrderNumber="22" Role="Synonym Qualifier"/>
+                <ItemRef ItemOID="IT.DM.ARMNRS" Mandatory="No" OrderNumber="23" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.DM.ACTARMUD" Mandatory="No" OrderNumber="24" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.DM.COUNTRY" Mandatory="Yes" OrderNumber="25" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.DM.DMDTC" Mandatory="No" OrderNumber="26" Role="Timing"/>
+                <def:Class Name="SPECIAL PURPOSE"/>
+                <def:leaf ID="LF.DM" xlink:href="dm.ndjson">
+                    <def:title>dm.ndjson</def:title>
+                </def:leaf>
+            </ItemGroupDef>
+            <ItemGroupDef OID="IG.SC" Name="SC" Domain="SC" SASDatasetName="SC"
+                          def:Structure="One record per characteristic per visit per subject." IsReferenceData="No"
+                          Repeating="Yes" Purpose="Tabulation" def:StandardOID="STD.SDTMIG">
+                <Description>
+                    <TranslatedText xml:lang="en">Subject Characteristics</TranslatedText>
+                </Description>
+                <ItemRef ItemOID="IT.SC.STUDYID" Mandatory="Yes" OrderNumber="1" Role="Identifier"/>
+                <ItemRef ItemOID="IT.SC.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier"/>
+                <ItemRef ItemOID="IT.SC.USUBJID" Mandatory="Yes" OrderNumber="3" Role="Identifier"/>
+                <ItemRef ItemOID="IT.SC.SCSEQ" Mandatory="Yes" OrderNumber="4" Role="Identifier"/>
+                <ItemRef ItemOID="IT.SC.SCTESTCD" Mandatory="Yes" OrderNumber="5" Role="Topic"/>
+                <ItemRef ItemOID="IT.SC.SCTEST" Mandatory="Yes" OrderNumber="6" Role="Synonym Qualifier"/>
+                <ItemRef ItemOID="IT.SC.SCORRES" Mandatory="No" OrderNumber="7" Role="Result Qualifier"/>
+                <ItemRef ItemOID="IT.SC.SCORRESU" Mandatory="No" OrderNumber="8" Role="Variable Qualifier"/>
+                <ItemRef ItemOID="IT.SC.SCSTRESC" Mandatory="No" OrderNumber="9" Role="Result Qualifier"/>
+                <ItemRef ItemOID="IT.SC.SCSTRESN" Mandatory="No" OrderNumber="10" Role="Result Qualifier"/>
+                <ItemRef ItemOID="IT.SC.SCSTRESU" Mandatory="No" OrderNumber="11" Role="Variable Qualifier"/>
+                <ItemRef ItemOID="IT.SC.SCDTC" Mandatory="No" OrderNumber="12" Role="Timing"/>
+                <def:Class Name="FINDINGS"/>
+                <def:leaf ID="LF.SC" xlink:href="sc.ndjson">
+                    <def:title>sc.ndjson</def:title>
+                </def:leaf>
+            </ItemGroupDef>
+            <ItemGroupDef OID="IG.MH" Name="MH" Domain="MH" SASDatasetName="MH"
+                          def:Structure="One record per medical history event per subject" IsReferenceData="No"
+                          Repeating="Yes" Purpose="Tabulation" def:StandardOID="STD.SDTMIG">
+                <Description>
+                    <TranslatedText xml:lang="en">Medical History</TranslatedText>
+                </Description>
+                <ItemRef ItemOID="IT.MH.STUDYID" Mandatory="Yes" OrderNumber="1" Role="Identifier"/>
+                <ItemRef ItemOID="IT.MH.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier"/>
+                <ItemRef ItemOID="IT.MH.USUBJID" Mandatory="Yes" OrderNumber="3" Role="Identifier"/>
+                <ItemRef ItemOID="IT.MH.MHSEQ" Mandatory="Yes" OrderNumber="4" Role="Identifier"/>
+                <ItemRef ItemOID="IT.MH.MHTERM" Mandatory="Yes" OrderNumber="5" Role="Topic"/>
+                <ItemRef ItemOID="IT.MH.MHDECOD" Mandatory="No" OrderNumber="6" Role="Synonym Qualifier"/>
+                <ItemRef ItemOID="IT.MH.MHPRESP" Mandatory="No" OrderNumber="7" Role="Variable Qualifier"/>
+                <ItemRef ItemOID="IT.MH.MHOCCUR" Mandatory="No" OrderNumber="8" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.MH.MHENRF" Mandatory="No" OrderNumber="9" Role="Timing"/>
+                <ItemRef ItemOID="IT.MH.MHENRTPT" Mandatory="No" OrderNumber="10" Role="Timing"/>
+                <ItemRef ItemOID="IT.MH.MHENTPT" Mandatory="No" OrderNumber="11" Role="Timing"/>
+                <def:Class Name="EVENTS"/>
+                <def:leaf ID="LF.MH" xlink:href="mh.ndjson">
+                    <def:title>mh.ndjson</def:title>
+                </def:leaf>
+            </ItemGroupDef>
+            <ItemGroupDef OID="IG.SU" Name="SU" Domain="SU" SASDatasetName="SU"
+                          def:Structure="One record per substance type per reported occurrence per subject"
+                          IsReferenceData="No" Repeating="Yes" Purpose="Tabulation" def:StandardOID="STD.SDTMIG">
+                <Description>
+                    <TranslatedText xml:lang="en">Substance Use</TranslatedText>
+                </Description>
+                <ItemRef ItemOID="IT.SU.STUDYID" Mandatory="Yes" OrderNumber="1" Role="Identifier"/>
+                <ItemRef ItemOID="IT.SU.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier"/>
+                <ItemRef ItemOID="IT.SU.USUBJID" Mandatory="Yes" OrderNumber="3" Role="Identifier"/>
+                <ItemRef ItemOID="IT.SU.SUSEQ" Mandatory="Yes" OrderNumber="4" Role="Identifier"/>
+                <ItemRef ItemOID="IT.SU.SUTRT" Mandatory="Yes" OrderNumber="5" Role="Topic"/>
+                <ItemRef ItemOID="IT.SU.SUCAT" Mandatory="No" OrderNumber="6" Role="Grouping Qualifier"/>
+                <ItemRef ItemOID="IT.SU.SUSCAT" Mandatory="No" OrderNumber="7" Role="Grouping Qualifier"/>
+                <ItemRef ItemOID="IT.SU.SUPRESP" Mandatory="No" OrderNumber="8" Role="Variable Qualifier"/>
+                <ItemRef ItemOID="IT.SU.SUOCCUR" Mandatory="No" OrderNumber="9" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.SU.SUDOSE" Mandatory="No" OrderNumber="10" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.SU.SUDOSTXT" Mandatory="No" OrderNumber="11" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.SU.SUDOSU" Mandatory="No" OrderNumber="12" Role="Variable Qualifier"/>
+                <ItemRef ItemOID="IT.SU.SUDOSFRQ" Mandatory="No" OrderNumber="13" Role="Variable Qualifier"/>
+                <ItemRef ItemOID="IT.SU.SUSTDTC" Mandatory="No" OrderNumber="14" Role="Timing"/>
+                <ItemRef ItemOID="IT.SU.SUENDTC" Mandatory="No" OrderNumber="15" Role="Timing"/>
+                <ItemRef ItemOID="IT.SU.SUDUR" Mandatory="No" OrderNumber="16" Role="Timing"/>
+                <ItemRef ItemOID="IT.SU.SUSTRF" Mandatory="No" OrderNumber="17" Role="Timing"/>
+                <ItemRef ItemOID="IT.SU.SUENRF" Mandatory="No" OrderNumber="18" Role="Timing"/>
+                <ItemRef ItemOID="IT.SU.SUSTRTPT" Mandatory="No" OrderNumber="19" Role="Timing"/>
+                <ItemRef ItemOID="IT.SU.SUSTTPT" Mandatory="No" OrderNumber="20" Role="Timing"/>
+                <ItemRef ItemOID="IT.SU.SUENRTPT" Mandatory="No" OrderNumber="21" Role="Timing"/>
+                <ItemRef ItemOID="IT.SU.SUENTPT" Mandatory="No" OrderNumber="22" Role="Timing"/>
+                <def:Class Name="INTERVENTIONS"/>
+                <def:leaf ID="LF.SU" xlink:href="su.ndjson">
+                    <def:title>su.ndjson</def:title>
+                </def:leaf>
+            </ItemGroupDef>
+            <ItemGroupDef OID="IG.PR" Name="PR" Domain="PR" SASDatasetName="PR"
+                          def:Structure="One record per recorded procedure per occurrence per subject"
+                          IsReferenceData="No" Repeating="Yes" Purpose="Tabulation" def:StandardOID="STD.SDTMIG">
+                <Description>
+                    <TranslatedText xml:lang="en">Procedures</TranslatedText>
+                </Description>
+                <ItemRef ItemOID="IT.PR.STUDYID" Mandatory="Yes" OrderNumber="1" Role="Identifier"/>
+                <ItemRef ItemOID="IT.PR.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier"/>
+                <ItemRef ItemOID="IT.PR.USUBJID" Mandatory="Yes" OrderNumber="3" Role="Identifier"/>
+                <ItemRef ItemOID="IT.PR.PRSEQ" Mandatory="Yes" OrderNumber="4" Role="Identifier"/>
+                <ItemRef ItemOID="IT.PR.PRTRT" Mandatory="Yes" OrderNumber="5" Role="Topic"/>
+                <ItemRef ItemOID="IT.PR.PRDECOD" Mandatory="No" OrderNumber="6" Role="Synonym Qualifier"/>
+                <ItemRef ItemOID="IT.PR.PRCAT" Mandatory="No" OrderNumber="7" Role="Grouping Qualifier"/>
+                <ItemRef ItemOID="IT.PR.PRSCAT" Mandatory="No" OrderNumber="8" Role="Grouping Qualifier"/>
+                <ItemRef ItemOID="IT.PR.PRPRESP" Mandatory="No" OrderNumber="9" Role="Variable Qualifier"/>
+                <ItemRef ItemOID="IT.PR.PROCCUR" Mandatory="No" OrderNumber="10" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.PR.PRLOC" Mandatory="No" OrderNumber="11" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.PR.PRSTDTC" Mandatory="No" OrderNumber="12" Role="Timing"/>
+                <ItemRef ItemOID="IT.PR.PRENDTC" Mandatory="No" OrderNumber="13" Role="Timing"/>
+                <def:Class Name="INTERVENTIONS"/>
+                <def:leaf ID="LF.PR" xlink:href="pr.ndjson">
+                    <def:title>pr.ndjson</def:title>
+                </def:leaf>
+            </ItemGroupDef>
+            <ItemGroupDef OID="IG.VS" Name="VS" Domain="VS" SASDatasetName="VS"
+                          def:Structure="One record per vital sign measurement per time point per visit per subject"
+                          IsReferenceData="No" Repeating="Yes" Purpose="Tabulation" def:StandardOID="STD.SDTMIG">
+                <Description>
+                    <TranslatedText xml:lang="en">Vital Signs</TranslatedText>
+                </Description>
+                <ItemRef ItemOID="IT.VS.STUDYID" Mandatory="Yes" OrderNumber="1" Role="Identifier"/>
+                <ItemRef ItemOID="IT.VS.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier"/>
+                <ItemRef ItemOID="IT.VS.USUBJID" Mandatory="Yes" OrderNumber="3" Role="Identifier"/>
+                <ItemRef ItemOID="IT.VS.VSSEQ" Mandatory="Yes" OrderNumber="4" Role="Identifier"/>
+                <ItemRef ItemOID="IT.VS.VSTESTCD" Mandatory="Yes" OrderNumber="5" Role="Topic"/>
+                <ItemRef ItemOID="IT.VS.VSTEST" Mandatory="Yes" OrderNumber="6" Role="Synonym Qualifier"/>
+                <ItemRef ItemOID="IT.VS.VSPOS" Mandatory="No" OrderNumber="7" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.VS.VSORRES" Mandatory="No" OrderNumber="8" Role="Result Qualifier"/>
+                <ItemRef ItemOID="IT.VS.VSORRESU" Mandatory="No" OrderNumber="9" Role="Variable Qualifier"/>
+                <ItemRef ItemOID="IT.VS.VSSTRESC" Mandatory="No" OrderNumber="10" Role="Result Qualifier"/>
+                <ItemRef ItemOID="IT.VS.VSSTRESN" Mandatory="No" OrderNumber="11" Role="Result Qualifier"/>
+                <ItemRef ItemOID="IT.VS.VSSTRESU" Mandatory="No" OrderNumber="12" Role="Variable Qualifier"/>
+                <ItemRef ItemOID="IT.VS.VSLOC" Mandatory="No" OrderNumber="13" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.VS.VSLAT" Mandatory="No" OrderNumber="14" Role="Result Qualifier"/>
+                <ItemRef ItemOID="IT.VS.VSLOBXFL" Mandatory="No" OrderNumber="15" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.VS.VISITNUM" Mandatory="No" OrderNumber="16" Role="Timing"/>
+                <ItemRef ItemOID="IT.VS.VSDTC" Mandatory="No" OrderNumber="17" Role="Timing"/>
+                <def:Class Name="FINDINGS"/>
+                <def:leaf ID="LF.VS" xlink:href="vs.ndjson">
+                    <def:title>vs.ndjson</def:title>
+                </def:leaf>
+            </ItemGroupDef>
+            <ItemGroupDef OID="IG.EG" Name="EG" Domain="EG" SASDatasetName="EG"
+                          def:Structure="One record per ECG observation per replicate per time point or one record per ECG observation per beat per visit per subject"
+                          IsReferenceData="No" Repeating="Yes" Purpose="Tabulation" def:StandardOID="STD.SDTMIG">
+                <Description>
+                    <TranslatedText xml:lang="en">ECG Test Results</TranslatedText>
+                </Description>
+                <ItemRef ItemOID="IT.EG.STUDYID" Mandatory="Yes" OrderNumber="1" Role="Identifier"/>
+                <ItemRef ItemOID="IT.EG.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier"/>
+                <ItemRef ItemOID="IT.EG.USUBJID" Mandatory="Yes" OrderNumber="3" Role="Identifier"/>
+                <ItemRef ItemOID="IT.EG.EGSEQ" Mandatory="Yes" OrderNumber="4" Role="Identifier"/>
+                <ItemRef ItemOID="IT.EG.EGTESTCD" Mandatory="Yes" OrderNumber="5" Role="Topic"/>
+                <ItemRef ItemOID="IT.EG.EGTEST" Mandatory="Yes" OrderNumber="6" Role="Synonym Qualifier"/>
+                <ItemRef ItemOID="IT.EG.EGCAT" Mandatory="No" OrderNumber="7" Role="Grouping Qualifier"/>
+                <ItemRef ItemOID="IT.EG.EGPOS" Mandatory="No" OrderNumber="8" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.EG.EGORRES" Mandatory="No" OrderNumber="9" Role="Result Qualifier"/>
+                <ItemRef ItemOID="IT.EG.EGORRESU" Mandatory="No" OrderNumber="10" Role="Variable Qualifier"/>
+                <ItemRef ItemOID="IT.EG.EGSTRESC" Mandatory="No" OrderNumber="11" Role="Result Qualifier"/>
+                <ItemRef ItemOID="IT.EG.EGSTRESN" Mandatory="No" OrderNumber="12" Role="Result Qualifier"/>
+                <ItemRef ItemOID="IT.EG.EGSTRESU" Mandatory="No" OrderNumber="13" Role="Variable Qualifier"/>
+                <ItemRef ItemOID="IT.EG.EGMETHOD" Mandatory="No" OrderNumber="14" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.EG.EGLOBXFL" Mandatory="No" OrderNumber="15" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.EG.EGEVAL" Mandatory="No" OrderNumber="16" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.EG.EGCLSIG" Mandatory="No" OrderNumber="17" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.EG.VISITNUM" Mandatory="No" OrderNumber="18" Role="Timing"/>
+                <ItemRef ItemOID="IT.EG.EGDTC" Mandatory="No" OrderNumber="19" Role="Timing"/>
+                <def:Class Name="FINDINGS"/>
+                <def:leaf ID="LF.EG" xlink:href="eg.ndjson">
+                    <def:title>eg.ndjson</def:title>
+                </def:leaf>
+            </ItemGroupDef>
+            <ItemGroupDef OID="IG.CM" Name="CM" Domain="CM" SASDatasetName="CM"
+                          def:Structure="One record per recorded intervention occurrence or constant-dosing interval per subject"
+                          IsReferenceData="No" Repeating="Yes" Purpose="Tabulation" def:StandardOID="STD.SDTMIG">
+                <Description>
+                    <TranslatedText xml:lang="en">Concomitant/Prior Medications</TranslatedText>
+                </Description>
+                <ItemRef ItemOID="IT.CM.STUDYID" Mandatory="Yes" OrderNumber="1" Role="Identifier"/>
+                <ItemRef ItemOID="IT.CM.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier"/>
+                <ItemRef ItemOID="IT.CM.USUBJID" Mandatory="Yes" OrderNumber="3" Role="Identifier"/>
+                <ItemRef ItemOID="IT.CM.CMSEQ" Mandatory="Yes" OrderNumber="4" Role="Identifier"/>
+                <ItemRef ItemOID="IT.CM.CMTRT" Mandatory="Yes" OrderNumber="5" Role="Topic"/>
+                <ItemRef ItemOID="IT.CM.CMDECOD" Mandatory="No" OrderNumber="6" Role="Synonym Qualifier"/>
+                <ItemRef ItemOID="IT.CM.CMCAT" Mandatory="No" OrderNumber="7" Role="Grouping Qualifier"/>
+                <ItemRef ItemOID="IT.CM.CMSCAT" Mandatory="No" OrderNumber="8" Role="Grouping Qualifier"/>
+                <ItemRef ItemOID="IT.CM.CMPRESP" Mandatory="No" OrderNumber="9" Role="Variable Qualifier"/>
+                <ItemRef ItemOID="IT.CM.CMOCCUR" Mandatory="No" OrderNumber="10" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.CM.CMINDC" Mandatory="No" OrderNumber="11" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.CM.CMDOSE" Mandatory="No" OrderNumber="12" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.CM.CMDOSU" Mandatory="No" OrderNumber="13" Role="Variable Qualifier"/>
+                <ItemRef ItemOID="IT.CM.CMDOSFRM" Mandatory="No" OrderNumber="14" Role="Variable Qualifier"/>
+                <ItemRef ItemOID="IT.CM.CMROUTE" Mandatory="No" OrderNumber="15" Role="Variable Qualifier"/>
+                <ItemRef ItemOID="IT.CM.CMSTDTC" Mandatory="No" OrderNumber="16" Role="Timing"/>
+                <ItemRef ItemOID="IT.CM.CMENDTC" Mandatory="No" OrderNumber="17" Role="Timing"/>
+                <def:Class Name="INTERVENTIONS"/>
+                <def:leaf ID="LF.CM" xlink:href="cm.ndjson">
+                    <def:title>cm.ndjson</def:title>
+                </def:leaf>
+            </ItemGroupDef>
+            <ItemGroupDef OID="IG.LB" Name="LB" Domain="LB" SASDatasetName="LB"
+                          def:Structure="One record per lab test per time point per visit per subject"
+                          IsReferenceData="No" Repeating="Yes" Purpose="Tabulation" def:StandardOID="STD.SDTMIG">
+                <Description>
+                    <TranslatedText xml:lang="en">Laboratory Test Results</TranslatedText>
+                </Description>
+                <ItemRef ItemOID="IT.LB.STUDYID" Mandatory="Yes" OrderNumber="1" Role="Identifier"/>
+                <ItemRef ItemOID="IT.LB.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier"/>
+                <ItemRef ItemOID="IT.LB.USUBJID" Mandatory="Yes" OrderNumber="3" Role="Identifier"/>
+                <ItemRef ItemOID="IT.LB.LBSEQ" Mandatory="Yes" OrderNumber="4" Role="Identifier"/>
+                <ItemRef ItemOID="IT.LB.LBTESTCD" Mandatory="Yes" OrderNumber="5" Role="Topic"/>
+                <ItemRef ItemOID="IT.LB.LBTEST" Mandatory="Yes" OrderNumber="6" Role="Synonym Qualifier"/>
+                <ItemRef ItemOID="IT.LB.LBCAT" Mandatory="No" OrderNumber="7" Role="Grouping Qualifier"/>
+                <ItemRef ItemOID="IT.LB.LBORRES" Mandatory="No" OrderNumber="8" Role="Result Qualifier"/>
+                <ItemRef ItemOID="IT.LB.LBORRESU" Mandatory="No" OrderNumber="9" Role="Variable Qualifier"/>
+                <ItemRef ItemOID="IT.LB.LBORNRLO" Mandatory="No" OrderNumber="10" Role="Variable Qualifier"/>
+                <ItemRef ItemOID="IT.LB.LBORNRHI" Mandatory="No" OrderNumber="11" Role="Variable Qualifier"/>
+                <ItemRef ItemOID="IT.LB.LBSTRESC" Mandatory="No" OrderNumber="12" Role="Result Qualifier"/>
+                <ItemRef ItemOID="IT.LB.LBSTRESN" Mandatory="No" OrderNumber="13" Role="Result Qualifier"/>
+                <ItemRef ItemOID="IT.LB.LBSTRESU" Mandatory="No" OrderNumber="14" Role="Variable Qualifier"/>
+                <ItemRef ItemOID="IT.LB.LBSTNRLO" Mandatory="No" OrderNumber="15" Role="Variable Qualifier"/>
+                <ItemRef ItemOID="IT.LB.LBSTNRHI" Mandatory="No" OrderNumber="16" Role="Variable Qualifier"/>
+                <ItemRef ItemOID="IT.LB.LBNRIND" Mandatory="No" OrderNumber="17" Role="Variable Qualifier"/>
+                <ItemRef ItemOID="IT.LB.LBSPEC" Mandatory="No" OrderNumber="18" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.LB.LBMETHOD" Mandatory="No" OrderNumber="19" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.LB.LBLOBXFL" Mandatory="No" OrderNumber="20" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.LB.LBFAST" Mandatory="No" OrderNumber="21" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.LB.VISITNUM" Mandatory="No" OrderNumber="22" Role="Timing"/>
+                <ItemRef ItemOID="IT.LB.LBDTC" Mandatory="No" OrderNumber="23" Role="Timing"/>
+                <def:Class Name="FINDINGS"/>
+                <def:leaf ID="LF.LB" xlink:href="lb.ndjson">
+                    <def:title>lb.ndjson</def:title>
+                </def:leaf>
+            </ItemGroupDef>
+            <ItemGroupDef OID="IG.MB" Name="MB" Domain="MB" SASDatasetName="MB"
+                          def:Structure="One record per microbiology specimen finding per time point per visit per subject"
+                          IsReferenceData="No" Repeating="Yes" Purpose="Tabulation" def:StandardOID="STD.SDTMIG">
+                <Description>
+                    <TranslatedText xml:lang="en">Microbiology Specimen</TranslatedText>
+                </Description>
+                <ItemRef ItemOID="IT.MB.STUDYID" Mandatory="Yes" OrderNumber="1" Role="Identifier"/>
+                <ItemRef ItemOID="IT.MB.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier"/>
+                <ItemRef ItemOID="IT.MB.USUBJID" Mandatory="Yes" OrderNumber="3" Role="Identifier"/>
+                <ItemRef ItemOID="IT.MB.MBSEQ" Mandatory="Yes" OrderNumber="4" Role="Identifier"/>
+                <ItemRef ItemOID="IT.MB.MBTESTCD" Mandatory="Yes" OrderNumber="5" Role="Topic"/>
+                <ItemRef ItemOID="IT.MB.MBTEST" Mandatory="Yes" OrderNumber="6" Role="Synonym Qualifier"/>
+                <ItemRef ItemOID="IT.MB.MBTSTDTL" Mandatory="No" OrderNumber="7" Role="Variable Qualifier"/>
+                <ItemRef ItemOID="IT.MB.MBORRES" Mandatory="No" OrderNumber="8" Role="Result Qualifier"/>
+                <ItemRef ItemOID="IT.MB.MBSTRESC" Mandatory="No" OrderNumber="9" Role="Result Qualifier"/>
+                <ItemRef ItemOID="IT.MB.MBSPEC" Mandatory="No" OrderNumber="10" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.MB.MBMETHOD" Mandatory="No" OrderNumber="11" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.MB.VISITNUM" Mandatory="No" OrderNumber="12" Role="Timing"/>
+                <ItemRef ItemOID="IT.MB.MBDTC" Mandatory="No" OrderNumber="13" Role="Timing"/>
+                <def:Class Name="FINDINGS"/>
+                <def:leaf ID="LF.MB" xlink:href="mb.ndjson">
+                    <def:title>mb.ndjson</def:title>
+                </def:leaf>
+            </ItemGroupDef>
+            <ItemGroupDef OID="IG.EC" Name="EC" Domain="EC" SASDatasetName="EC"
+                          def:Structure="One record per protocol-specified study treatment, collected-dosing interval, per subject, per mood"
+                          IsReferenceData="No" Repeating="Yes" Purpose="Tabulation" def:StandardOID="STD.SDTMIG">
+                <Description>
+                    <TranslatedText xml:lang="en">Exposure as Collected</TranslatedText>
+                </Description>
+                <ItemRef ItemOID="IT.EC.STUDYID" Mandatory="Yes" OrderNumber="1" Role="Identifier"/>
+                <ItemRef ItemOID="IT.EC.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier"/>
+                <ItemRef ItemOID="IT.EC.USUBJID" Mandatory="Yes" OrderNumber="3" Role="Identifier"/>
+                <ItemRef ItemOID="IT.EC.ECSEQ" Mandatory="Yes" OrderNumber="4" Role="Identifier"/>
+                <ItemRef ItemOID="IT.EC.ECREFID" Mandatory="No" OrderNumber="5" Role="Identifier"/>
+                <ItemRef ItemOID="IT.EC.ECTRT" Mandatory="Yes" OrderNumber="6" Role="Topic"/>
+                <ItemRef ItemOID="IT.EC.ECDOSE" Mandatory="No" OrderNumber="7" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.EC.ECDOSTXT" Mandatory="No" OrderNumber="8" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.EC.ECDOSU" Mandatory="No" OrderNumber="9" Role="Variable Qualifier"/>
+                <ItemRef ItemOID="IT.EC.ECDOSFRM" Mandatory="No" OrderNumber="10" Role="Variable Qualifier"/>
+                <ItemRef ItemOID="IT.EC.ECDOSFRQ" Mandatory="No" OrderNumber="11" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.EC.ECDOSRGM" Mandatory="No" OrderNumber="12" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.EC.ECROUTE" Mandatory="No" OrderNumber="13" Role="Variable Qualifier"/>
+                <ItemRef ItemOID="IT.EC.ECLOC" Mandatory="No" OrderNumber="14" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.EC.ECLAT" Mandatory="No" OrderNumber="15" Role="Variable Qualifier"/>
+                <ItemRef ItemOID="IT.EC.ECDIR" Mandatory="No" OrderNumber="16" Role="Variable Qualifier"/>
+                <ItemRef ItemOID="IT.EC.ECSTDTC" Mandatory="No" OrderNumber="17" Role="Timing"/>
+                <ItemRef ItemOID="IT.EC.ECENDTC" Mandatory="No" OrderNumber="18" Role="Timing"/>
+                <def:Class Name="INTERVENTIONS"/>
+                <def:leaf ID="LF.EC" xlink:href="ec.ndjson">
+                    <def:title>ec.ndjson</def:title>
+                </def:leaf>
+            </ItemGroupDef>
+            <ItemGroupDef OID="IG.AE" Name="AE" Domain="AE" SASDatasetName="AE"
+                          def:Structure="One record per adverse event per subject" IsReferenceData="No" Repeating="Yes"
+                          Purpose="Tabulation" def:StandardOID="STD.SDTMIG">
+                <Description>
+                    <TranslatedText xml:lang="en">Adverse Events</TranslatedText>
+                </Description>
+                <ItemRef ItemOID="IT.AE.STUDYID" Mandatory="Yes" OrderNumber="1" Role="Identifier"/>
+                <ItemRef ItemOID="IT.AE.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier"/>
+                <ItemRef ItemOID="IT.AE.USUBJID" Mandatory="Yes" OrderNumber="3" Role="Identifier"/>
+                <ItemRef ItemOID="IT.AE.AESEQ" Mandatory="Yes" OrderNumber="4" Role="Identifier"/>
+                <ItemRef ItemOID="IT.AE.AETERM" Mandatory="Yes" OrderNumber="5" Role="Topic"/>
+                <ItemRef ItemOID="IT.AE.AELLT" Mandatory="No" OrderNumber="6" Role="Variable Qualifier"/>
+                <ItemRef ItemOID="IT.AE.AELLTCD" Mandatory="No" OrderNumber="7" Role="Variable Qualifier"/>
+                <ItemRef ItemOID="IT.AE.AEDECOD" Mandatory="Yes" OrderNumber="8" Role="Synonym Qualifier"/>
+                <ItemRef ItemOID="IT.AE.AEPTCD" Mandatory="No" OrderNumber="9" Role="Variable Qualifier"/>
+                <ItemRef ItemOID="IT.AE.AEHLT" Mandatory="No" OrderNumber="10" Role="Variable Qualifier"/>
+                <ItemRef ItemOID="IT.AE.AEHLTCD" Mandatory="No" OrderNumber="11" Role="Variable Qualifier"/>
+                <ItemRef ItemOID="IT.AE.AEHLGT" Mandatory="No" OrderNumber="12" Role="Variable Qualifier"/>
+                <ItemRef ItemOID="IT.AE.AEHLGTCD" Mandatory="No" OrderNumber="13" Role="Variable Qualifier"/>
+                <ItemRef ItemOID="IT.AE.AECAT" Mandatory="No" OrderNumber="14" Role="Grouping Qualifier"/>
+                <ItemRef ItemOID="IT.AE.AESCAT" Mandatory="No" OrderNumber="15" Role="Grouping Qualifier"/>
+                <ItemRef ItemOID="IT.AE.AEPRESP" Mandatory="No" OrderNumber="16" Role="Variable Qualifier"/>
+                <ItemRef ItemOID="IT.AE.AEBODSYS" Mandatory="No" OrderNumber="17" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.AE.AEBDSYCD" Mandatory="No" OrderNumber="18" Role="Variable Qualifier"/>
+                <ItemRef ItemOID="IT.AE.AESOC" Mandatory="No" OrderNumber="19" Role="Variable Qualifier"/>
+                <ItemRef ItemOID="IT.AE.AESOCCD" Mandatory="No" OrderNumber="20" Role="Variable Qualifier"/>
+                <ItemRef ItemOID="IT.AE.AELOC" Mandatory="No" OrderNumber="21" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.AE.AESEV" Mandatory="No" OrderNumber="22" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.AE.AESER" Mandatory="No" OrderNumber="23" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.AE.AEACN" Mandatory="No" OrderNumber="24" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.AE.AEACNOTH" Mandatory="No" OrderNumber="25" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.AE.AEREL" Mandatory="No" OrderNumber="26" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.AE.AERELNST" Mandatory="No" OrderNumber="27" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.AE.AEPATT" Mandatory="No" OrderNumber="28" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.AE.AEOUT" Mandatory="No" OrderNumber="29" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.AE.AESCAN" Mandatory="No" OrderNumber="30" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.AE.AESCONG" Mandatory="No" OrderNumber="31" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.AE.AESDISAB" Mandatory="No" OrderNumber="32" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.AE.AESDTH" Mandatory="No" OrderNumber="33" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.AE.AESHOSP" Mandatory="No" OrderNumber="34" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.AE.AESLIFE" Mandatory="No" OrderNumber="35" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.AE.AESOD" Mandatory="No" OrderNumber="36" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.AE.AESMIE" Mandatory="No" OrderNumber="37" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.AE.AECONTRT" Mandatory="No" OrderNumber="38" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.AE.AETOXGR" Mandatory="No" OrderNumber="39" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.AE.AESTDTC" Mandatory="No" OrderNumber="40" Role="Timing"/>
+                <ItemRef ItemOID="IT.AE.AEENDTC" Mandatory="No" OrderNumber="41" Role="Timing"/>
+                <ItemRef ItemOID="IT.AE.AEENRF" Mandatory="No" OrderNumber="42" Role="Timing"/>
+                <ItemRef ItemOID="IT.AE.AEENRTPT" Mandatory="No" OrderNumber="43" Role="Timing"/>
+                <ItemRef ItemOID="IT.AE.AEENTPT" Mandatory="No" OrderNumber="44" Role="Timing"/>
+                <def:Class Name="EVENTS"/>
+                <def:leaf ID="LF.AE" xlink:href="ae.ndjson">
+                    <def:title>ae.ndjson</def:title>
+                </def:leaf>
+            </ItemGroupDef>
+            <ItemGroupDef OID="IG.TS" Name="TS" Domain="TS" SASDatasetName="TS"
+                          def:Structure="One record per trial summary parameter value" IsReferenceData="Yes"
+                          Repeating="No" Purpose="Tabulation" def:StandardOID="STD.SDTMIG">
+                <Description>
+                    <TranslatedText xml:lang="en">Trial Summary</TranslatedText>
+                </Description>
+                <ItemRef ItemOID="IT.TS.STUDYID" Mandatory="Yes" OrderNumber="1" Role="Identifier"/>
+                <ItemRef ItemOID="IT.TS.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier"/>
+                <ItemRef ItemOID="IT.TS.TSSEQ" Mandatory="Yes" OrderNumber="3" Role="Identifier"/>
+                <ItemRef ItemOID="IT.TS.TSPARMCD" Mandatory="Yes" OrderNumber="4" Role="Topic"/>
+                <ItemRef ItemOID="IT.TS.TSPARM" Mandatory="Yes" OrderNumber="5" Role="Synonym Qualifier"/>
+                <ItemRef ItemOID="IT.TS.TSVAL" Mandatory="No" OrderNumber="6" Role="Result Qualifier"/>
+                <ItemRef ItemOID="IT.TS.TSVALCD" Mandatory="No" OrderNumber="7" Role="Result Qualifier"/>
+                <ItemRef ItemOID="IT.TS.TSVCDREF" Mandatory="No" OrderNumber="8" Role="Result Qualifier"/>
+                <ItemRef ItemOID="IT.TS.TSVCDVER" Mandatory="No" OrderNumber="9" Role="Result Qualifier"/>
+                <def:Class Name="TRIAL DESIGN"/>
+                <def:leaf ID="LF.TS" xlink:href="ts.ndjson">
+                    <def:title>ts.ndjson</def:title>
+                </def:leaf>
+            </ItemGroupDef>
+            <ItemGroupDef OID="IG.TA" Name="TA" Domain="TA" SASDatasetName="TA"
+                          def:Structure="One record per planned Element per Arm" IsReferenceData="Yes" Repeating="No"
+                          Purpose="Tabulation" def:StandardOID="STD.SDTMIG">
+                <Description>
+                    <TranslatedText xml:lang="en">Trial Arms</TranslatedText>
+                </Description>
+                <ItemRef ItemOID="IT.TA.STUDYID" Mandatory="Yes" OrderNumber="1" Role="Identifier"/>
+                <ItemRef ItemOID="IT.TA.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier"/>
+                <ItemRef ItemOID="IT.TA.ARMCD" Mandatory="Yes" OrderNumber="3" Role="Topic"/>
+                <ItemRef ItemOID="IT.TA.ARM" Mandatory="Yes" OrderNumber="4" Role="Synonym Qualifier"/>
+                <ItemRef ItemOID="IT.TA.TAETORD" Mandatory="Yes" OrderNumber="5" Role="Timing"/>
+                <ItemRef ItemOID="IT.TA.ETCD" Mandatory="Yes" OrderNumber="6" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.TA.ELEMENT" Mandatory="No" OrderNumber="7" Role="Synonym Qualifier"/>
+                <ItemRef ItemOID="IT.TA.TABRANCH" Mandatory="No" OrderNumber="8" Role="Rule"/>
+                <ItemRef ItemOID="IT.TA.TATRANS" Mandatory="No" OrderNumber="9" Role="Rule"/>
+                <ItemRef ItemOID="IT.TA.EPOCH" Mandatory="Yes" OrderNumber="10" Role="Timing"/>
+                <def:Class Name="TRIAL DESIGN"/>
+                <def:leaf ID="LF.TA" xlink:href="ta.ndjson">
+                    <def:title>ta.ndjson</def:title>
+                </def:leaf>
+            </ItemGroupDef>
+            <ItemGroupDef OID="IG.TE" Name="TE" Domain="TE" SASDatasetName="TE"
+                          def:Structure="One record per planned Element" IsReferenceData="Yes" Repeating="No"
+                          Purpose="Tabulation" def:StandardOID="STD.SDTMIG">
+                <Description>
+                    <TranslatedText xml:lang="en">Trial Elements</TranslatedText>
+                </Description>
+                <ItemRef ItemOID="IT.TE.STUDYID" Mandatory="Yes" OrderNumber="1" Role="Identifier"/>
+                <ItemRef ItemOID="IT.TE.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier"/>
+                <ItemRef ItemOID="IT.TE.ETCD" Mandatory="Yes" OrderNumber="3" Role="Topic"/>
+                <ItemRef ItemOID="IT.TE.ELEMENT" Mandatory="Yes" OrderNumber="4" Role="Synonym Qualifier"/>
+                <ItemRef ItemOID="IT.TE.TESTRL" Mandatory="Yes" OrderNumber="5" Role="Rule"/>
+                <def:Class Name="TRIAL DESIGN"/>
+                <def:leaf ID="LF.TE" xlink:href="te.ndjson">
+                    <def:title>te.ndjson</def:title>
+                </def:leaf>
+            </ItemGroupDef>
+            <ItemGroupDef OID="IG.TI" Name="TI" Domain="TI" SASDatasetName="TI"
+                          def:Structure="One record per I/E criterion" IsReferenceData="Yes" Repeating="No"
+                          Purpose="Tabulation" def:StandardOID="STD.SDTMIG">
+                <Description>
+                    <TranslatedText xml:lang="en">Trial Inclusion/Exclusion Criteria</TranslatedText>
+                </Description>
+                <ItemRef ItemOID="IT.TI.STUDYID" Mandatory="Yes" OrderNumber="1" Role="Identifier"/>
+                <ItemRef ItemOID="IT.TI.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier"/>
+                <ItemRef ItemOID="IT.TI.IETESTCD" Mandatory="Yes" OrderNumber="3" Role="Topic"/>
+                <ItemRef ItemOID="IT.TI.IETEST" Mandatory="Yes" OrderNumber="4" Role="Synonym Qualifier"/>
+                <ItemRef ItemOID="IT.TI.IECAT" Mandatory="Yes" OrderNumber="5" Role="Grouping Qualifier"/>
+                <def:Class Name="TRIAL DESIGN"/>
+                <def:leaf ID="LF.TI" xlink:href="ti.ndjson">
+                    <def:title>ti.ndjson</def:title>
+                </def:leaf>
+            </ItemGroupDef>
+            <ItemGroupDef OID="IG.TV" Name="TV" Domain="TV" SASDatasetName="TV"
+                          def:Structure="One record per planned Visit per Arm" IsReferenceData="Yes" Repeating="No"
+                          Purpose="Tabulation" def:StandardOID="STD.SDTMIG">
+                <Description>
+                    <TranslatedText xml:lang="en">Trial Visits</TranslatedText>
+                </Description>
+                <ItemRef ItemOID="IT.TV.STUDYID" Mandatory="Yes" OrderNumber="1" Role="Identifier"/>
+                <ItemRef ItemOID="IT.TV.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier"/>
+                <ItemRef ItemOID="IT.TV.VISITNUM" Mandatory="Yes" OrderNumber="3" Role="Topic"/>
+                <ItemRef ItemOID="IT.TV.VISIT" Mandatory="Yes" OrderNumber="4" Role="Synonym Qualifier"/>
+                <ItemRef ItemOID="IT.TV.VISITDY" Mandatory="No" OrderNumber="5" Role="Timing"/>
+                <ItemRef ItemOID="IT.TV.ARMCD" Mandatory="No" OrderNumber="6" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.TV.ARM" Mandatory="No" OrderNumber="7" Role="Synonym Qualifier"/>
+                <ItemRef ItemOID="IT.TV.TVSTRL" Mandatory="Yes" OrderNumber="8" Role="Rule"/>
+                <ItemRef ItemOID="IT.TV.TVENRL" Mandatory="No" OrderNumber="9" Role="Rule"/>
+                <def:Class Name="TRIAL DESIGN"/>
+                <def:leaf ID="LF.TV" xlink:href="tv.ndjson">
+                    <def:title>tv.ndjson</def:title>
+                </def:leaf>
+            </ItemGroupDef>
+            <ItemGroupDef OID="IG.SV" Name="SV" Domain="SV" SASDatasetName="SV"
+                          def:Structure="One record per actual or planned visit per subject" IsReferenceData="No"
+                          Repeating="Yes" Purpose="Tabulation" def:StandardOID="STD.SDTMIG">
+                <Description>
+                    <TranslatedText xml:lang="en">Subject Visits</TranslatedText>
+                </Description>
+                <ItemRef ItemOID="IT.SV.STUDYID" Mandatory="Yes" OrderNumber="1" Role="Identifier"/>
+                <ItemRef ItemOID="IT.SV.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier"/>
+                <ItemRef ItemOID="IT.SV.USUBJID" Mandatory="Yes" OrderNumber="3" Role="Identifier"/>
+                <ItemRef ItemOID="IT.SV.VISITNUM" Mandatory="Yes" OrderNumber="4" Role="Topic"/>
+                <ItemRef ItemOID="IT.SV.VISIT" Mandatory="No" OrderNumber="5" Role="Synonym Qualifier"/>
+                <ItemRef ItemOID="IT.SV.SVPRESP" Mandatory="No" OrderNumber="6" Role="Variable Qualifier"/>
+                <ItemRef ItemOID="IT.SV.SVOCCUR" Mandatory="No" OrderNumber="7" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.SV.SVCNTMOD" Mandatory="No" OrderNumber="8" Role="Record Qualifier"/>
+                <ItemRef ItemOID="IT.SV.SVSTDTC" Mandatory="No" OrderNumber="9" Role="Timing"/>
+                <ItemRef ItemOID="IT.SV.SVENDTC" Mandatory="No" OrderNumber="10" Role="Timing"/>
+                <def:Class Name="SPECIAL PURPOSE"/>
+                <def:leaf ID="LF.SV" xlink:href="sv.ndjson">
+                    <def:title>sv.ndjson</def:title>
+                </def:leaf>
+            </ItemGroupDef>
+            <ItemGroupDef OID="IG.IE" Name="IE" Domain="IE" SASDatasetName="IE"
+                          def:Structure="One record per inclusion/exclusion criterion not met per subject"
+                          IsReferenceData="No" Repeating="Yes" Purpose="Tabulation" def:StandardOID="STD.SDTMIG">
+                <Description>
+                    <TranslatedText xml:lang="en">Inclusion/Exclusion Criteria Not Met</TranslatedText>
+                </Description>
+                <ItemRef ItemOID="IT.IE.STUDYID" Mandatory="Yes" OrderNumber="1" Role="Identifier"/>
+                <ItemRef ItemOID="IT.IE.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier"/>
+                <ItemRef ItemOID="IT.IE.USUBJID" Mandatory="Yes" OrderNumber="3" Role="Identifier"/>
+                <ItemRef ItemOID="IT.IE.IESEQ" Mandatory="Yes" OrderNumber="4" Role="Identifier"/>
+                <ItemRef ItemOID="IT.IE.IETESTCD" Mandatory="Yes" OrderNumber="5" Role="Topic"/>
+                <ItemRef ItemOID="IT.IE.IETEST" Mandatory="Yes" OrderNumber="6" Role="Synonym Qualifier"/>
+                <ItemRef ItemOID="IT.IE.IECAT" Mandatory="Yes" OrderNumber="7" Role="Grouping Qualifier"/>
+                <ItemRef ItemOID="IT.IE.IEORRES" Mandatory="Yes" OrderNumber="8" Role="Result Qualifier"/>
+                <ItemRef ItemOID="IT.IE.IESTRESC" Mandatory="Yes" OrderNumber="9" Role="Result Qualifier"/>
+                <def:Class Name="FINDINGS"/>
+                <def:leaf ID="LF.IE" xlink:href="ie.ndjson">
+                    <def:title>ie.ndjson</def:title>
+                </def:leaf>
+            </ItemGroupDef>
+            <ItemGroupDef OID="IG.SE" Name="SE" Domain="SE" SASDatasetName="SE"
+                          def:Structure="One record per actual Element per subject" IsReferenceData="No" Repeating="Yes"
+                          Purpose="Tabulation" def:StandardOID="STD.SDTMIG">
+                <Description>
+                    <TranslatedText xml:lang="en">Subject Elements</TranslatedText>
+                </Description>
+                <ItemRef ItemOID="IT.SE.STUDYID" Mandatory="Yes" OrderNumber="1" Role="Identifier"/>
+                <ItemRef ItemOID="IT.SE.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier"/>
+                <ItemRef ItemOID="IT.SE.USUBJID" Mandatory="Yes" OrderNumber="3" Role="Identifier"/>
+                <ItemRef ItemOID="IT.SE.SESEQ" Mandatory="Yes" OrderNumber="4" Role="Identifier"/>
+                <ItemRef ItemOID="IT.SE.ETCD" Mandatory="Yes" OrderNumber="5" Role="Topic"/>
+                <ItemRef ItemOID="IT.SE.ELEMENT" Mandatory="No" OrderNumber="6" Role="Synonym Qualifier"/>
+                <ItemRef ItemOID="IT.SE.EPOCH" Mandatory="No" OrderNumber="7" Role="Timing"/>
+                <ItemRef ItemOID="IT.SE.SESTDTC" Mandatory="Yes" OrderNumber="8" Role="Timing"/>
+                <ItemRef ItemOID="IT.SE.SEENDTC" Mandatory="No" OrderNumber="9" Role="Timing"/>
+                <def:Class Name="SPECIAL PURPOSE"/>
+                <def:leaf ID="LF.SE" xlink:href="se.ndjson">
+                    <def:title>se.ndjson</def:title>
+                </def:leaf>
+            </ItemGroupDef>
+            <ItemDef OID="IT.DS.STUDYID" Name="STUDYID" DataType="text" SASFieldName="STUDYID" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Study Identifier</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.DS.DOMAIN" Name="DOMAIN" DataType="text" SASFieldName="DOMAIN" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.DS.USUBJID" Name="USUBJID" DataType="text" SASFieldName="USUBJID" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.DS.DSSEQ" Name="DSSEQ" DataType="integer" SASFieldName="DSSEQ" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Sequence Number</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.DS.DSTERM" Name="DSTERM" DataType="text" SASFieldName="DSTERM" Length="200">
+                <Description>
+                    <TranslatedText xml:lang="en">Reported Term for the Disposition Event</TranslatedText>
+                </Description>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.DS.DSDECOD" Name="DSDECOD" DataType="text" SASFieldName="DSDECOD" Length="200">
+                <Description>
+                    <TranslatedText xml:lang="en">Standardized Disposition Term</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.NCOMPLT"/>
+                <def:Origin Type="Assigned" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.DS.DSCAT" Name="DSCAT" DataType="text" SASFieldName="DSCAT" Length="200">
+                <Description>
+                    <TranslatedText xml:lang="en">Category for Disposition Event</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.DSCAT"/>
+                <def:Origin Type="Assigned" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.DS.DSSCAT" Name="DSSCAT" DataType="text" SASFieldName="DSSCAT" Length="200">
+                <Description>
+                    <TranslatedText xml:lang="en">Subcategory for Disposition Event</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.DSSCAT"/>
+                <def:Origin Type="Assigned" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.DS.DSSTDTC" Name="DSSTDTC" DataType="datetime" SASFieldName="DSSTDTC">
+                <Description>
+                    <TranslatedText xml:lang="en">Start Date/Time of Disposition Event</TranslatedText>
+                </Description>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.DS.DSSTDY" Name="DSSTDY" DataType="integer" SASFieldName="DSSTDY" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Study Day of Start of Disposition Event</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.DM.STUDYID" Name="STUDYID" DataType="text" SASFieldName="STUDYID" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Study Identifier</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.DM.DOMAIN" Name="DOMAIN" DataType="text" SASFieldName="DOMAIN" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.DM.USUBJID" Name="USUBJID" DataType="text" SASFieldName="USUBJID" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.DM.SUBJID" Name="SUBJID" DataType="text" SASFieldName="SUBJID" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Subject Identifier for the Study</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.DM.RFSTDTC" Name="RFSTDTC" DataType="datetime" SASFieldName="RFSTDTC">
+                <Description>
+                    <TranslatedText xml:lang="en">Subject Reference Start Date/Time</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.DM.RFENDTC" Name="RFENDTC" DataType="datetime" SASFieldName="RFENDTC">
+                <Description>
+                    <TranslatedText xml:lang="en">Subject Reference End Date/Time</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.DM.RFXSTDTC" Name="RFXSTDTC" DataType="datetime" SASFieldName="RFXSTDTC">
+                <Description>
+                    <TranslatedText xml:lang="en">Date/Time of First Study Treatment</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.DM.RFXENDTC" Name="RFXENDTC" DataType="datetime" SASFieldName="RFXENDTC">
+                <Description>
+                    <TranslatedText xml:lang="en">Date/Time of Last Study Treatment</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.DM.RFICDTC" Name="RFICDTC" DataType="datetime" SASFieldName="RFICDTC">
+                <Description>
+                    <TranslatedText xml:lang="en">Date/Time of Informed Consent</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.DM.RFPENDTC" Name="RFPENDTC" DataType="datetime" SASFieldName="RFPENDTC">
+                <Description>
+                    <TranslatedText xml:lang="en">Date/Time of End of Participation</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.DM.DTHDTC" Name="DTHDTC" DataType="datetime" SASFieldName="DTHDTC">
+                <Description>
+                    <TranslatedText xml:lang="en">Date/Time of Death</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.DM.DTHFL" Name="DTHFL" DataType="text" SASFieldName="DTHFL" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Subject Death Flag</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.NY"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.DM.SITEID" Name="SITEID" DataType="text" SASFieldName="SITEID" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Study Site Identifier</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.DM.AGE" Name="AGE" DataType="float" SASFieldName="AGE" Length="6" SignificantDigits="2"
+                     def:DisplayFormat="3.2">
+                <Description>
+                    <TranslatedText xml:lang="en">Age</TranslatedText>
+                </Description>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.DM.AGEU" Name="AGEU" DataType="text" SASFieldName="AGEU" Length="20">
+                <Description>
+                    <TranslatedText xml:lang="en">Age Units</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.AGEU"/>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.DM.SEX" Name="SEX" DataType="text" SASFieldName="SEX" Length="100">
+                <Description>
+                    <TranslatedText xml:lang="en">Sex</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.SEX"/>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.DM.RACE" Name="RACE" DataType="text" SASFieldName="RACE" Length="100">
+                <Description>
+                    <TranslatedText xml:lang="en">Race</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.RACE"/>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.DM.ETHNIC" Name="ETHNIC" DataType="text" SASFieldName="ETHNIC" Length="100">
+                <Description>
+                    <TranslatedText xml:lang="en">Ethnicity</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.ETHNIC"/>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.DM.ARMCD" Name="ARMCD" DataType="text" SASFieldName="ARMCD" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Planned Arm Code</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.DM.ARM" Name="ARM" DataType="text" SASFieldName="ARM" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Description of Planned Arm</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.DM.ACTARMCD" Name="ACTARMCD" DataType="text" SASFieldName="ACTARMCD"
+                     Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Actual Arm Code</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.DM.ACTARM" Name="ACTARM" DataType="text" SASFieldName="ACTARM" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Description of Actual Arm</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.DM.ARMNRS" Name="ARMNRS" DataType="text" SASFieldName="ARMNRS" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Reason Arm and/or Actual Arm is Null</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.ARMNULRS"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.DM.ACTARMUD" Name="ACTARMUD" DataType="text" SASFieldName="ACTARMUD"
+                     Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Description of Unplanned Actual Arm</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.DM.COUNTRY" Name="COUNTRY" DataType="text" SASFieldName="COUNTRY" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Country</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.DM.DMDTC" Name="DMDTC" DataType="datetime" SASFieldName="DMDTC">
+                <Description>
+                    <TranslatedText xml:lang="en">Date/Time of Collection</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.SC.STUDYID" Name="STUDYID" DataType="text" SASFieldName="STUDYID" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Study Identifier</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.SC.DOMAIN" Name="DOMAIN" DataType="text" SASFieldName="DOMAIN" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.SC.USUBJID" Name="USUBJID" DataType="text" SASFieldName="USUBJID" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.SC.SCSEQ" Name="SCSEQ" DataType="integer" SASFieldName="SCSEQ" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Sequence Number</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.SC.SCTESTCD" Name="SCTESTCD" DataType="text" SASFieldName="SCTESTCD"
+                     Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Subject Characteristic Short Name</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.SCTESTCD"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.SC.SCTEST" Name="SCTEST" DataType="text" SASFieldName="SCTEST" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Subject Characteristic</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.SCTEST"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.SC.SCORRES" Name="SCORRES" DataType="text" SASFieldName="SCORRES" Length="100">
+                <Description>
+                    <TranslatedText xml:lang="en">Result or Finding in Original Units</TranslatedText>
+                </Description>
+                <def:ValueListRef ValueListOID="VL.SC.SCORRES"/>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.SC.SCORRESU" Name="SCORRESU" DataType="text" SASFieldName="SCORRESU"
+                     Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Original Units</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.UNIT"/>
+                <def:ValueListRef ValueListOID="VL.SC.SCORRESU"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.SC.SCSTRESC" Name="SCSTRESC" DataType="text" SASFieldName="SCSTRESC" Length="100">
+                <Description>
+                    <TranslatedText xml:lang="en">Character Result/Finding in Std Format</TranslatedText>
+                </Description>
+                <def:Origin Type="Assigned" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.SC.SCSTRESN" Name="SCSTRESN" DataType="text" SASFieldName="SCSTRESN" Length="100">
+                <Description>
+                    <TranslatedText xml:lang="en">Numeric Result/Finding in Standard Units</TranslatedText>
+                </Description>
+                <def:Origin Type="Assigned" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.SC.SCSTRESU" Name="SCSTRESU" DataType="text" SASFieldName="SCSTRESU"
+                     Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Standard Units</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.UNIT"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.SC.SCDTC" Name="SCDTC" DataType="datetime" SASFieldName="SCDTC">
+                <Description>
+                    <TranslatedText xml:lang="en">Date/Time of Collection</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.SC.SCORRES.EDULEVEL" Name="SCORRES" DataType="float" SASFieldName="SCORRES" Length="4"
+                     SignificantDigits="1" def:DisplayFormat="3.1">
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.SC.SCORRES.EDUYRNUM" Name="SCORRES" DataType="float" SASFieldName="SCORRES" Length="4"
+                     SignificantDigits="1" def:DisplayFormat="3.1">
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.SC.SCORRESU.EDUYRNUM" Name="SCORRESU" DataType="text" SASFieldName="SCORRESU"
+                     Length="__PLACEHOLDER__"/>
+            <ItemDef OID="IT.MH.STUDYID" Name="STUDYID" DataType="text" SASFieldName="STUDYID" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Study Identifier</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.MH.DOMAIN" Name="DOMAIN" DataType="text" SASFieldName="DOMAIN" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.MH.USUBJID" Name="USUBJID" DataType="text" SASFieldName="USUBJID" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.MH.MHSEQ" Name="MHSEQ" DataType="integer" SASFieldName="MHSEQ" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Sequence Number</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.MH.MHTERM" Name="MHTERM" DataType="text" SASFieldName="MHTERM" Length="200">
+                <Description>
+                    <TranslatedText xml:lang="en">Reported Term for the Medical History</TranslatedText>
+                </Description>
+                <def:Origin Type="Assigned" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.MH.MHDECOD" Name="MHDECOD" DataType="text" SASFieldName="MHDECOD" Length="200">
+                <Description>
+                    <TranslatedText xml:lang="en">Dictionary-Derived Term</TranslatedText>
+                </Description>
+                <def:Origin Type="Assigned" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.MH.MHPRESP" Name="MHPRESP" DataType="text" SASFieldName="MHPRESP" Length="1">
+                <Description>
+                    <TranslatedText xml:lang="en">Medical History Event Pre-Specified</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.NY"/>
+                <def:Origin Type="Assigned" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.MH.MHOCCUR" Name="MHOCCUR" DataType="text" SASFieldName="MHOCCUR" Length="1">
+                <Description>
+                    <TranslatedText xml:lang="en">Medical History Occurrence</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.NY"/>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.MH.MHENRF" Name="MHENRF" DataType="text" SASFieldName="MHENRF" Length="20">
+                <Description>
+                    <TranslatedText xml:lang="en">End Relative to Reference Period</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.STENRF"/>
+                <def:Origin Type="Assigned" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.MH.MHENRTPT" Name="MHENRTPT" DataType="text" SASFieldName="MHENRTPT" Length="20">
+                <Description>
+                    <TranslatedText xml:lang="en">End Relative to Reference Time Point</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.STENRF"/>
+                <def:Origin Type="Assigned" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.MH.MHENTPT" Name="MHENTPT" DataType="text" SASFieldName="MHENTPT" Length="20">
+                <Description>
+                    <TranslatedText xml:lang="en">End Reference Time Point</TranslatedText>
+                </Description>
+                <def:Origin Type="Assigned" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.SU.STUDYID" Name="STUDYID" DataType="text" SASFieldName="STUDYID" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Study Identifier</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.SU.DOMAIN" Name="DOMAIN" DataType="text" SASFieldName="DOMAIN" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.SU.USUBJID" Name="USUBJID" DataType="text" SASFieldName="USUBJID" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.SU.SUSEQ" Name="SUSEQ" DataType="integer" SASFieldName="SUSEQ" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Sequence Number</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.SU.SUTRT" Name="SUTRT" DataType="text" SASFieldName="SUTRT" Length="200">
+                <Description>
+                    <TranslatedText xml:lang="en">Reported Name of Substance</TranslatedText>
+                </Description>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.SU.SUCAT" Name="SUCAT" DataType="text" SASFieldName="SUCAT" Length="200">
+                <Description>
+                    <TranslatedText xml:lang="en">Category for Substance Use</TranslatedText>
+                </Description>
+                <def:Origin Type="Assigned" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.SU.SUSCAT" Name="SUSCAT" DataType="text" SASFieldName="SUSCAT" Length="200">
+                <Description>
+                    <TranslatedText xml:lang="en">Subcategory for Substance Use</TranslatedText>
+                </Description>
+                <def:Origin Type="Assigned" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.SU.SUPRESP" Name="SUPRESP" DataType="text" SASFieldName="SUPRESP" Length="1">
+                <Description>
+                    <TranslatedText xml:lang="en">SU Pre-Specified</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.NY"/>
+                <def:Origin Type="Assigned" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.SU.SUOCCUR" Name="SUOCCUR" DataType="text" SASFieldName="SUOCCUR" Length="1">
+                <Description>
+                    <TranslatedText xml:lang="en">SU Occurrence</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.NY"/>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.SU.SUDOSE" Name="SUDOSE" DataType="float" SASFieldName="SUDOSE" Length="12"
+                     SignificantDigits="4" def:DisplayFormat="12.4">
+                <Description>
+                    <TranslatedText xml:lang="en">Substance Use Consumption</TranslatedText>
+                </Description>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.SU.SUDOSTXT" Name="SUDOSTXT" DataType="text" SASFieldName="SUDOSTXT" Length="40">
+                <Description>
+                    <TranslatedText xml:lang="en">Substance Use Consumption Text</TranslatedText>
+                </Description>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.SU.SUDOSU" Name="SUDOSU" DataType="text" SASFieldName="SUDOSU" Length="40">
+                <Description>
+                    <TranslatedText xml:lang="en">Consumption Units</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.UNIT"/>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.SU.SUDOSFRQ" Name="SUDOSFRQ" DataType="text" SASFieldName="SUDOSFRQ" Length="40">
+                <Description>
+                    <TranslatedText xml:lang="en">Use Frequency Per Interval</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.FREQ"/>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.SU.SUSTDTC" Name="SUSTDTC" DataType="datetime" SASFieldName="SUSTDTC">
+                <Description>
+                    <TranslatedText xml:lang="en">Start Date/Time of Substance Use</TranslatedText>
+                </Description>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.SU.SUENDTC" Name="SUENDTC" DataType="datetime" SASFieldName="SUENDTC">
+                <Description>
+                    <TranslatedText xml:lang="en">End Date/Time of Substance Use</TranslatedText>
+                </Description>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.SU.SUDUR" Name="SUDUR" DataType="durationDatetime" SASFieldName="SUDUR">
+                <Description>
+                    <TranslatedText xml:lang="en">Duration of Substance Use</TranslatedText>
+                </Description>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.SU.SUSTRF" Name="SUSTRF" DataType="text" SASFieldName="SUSTRF" Length="20">
+                <Description>
+                    <TranslatedText xml:lang="en">Start Relative to Reference Period</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.STENRF"/>
+                <def:Origin Type="Assigned" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.SU.SUENRF" Name="SUENRF" DataType="text" SASFieldName="SUENRF" Length="20">
+                <Description>
+                    <TranslatedText xml:lang="en">End Relative to Reference Period</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.STENRF"/>
+                <def:Origin Type="Assigned" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.SU.SUSTRTPT" Name="SUSTRTPT" DataType="text" SASFieldName="SUSTRTPT" Length="20">
+                <Description>
+                    <TranslatedText xml:lang="en">Start Relative to Reference Time Point</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.STENRF"/>
+                <def:Origin Type="Assigned" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.SU.SUSTTPT" Name="SUSTTPT" DataType="text" SASFieldName="SUSTTPT" Length="20">
+                <Description>
+                    <TranslatedText xml:lang="en">Start Reference Time Point</TranslatedText>
+                </Description>
+                <def:Origin Type="Assigned" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.SU.SUENRTPT" Name="SUENRTPT" DataType="text" SASFieldName="SUENRTPT" Length="20">
+                <Description>
+                    <TranslatedText xml:lang="en">End Relative to Reference Time Point</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.STENRF"/>
+                <def:Origin Type="Assigned" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.SU.SUENTPT" Name="SUENTPT" DataType="text" SASFieldName="SUENTPT" Length="20">
+                <Description>
+                    <TranslatedText xml:lang="en">End Reference Time Point</TranslatedText>
+                </Description>
+                <def:Origin Type="Assigned" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.PR.STUDYID" Name="STUDYID" DataType="text" SASFieldName="STUDYID" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Study Identifier</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.PR.DOMAIN" Name="DOMAIN" DataType="text" SASFieldName="DOMAIN" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.PR.USUBJID" Name="USUBJID" DataType="text" SASFieldName="USUBJID" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.PR.PRSEQ" Name="PRSEQ" DataType="integer" SASFieldName="PRSEQ" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Sequence Number</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.PR.PRTRT" Name="PRTRT" DataType="text" SASFieldName="PRTRT" Length="200">
+                <Description>
+                    <TranslatedText xml:lang="en">Reported Name of Procedure</TranslatedText>
+                </Description>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.PR.PRDECOD" Name="PRDECOD" DataType="text" SASFieldName="PRDECOD" Length="200">
+                <Description>
+                    <TranslatedText xml:lang="en">Standardized Procedure Name</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.PROCEDUR"/>
+                <def:Origin Type="Assigned" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.PR.PRCAT" Name="PRCAT" DataType="text" SASFieldName="PRCAT" Length="200">
+                <Description>
+                    <TranslatedText xml:lang="en">Category</TranslatedText>
+                </Description>
+                <def:Origin Type="Assigned" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.PR.PRSCAT" Name="PRSCAT" DataType="text" SASFieldName="PRSCAT" Length="200">
+                <Description>
+                    <TranslatedText xml:lang="en">Subcategory</TranslatedText>
+                </Description>
+                <def:Origin Type="Assigned" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.PR.PRPRESP" Name="PRPRESP" DataType="text" SASFieldName="PRPRESP" Length="1">
+                <Description>
+                    <TranslatedText xml:lang="en">Pre-specified</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.NY"/>
+                <def:Origin Type="Assigned" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.PR.PROCCUR" Name="PROCCUR" DataType="text" SASFieldName="PROCCUR" Length="1">
+                <Description>
+                    <TranslatedText xml:lang="en">Occurrence</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.NY"/>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.PR.PRLOC" Name="PRLOC" DataType="text" SASFieldName="PRLOC" Length="200">
+                <Description>
+                    <TranslatedText xml:lang="en">Location of Procedure</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.LOC"/>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.PR.PRSTDTC" Name="PRSTDTC" DataType="datetime" SASFieldName="PRSTDTC">
+                <Description>
+                    <TranslatedText xml:lang="en">Start Date/Time of Procedure</TranslatedText>
+                </Description>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.PR.PRENDTC" Name="PRENDTC" DataType="datetime" SASFieldName="PRENDTC">
+                <Description>
+                    <TranslatedText xml:lang="en">End Date/Time of Procedure</TranslatedText>
+                </Description>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.VS.STUDYID" Name="STUDYID" DataType="text" SASFieldName="STUDYID" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Study Identifier</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.VS.DOMAIN" Name="DOMAIN" DataType="text" SASFieldName="DOMAIN" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.VS.USUBJID" Name="USUBJID" DataType="text" SASFieldName="USUBJID" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.VS.VSSEQ" Name="VSSEQ" DataType="integer" SASFieldName="VSSEQ" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Sequence Number</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.VS.VSTESTCD" Name="VSTESTCD" DataType="text" SASFieldName="VSTESTCD"
+                     Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Vital Signs Test Short Name</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.VSTESTCD"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.VS.VSTEST" Name="VSTEST" DataType="text" SASFieldName="VSTEST" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Vital Signs Test Name</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.VSTEST"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.VS.VSPOS" Name="VSPOS" DataType="text" SASFieldName="VSPOS" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Vital Signs Position of Subject</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.POSITION"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.VS.VSORRES" Name="VSORRES" DataType="float" SASFieldName="VSORRES" Length="8"
+                     SignificantDigits="3" def:DisplayFormat="8.3">
+                <Description>
+                    <TranslatedText xml:lang="en">Result or Finding in Original Units</TranslatedText>
+                </Description>
+                <def:ValueListRef ValueListOID="VL.VS.VSORRES"/>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.VS.VSORRESU" Name="VSORRESU" DataType="text" SASFieldName="VSORRESU"
+                     Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Original Units</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.VSRESU"/>
+                <def:ValueListRef ValueListOID="VL.VS.VSORRESU"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.VS.VSSTRESC" Name="VSSTRESC" DataType="float" SASFieldName="VSSTRESC" Length="8"
+                     SignificantDigits="3" def:DisplayFormat="8.3">
+                <Description>
+                    <TranslatedText xml:lang="en">Character Result/Finding in Std Format</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.VS.VSSTRESN" Name="VSSTRESN" DataType="float" SASFieldName="VSSTRESN" Length="8"
+                     SignificantDigits="3" def:DisplayFormat="8.3">
+                <Description>
+                    <TranslatedText xml:lang="en">Numeric Result/Finding in Standard Units</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.VS.VSSTRESU" Name="VSSTRESU" DataType="text" SASFieldName="VSSTRESU"
+                     Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Standard Units</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.VSRESU"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.VS.VSLOC" Name="VSLOC" DataType="text" SASFieldName="VSLOC" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Location of Vital Signs Measurement</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.LOC"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.VS.VSLAT" Name="VSLAT" DataType="text" SASFieldName="VSLAT" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Laterality</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.LAT"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.VS.VSLOBXFL" Name="VSLOBXFL" DataType="text" SASFieldName="VSLOBXFL"
+                     Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Last Observation Before Exposure Flag</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.NY"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.VS.VISITNUM" Name="VISITNUM" DataType="integer" SASFieldName="VISITNUM"
+                     Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Visit Number</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.VS.VSDTC" Name="VSDTC" DataType="datetime" SASFieldName="VSDTC">
+                <Description>
+                    <TranslatedText xml:lang="en">Date/Time of Measurements</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.VS.VSORRES.TEMP" Name="VSORRES" DataType="float" SASFieldName="VSORRES" Length="8"
+                     SignificantDigits="3" def:DisplayFormat="8.3">
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.VS.VSORRES.WEIGHT" Name="VSORRES" DataType="float" SASFieldName="VSORRES" Length="8"
+                     SignificantDigits="3" def:DisplayFormat="8.3">
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.VS.VSORRES.HEIGHT" Name="VSORRES" DataType="float" SASFieldName="VSORRES" Length="8"
+                     SignificantDigits="3" def:DisplayFormat="8.3">
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.VS.VSORRES.PULSE" Name="VSORRES" DataType="integer" SASFieldName="VSORRES" Length="3">
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.VS.VSORRES.RESP" Name="VSORRES" DataType="integer" SASFieldName="VSORRES" Length="3">
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.VS.VSORRES.BMI" Name="VSORRES" DataType="float" SASFieldName="VSORRES" Length="8"
+                     SignificantDigits="3" def:DisplayFormat="8.3">
+                <def:Origin Type="Derived" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.VS.VSORRES.SYSBP" Name="VSORRES" DataType="integer" SASFieldName="VSORRES" Length="3">
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.VS.VSORRES.DIABP" Name="VSORRES" DataType="integer" SASFieldName="VSORRES" Length="3">
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.VS.VSORRES.HR" Name="VSORRES" DataType="integer" SASFieldName="VSORRES" Length="3">
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.VS.VSORRESU.TEMP" Name="VSORRESU" DataType="text" SASFieldName="VSORRESU"
+                     Length="__PLACEHOLDER__"/>
+            <ItemDef OID="IT.VS.VSORRESU.WEIGHT" Name="VSORRESU" DataType="text" SASFieldName="VSORRESU"
+                     Length="__PLACEHOLDER__"/>
+            <ItemDef OID="IT.VS.VSORRESU.HEIGHT" Name="VSORRESU" DataType="text" SASFieldName="VSORRESU"
+                     Length="__PLACEHOLDER__"/>
+            <ItemDef OID="IT.VS.VSORRESU.PULSE" Name="VSORRESU" DataType="text" SASFieldName="VSORRESU"
+                     Length="__PLACEHOLDER__"/>
+            <ItemDef OID="IT.VS.VSORRESU.RESP" Name="VSORRESU" DataType="text" SASFieldName="VSORRESU"
+                     Length="__PLACEHOLDER__"/>
+            <ItemDef OID="IT.VS.VSORRESU.BMI" Name="VSORRESU" DataType="text" SASFieldName="VSORRESU"
+                     Length="__PLACEHOLDER__"/>
+            <ItemDef OID="IT.VS.VSORRESU.SYSBP" Name="VSORRESU" DataType="text" SASFieldName="VSORRESU"
+                     Length="__PLACEHOLDER__"/>
+            <ItemDef OID="IT.VS.VSORRESU.DIABP" Name="VSORRESU" DataType="text" SASFieldName="VSORRESU"
+                     Length="__PLACEHOLDER__"/>
+            <ItemDef OID="IT.VS.VSORRESU.HR" Name="VSORRESU" DataType="text" SASFieldName="VSORRESU"
+                     Length="__PLACEHOLDER__"/>
+            <ItemDef OID="IT.EG.STUDYID" Name="STUDYID" DataType="text" SASFieldName="STUDYID" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Study Identifier</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.EG.DOMAIN" Name="DOMAIN" DataType="text" SASFieldName="DOMAIN" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.EG.USUBJID" Name="USUBJID" DataType="text" SASFieldName="USUBJID" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.EG.EGSEQ" Name="EGSEQ" DataType="integer" SASFieldName="EGSEQ" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Sequence Number</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.EG.EGTESTCD" Name="EGTESTCD" DataType="text" SASFieldName="EGTESTCD"
+                     Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">ECG Test or Examination Short Name</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.EGTESTCD"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.EG.EGTEST" Name="EGTEST" DataType="text" SASFieldName="EGTEST" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">ECG Test or Examination Name</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.EGTEST"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.EG.EGCAT" Name="EGCAT" DataType="text" SASFieldName="EGCAT" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Category for ECG</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.EG.EGPOS" Name="EGPOS" DataType="text" SASFieldName="EGPOS" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">ECG Position of Subject</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.POSITION"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.EG.EGORRES" Name="EGORRES" DataType="text" SASFieldName="EGORRES" Length="20">
+                <Description>
+                    <TranslatedText xml:lang="en">Result or Finding in Original Units</TranslatedText>
+                </Description>
+                <def:ValueListRef ValueListOID="VL.EG.EGORRES"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.EG.EGORRESU" Name="EGORRESU" DataType="text" SASFieldName="EGORRESU"
+                     Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Original Units</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.UNIT"/>
+                <def:ValueListRef ValueListOID="VL.EG.EGORRESU"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.EG.EGSTRESC" Name="EGSTRESC" DataType="text" SASFieldName="EGSTRESC" Length="20">
+                <Description>
+                    <TranslatedText xml:lang="en">Character Result/Finding in Std Format</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.EGSTRESC"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.EG.EGSTRESN" Name="EGSTRESN" DataType="float" SASFieldName="EGSTRESN" Length="8"
+                     SignificantDigits="3" def:DisplayFormat="8.3">
+                <Description>
+                    <TranslatedText xml:lang="en">Numeric Result/Finding in Standard Units</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.EG.EGSTRESU" Name="EGSTRESU" DataType="text" SASFieldName="EGSTRESU"
+                     Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Standard Units</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.UNIT"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.EG.EGMETHOD" Name="EGMETHOD" DataType="text" SASFieldName="EGMETHOD"
+                     Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Method of Test or Examination</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.EGMETHOD"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.EG.EGLOBXFL" Name="EGLOBXFL" DataType="text" SASFieldName="EGLOBXFL"
+                     Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Last Observation Before Exposure Flag</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.NY"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.EG.EGEVAL" Name="EGEVAL" DataType="text" SASFieldName="EGEVAL" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Evaluator</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.EVAL"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.EG.EGCLSIG" Name="EGCLSIG" DataType="text" SASFieldName="EGCLSIG" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Clinically Significant, Collected</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.NY"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.EG.VISITNUM" Name="VISITNUM" DataType="integer" SASFieldName="VISITNUM"
+                     Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Visit Number</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.EG.EGDTC" Name="EGDTC" DataType="datetime" SASFieldName="EGDTC">
+                <Description>
+                    <TranslatedText xml:lang="en">Date/Time of ECG</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.EG.EGORRES.INTP" Name="EGORRES" DataType="text" SASFieldName="EGORRES" Length="20"/>
+            <ItemDef OID="IT.EG.EGORRES.AVCOND" Name="EGORRES" DataType="text" SASFieldName="EGORRES" Length="8"
+                     SignificantDigits="3" def:DisplayFormat="8.3"/>
+            <ItemDef OID="IT.EG.EGORRES.AXISVOLT" Name="EGORRES" DataType="text" SASFieldName="EGORRES" Length="8"
+                     SignificantDigits="3" def:DisplayFormat="8.3"/>
+            <ItemDef OID="IT.EG.EGORRES.CHYPTENL" Name="EGORRES" DataType="text" SASFieldName="EGORRES" Length="8"
+                     SignificantDigits="3" def:DisplayFormat="8.3"/>
+            <ItemDef OID="IT.EG.EGORRES.TECHQUAL" Name="EGORRES" DataType="text" SASFieldName="EGORRES" Length="200"/>
+            <ItemDef OID="IT.EG.EGORRES.IVTIACD" Name="EGORRES" DataType="text" SASFieldName="EGORRES" Length="8"
+                     SignificantDigits="3" def:DisplayFormat="8.3"/>
+            <ItemDef OID="IT.EG.EGORRES.PACEMAKR" Name="EGORRES" DataType="text" SASFieldName="EGORRES" Length="8"
+                     SignificantDigits="3" def:DisplayFormat="8.3"/>
+            <ItemDef OID="IT.EG.EGORRES.RHYNOS" Name="EGORRES" DataType="text" SASFieldName="EGORRES" Length="8"
+                     SignificantDigits="3" def:DisplayFormat="8.3"/>
+            <ItemDef OID="IT.EG.EGORRES.SNRARRY" Name="EGORRES" DataType="text" SASFieldName="EGORRES" Length="8"
+                     SignificantDigits="3" def:DisplayFormat="8.3"/>
+            <ItemDef OID="IT.EG.EGORRES.SPRARRY" Name="EGORRES" DataType="text" SASFieldName="EGORRES" Length="8"
+                     SignificantDigits="3" def:DisplayFormat="8.3"/>
+            <ItemDef OID="IT.EG.EGORRES.SPRTARRY" Name="EGORRES" DataType="text" SASFieldName="EGORRES" Length="8"
+                     SignificantDigits="3" def:DisplayFormat="8.3"/>
+            <ItemDef OID="IT.EG.EGORRES.VTARRY" Name="EGORRES" DataType="text" SASFieldName="EGORRES" Length="8"
+                     SignificantDigits="3" def:DisplayFormat="8.3"/>
+            <ItemDef OID="IT.EG.EGORRES.VTTARRY" Name="EGORRES" DataType="text" SASFieldName="EGORRES" Length="8"
+                     SignificantDigits="3" def:DisplayFormat="8.3"/>
+            <ItemDef OID="IT.EG.EGORRES.PRAG" Name="EGORRES" DataType="text" SASFieldName="EGORRES" Length="8"
+                     SignificantDigits="3" def:DisplayFormat="8.3"/>
+            <ItemDef OID="IT.EG.EGORRES.QRSAG" Name="EGORRES" DataType="text" SASFieldName="EGORRES" Length="8"
+                     SignificantDigits="3" def:DisplayFormat="8.3"/>
+            <ItemDef OID="IT.EG.EGORRES.QTAG" Name="EGORRES" DataType="text" SASFieldName="EGORRES" Length="8"
+                     SignificantDigits="3" def:DisplayFormat="8.3"/>
+            <ItemDef OID="IT.EG.EGORRES.QTCBAG" Name="EGORRES" DataType="text" SASFieldName="EGORRES" Length="8"
+                     SignificantDigits="3" def:DisplayFormat="8.3"/>
+            <ItemDef OID="IT.EG.EGORRES.QTCFAG" Name="EGORRES" DataType="text" SASFieldName="EGORRES" Length="8"
+                     SignificantDigits="3" def:DisplayFormat="8.3"/>
+            <ItemDef OID="IT.EG.EGORRES.RRAG" Name="EGORRES" DataType="text" SASFieldName="EGORRES" Length="8"
+                     SignificantDigits="3" def:DisplayFormat="8.3"/>
+            <ItemDef OID="IT.EG.EGORRES.EGHRMN" Name="EGORRES" DataType="text" SASFieldName="EGORRES" Length="8"
+                     SignificantDigits="3" def:DisplayFormat="8.3"/>
+            <ItemDef OID="IT.EG.EGORRES.QRS_AXIS" Name="EGORRES" DataType="text" SASFieldName="EGORRES" Length="8"
+                     SignificantDigits="3" def:DisplayFormat="8.3"/>
+            <ItemDef OID="IT.EG.EGORRESU.PRAG" Name="EGORRESU" DataType="text" SASFieldName="EGORRESU"
+                     Length="__PLACEHOLDER__"/>
+            <ItemDef OID="IT.EG.EGORRESU.QRSAG" Name="EGORRESU" DataType="text" SASFieldName="EGORRESU"
+                     Length="__PLACEHOLDER__"/>
+            <ItemDef OID="IT.EG.EGORRESU.QTAG" Name="EGORRESU" DataType="text" SASFieldName="EGORRESU"
+                     Length="__PLACEHOLDER__"/>
+            <ItemDef OID="IT.EG.EGORRESU.QTCBAG" Name="EGORRESU" DataType="text" SASFieldName="EGORRESU"
+                     Length="__PLACEHOLDER__"/>
+            <ItemDef OID="IT.EG.EGORRESU.QTCFAG" Name="EGORRESU" DataType="text" SASFieldName="EGORRESU"
+                     Length="__PLACEHOLDER__"/>
+            <ItemDef OID="IT.EG.EGORRESU.RRAG" Name="EGORRESU" DataType="text" SASFieldName="EGORRESU"
+                     Length="__PLACEHOLDER__"/>
+            <ItemDef OID="IT.EG.EGORRESU.EGHRMN" Name="EGORRESU" DataType="text" SASFieldName="EGORRESU"
+                     Length="__PLACEHOLDER__"/>
+            <ItemDef OID="IT.EG.EGORRESU.QRS_AXIS" Name="EGORRESU" DataType="text" SASFieldName="EGORRESU"
+                     Length="__PLACEHOLDER__"/>
+            <ItemDef OID="IT.CM.STUDYID" Name="STUDYID" DataType="text" SASFieldName="STUDYID" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Study Identifier</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.CM.DOMAIN" Name="DOMAIN" DataType="text" SASFieldName="DOMAIN" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.CM.USUBJID" Name="USUBJID" DataType="text" SASFieldName="USUBJID" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.CM.CMSEQ" Name="CMSEQ" DataType="integer" SASFieldName="CMSEQ" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Sequence Number</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.CM.CMTRT" Name="CMTRT" DataType="text" SASFieldName="CMTRT" Length="200">
+                <Description>
+                    <TranslatedText xml:lang="en">Reported Name of Drug, Med, or Therapy</TranslatedText>
+                </Description>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.CM.CMDECOD" Name="CMDECOD" DataType="text" SASFieldName="CMDECOD" Length="200">
+                <Description>
+                    <TranslatedText xml:lang="en">Standardized Medication Name</TranslatedText>
+                </Description>
+                <def:Origin Type="Assigned" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.CM.CMCAT" Name="CMCAT" DataType="text" SASFieldName="CMCAT" Length="200">
+                <Description>
+                    <TranslatedText xml:lang="en">Category for Medication</TranslatedText>
+                </Description>
+                <def:Origin Type="Assigned" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.CM.CMSCAT" Name="CMSCAT" DataType="text" SASFieldName="CMSCAT" Length="200">
+                <Description>
+                    <TranslatedText xml:lang="en">Subcategory for Medication</TranslatedText>
+                </Description>
+                <def:Origin Type="Assigned" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.CM.CMPRESP" Name="CMPRESP" DataType="text" SASFieldName="CMPRESP" Length="1">
+                <Description>
+                    <TranslatedText xml:lang="en">CM Pre-specified</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.NY"/>
+                <def:Origin Type="Assigned" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.CM.CMOCCUR" Name="CMOCCUR" DataType="text" SASFieldName="CMOCCUR" Length="1">
+                <Description>
+                    <TranslatedText xml:lang="en">CM Occurrence</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.NY"/>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.CM.CMINDC" Name="CMINDC" DataType="text" SASFieldName="CMINDC" Length="200">
+                <Description>
+                    <TranslatedText xml:lang="en">Indication</TranslatedText>
+                </Description>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.CM.CMDOSE" Name="CMDOSE" DataType="text" SASFieldName="CMDOSE" Length="40">
+                <Description>
+                    <TranslatedText xml:lang="en">Dose per Administration</TranslatedText>
+                </Description>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.CM.CMDOSU" Name="CMDOSU" DataType="text" SASFieldName="CMDOSU" Length="40">
+                <Description>
+                    <TranslatedText xml:lang="en">Dose Units</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.UNIT"/>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.CM.CMDOSFRM" Name="CMDOSFRM" DataType="text" SASFieldName="CMDOSFRM" Length="40">
+                <Description>
+                    <TranslatedText xml:lang="en">Dose Form</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.FRM"/>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.CM.CMROUTE" Name="CMROUTE" DataType="text" SASFieldName="CMROUTE" Length="200">
+                <Description>
+                    <TranslatedText xml:lang="en">Route of Administration</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.ROUTE"/>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.CM.CMSTDTC" Name="CMSTDTC" DataType="datetime" SASFieldName="CMSTDTC">
+                <Description>
+                    <TranslatedText xml:lang="en">Start Date/Time of Medication</TranslatedText>
+                </Description>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.CM.CMENDTC" Name="CMENDTC" DataType="datetime" SASFieldName="CMENDTC">
+                <Description>
+                    <TranslatedText xml:lang="en">End Date/Time of Medication</TranslatedText>
+                </Description>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.LB.STUDYID" Name="STUDYID" DataType="text" SASFieldName="STUDYID" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Study Identifier</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.DOMAIN" Name="DOMAIN" DataType="text" SASFieldName="DOMAIN" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.USUBJID" Name="USUBJID" DataType="text" SASFieldName="USUBJID" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBSEQ" Name="LBSEQ" DataType="integer" SASFieldName="LBSEQ" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Sequence Number</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBTESTCD" Name="LBTESTCD" DataType="text" SASFieldName="LBTESTCD"
+                     Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Lab Test or Examination Short Name</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.LBTESTCD"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBTEST" Name="LBTEST" DataType="text" SASFieldName="LBTEST" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Lab Test or Examination Name</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.LBTEST"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBCAT" Name="LBCAT" DataType="text" SASFieldName="LBCAT" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Category for Lab Test</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBORRES" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12"
+                     SignificantDigits="4" def:DisplayFormat="12.4">
+                <Description>
+                    <TranslatedText xml:lang="en">Result or Finding in Original Units</TranslatedText>
+                </Description>
+                <def:ValueListRef ValueListOID="VL.LB.LBORRES"/>
+                <def:Origin Type="Collected" Source="Vendor"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBORRESU" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU"
+                     Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Original Units</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.UNIT"/>
+                <def:ValueListRef ValueListOID="VL.LB.LBORRESU"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBORNRLO" Name="LBORNRLO" DataType="text" SASFieldName="LBORNRLO"
+                     Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Reference Range Lower Limit in Orig Unit</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBORNRHI" Name="LBORNRHI" DataType="text" SASFieldName="LBORNRHI"
+                     Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Reference Range Upper Limit in Orig Unit</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBSTRESC" Name="LBSTRESC" DataType="float" SASFieldName="LBSTRESC" Length="12"
+                     SignificantDigits="4" def:DisplayFormat="12.4">
+                <Description>
+                    <TranslatedText xml:lang="en">Character Result/Finding in Std Format</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.LBSTRESC"/>
+                <def:Origin Type="Collected" Source="Vendor"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBSTRESN" Name="LBSTRESN" DataType="float" SASFieldName="LBSTRESN" Length="12"
+                     SignificantDigits="4" def:DisplayFormat="12.4">
+                <Description>
+                    <TranslatedText xml:lang="en">Numeric Result/Finding in Standard Units</TranslatedText>
+                </Description>
+                <def:Origin Type="Collected" Source="Vendor"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBSTRESU" Name="LBSTRESU" DataType="text" SASFieldName="LBSTRESU"
+                     Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Standard Units</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.UNIT"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBSTNRLO" Name="LBSTNRLO" DataType="integer" SASFieldName="LBSTNRLO"
+                     Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Reference Range Lower Limit-Std Units</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBSTNRHI" Name="LBSTNRHI" DataType="integer" SASFieldName="LBSTNRHI"
+                     Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Reference Range Upper Limit-Std Units</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBNRIND" Name="LBNRIND" DataType="text" SASFieldName="LBNRIND" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Reference Range Indicator</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.NRIND"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBSPEC" Name="LBSPEC" DataType="text" SASFieldName="LBSPEC" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Specimen Type</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.SPECTYPE"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBMETHOD" Name="LBMETHOD" DataType="text" SASFieldName="LBMETHOD"
+                     Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Method of Test or Examination</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.METHOD"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBLOBXFL" Name="LBLOBXFL" DataType="text" SASFieldName="LBLOBXFL"
+                     Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Last Observation Before Exposure Flag</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.NY"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBFAST" Name="LBFAST" DataType="text" SASFieldName="LBFAST" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Fasting Status</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.NY"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.VISITNUM" Name="VISITNUM" DataType="integer" SASFieldName="VISITNUM"
+                     Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Visit Number</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBDTC" Name="LBDTC" DataType="datetime" SASFieldName="LBDTC">
+                <Description>
+                    <TranslatedText xml:lang="en">Date/Time of Specimen Collection</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBORRES.HGB" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12"
+                     SignificantDigits="4" def:DisplayFormat="12.4">
+                <def:Origin Type="Collected" Source="Vendor"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBORRES.HCT" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12"
+                     SignificantDigits="4" def:DisplayFormat="12.4">
+                <def:Origin Type="Collected" Source="Vendor"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBORRES.RBC" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12"
+                     SignificantDigits="4" def:DisplayFormat="12.4">
+                <def:Origin Type="Collected" Source="Vendor"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBORRES.MCH" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12"
+                     SignificantDigits="4" def:DisplayFormat="12.4">
+                <def:Origin Type="Collected" Source="Vendor"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBORRES.MCHC" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12"
+                     SignificantDigits="4" def:DisplayFormat="12.4">
+                <def:Origin Type="Collected" Source="Vendor"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBORRES.MCV" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12"
+                     SignificantDigits="4" def:DisplayFormat="12.4">
+                <def:Origin Type="Collected" Source="Vendor"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBORRES.WBC" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12"
+                     SignificantDigits="4" def:DisplayFormat="12.4">
+                <def:Origin Type="Collected" Source="Vendor"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBORRES.NEUTSG" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12"
+                     SignificantDigits="4" def:DisplayFormat="12.4">
+                <def:Origin Type="Collected" Source="Vendor"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBORRES.NEUTB" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12"
+                     SignificantDigits="4" def:DisplayFormat="12.4">
+                <def:Origin Type="Collected" Source="Vendor"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBORRES.NEUT" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12"
+                     SignificantDigits="4" def:DisplayFormat="12.4">
+                <def:Origin Type="Collected" Source="Vendor"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBORRES.MONO" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12"
+                     SignificantDigits="4" def:DisplayFormat="12.4">
+                <def:Origin Type="Collected" Source="Vendor"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBORRES.EOS" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12"
+                     SignificantDigits="4" def:DisplayFormat="12.4">
+                <def:Origin Type="Collected" Source="Vendor"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBORRES.BASO" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12"
+                     SignificantDigits="4" def:DisplayFormat="12.4">
+                <def:Origin Type="Collected" Source="Vendor"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBORRES.PLAT" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12"
+                     SignificantDigits="4" def:DisplayFormat="12.4">
+                <def:Origin Type="Collected" Source="Vendor"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBORRES.MICROCY" Name="LBORRES" DataType="text" SASFieldName="LBORRES" Length="200">
+                <def:Origin Type="Collected" Source="Vendor"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBORRES.MACROCY" Name="LBORRES" DataType="text" SASFieldName="LBORRES" Length="200">
+                <def:Origin Type="Collected" Source="Vendor"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBORRES.ANISO" Name="LBORRES" DataType="text" SASFieldName="LBORRES" Length="200">
+                <def:Origin Type="Collected" Source="Vendor"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBORRES.POIKILO" Name="LBORRES" DataType="text" SASFieldName="LBORRES" Length="200">
+                <def:Origin Type="Collected" Source="Vendor"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBORRES.POLYCHR" Name="LBORRES" DataType="text" SASFieldName="LBORRES" Length="200">
+                <def:Origin Type="Collected" Source="Vendor"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBORRES.ALT" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12"
+                     SignificantDigits="4" def:DisplayFormat="12.4">
+                <def:Origin Type="Collected" Source="Vendor"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBORRES.ALB" Name="LBORRES" DataType="text" SASFieldName="LBORRES" Length="200"
+                     SignificantDigits="4">
+                <def:Origin Type="Collected" Source="Vendor"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBORRES.ALP" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12"
+                     SignificantDigits="4" def:DisplayFormat="12.4">
+                <def:Origin Type="Collected" Source="Vendor"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBORRES.AST" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12"
+                     SignificantDigits="4" def:DisplayFormat="12.4">
+                <def:Origin Type="Collected" Source="Vendor"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBORRES.CREAT" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12"
+                     SignificantDigits="4" def:DisplayFormat="12.4">
+                <def:Origin Type="Collected" Source="Vendor"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBORRES.K" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12"
+                     SignificantDigits="4" def:DisplayFormat="12.4">
+                <def:Origin Type="Collected" Source="Vendor"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBORRES.SODIUM" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12"
+                     SignificantDigits="4" def:DisplayFormat="12.4">
+                <def:Origin Type="Collected" Source="Vendor"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBORRES.UREAN" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12"
+                     SignificantDigits="4" def:DisplayFormat="12.4">
+                <def:Origin Type="Collected" Source="Vendor"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBORRES.BICARB" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12"
+                     SignificantDigits="4" def:DisplayFormat="12.4">
+                <def:Origin Type="Collected" Source="Vendor"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBORRES.CL" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12"
+                     SignificantDigits="4" def:DisplayFormat="12.4">
+                <def:Origin Type="Collected" Source="Vendor"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBORRES.BILI" Name="LBORRES" DataType="text" SASFieldName="LBORRES" Length="200"
+                     SignificantDigits="4">
+                <def:Origin Type="Collected" Source="Vendor"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBORRES.GGT" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12"
+                     SignificantDigits="4" def:DisplayFormat="12.4">
+                <def:Origin Type="Collected" Source="Vendor"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBORRES.URATE" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12"
+                     SignificantDigits="4" def:DisplayFormat="12.4">
+                <def:Origin Type="Collected" Source="Vendor"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBORRES.PHOS" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12"
+                     SignificantDigits="4" def:DisplayFormat="12.4">
+                <def:Origin Type="Collected" Source="Vendor"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBORRES.CA" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12"
+                     SignificantDigits="4" def:DisplayFormat="12.4">
+                <def:Origin Type="Collected" Source="Vendor"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBORRES.GLUC" Name="LBORRES" DataType="text" SASFieldName="LBORRES" Length="200"/>
+            <ItemDef OID="IT.LB.LBORRES.PROT" Name="LBORRES" DataType="text" SASFieldName="LBORRES" Length="200"
+                     SignificantDigits="4">
+                <def:Origin Type="Collected" Source="Vendor"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBORRES.CHOL" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12"
+                     SignificantDigits="4" def:DisplayFormat="12.4">
+                <def:Origin Type="Collected" Source="Vendor"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBORRES.T3UP" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12"
+                     SignificantDigits="4" def:DisplayFormat="12.4">
+                <def:Origin Type="Collected" Source="Vendor"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBORRES.T3" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12"
+                     SignificantDigits="4" def:DisplayFormat="12.4">
+                <def:Origin Type="Collected" Source="Vendor"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBORRES.T4FR" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12"
+                     SignificantDigits="4" def:DisplayFormat="12.4">
+                <def:Origin Type="Collected" Source="Vendor"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBORRES.T4FRIDX" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12"
+                     SignificantDigits="4" def:DisplayFormat="12.4">
+                <def:Origin Type="Collected" Source="Vendor"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBORRES.TSH" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12"
+                     SignificantDigits="4" def:DisplayFormat="12.4">
+                <def:Origin Type="Collected" Source="Vendor"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBORRES.VITB9" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12"
+                     SignificantDigits="4" def:DisplayFormat="12.4">
+                <def:Origin Type="Collected" Source="Vendor"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBORRES.VITB12" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12"
+                     SignificantDigits="4" def:DisplayFormat="12.4">
+                <def:Origin Type="Collected" Source="Vendor"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBORRES.COLOR" Name="LBORRES" DataType="text" SASFieldName="LBORRES" Length="200">
+                <def:Origin Type="Collected" Source="Vendor"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBORRES.SPGRAV" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12"
+                     SignificantDigits="4" def:DisplayFormat="12.4">
+                <def:Origin Type="Collected" Source="Vendor"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBORRES.KETONES" Name="LBORRES" DataType="text" SASFieldName="LBORRES" Length="200"
+                     SignificantDigits="4">
+                <def:Origin Type="Collected" Source="Vendor"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBORRES.UROBIL" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12"
+                     SignificantDigits="4" def:DisplayFormat="12.4">
+                <def:Origin Type="Collected" Source="Vendor"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBORRES.OCCBLD" Name="LBORRES" DataType="text" SASFieldName="LBORRES" Length="200"
+                     SignificantDigits="4">
+                <def:Origin Type="Collected" Source="Vendor"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBORRES.NITRITE" Name="LBORRES" DataType="text" SASFieldName="LBORRES" Length="200"
+                     SignificantDigits="4">
+                <def:Origin Type="Collected" Source="Vendor"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBORRES.HBA1C" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12"
+                     SignificantDigits="4" def:DisplayFormat="12.4">
+                <def:Origin Type="Collected" Source="Vendor"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBORRES.HBA1CHGB" Name="LBORRES" DataType="float" SASFieldName="LBORRES" Length="12"
+                     SignificantDigits="4" def:DisplayFormat="12.4">
+                <def:Origin Type="Collected" Source="Vendor"/>
+            </ItemDef>
+            <ItemDef OID="IT.LB.LBORRESU.HGB" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU"
+                     Length="__PLACEHOLDER__"/>
+            <ItemDef OID="IT.LB.LBORRESU.HCT" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU"
+                     Length="__PLACEHOLDER__"/>
+            <ItemDef OID="IT.LB.LBORRESU.RBC" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU"
+                     Length="__PLACEHOLDER__"/>
+            <ItemDef OID="IT.LB.LBORRESU.MCH" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU"
+                     Length="__PLACEHOLDER__"/>
+            <ItemDef OID="IT.LB.LBORRESU.MCHC" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU"
+                     Length="__PLACEHOLDER__"/>
+            <ItemDef OID="IT.LB.LBORRESU.MCV" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU"
+                     Length="__PLACEHOLDER__"/>
+            <ItemDef OID="IT.LB.LBORRESU.WBC" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU"
+                     Length="__PLACEHOLDER__"/>
+            <ItemDef OID="IT.LB.LBORRESU.NEUTSG" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU"
+                     Length="__PLACEHOLDER__"/>
+            <ItemDef OID="IT.LB.LBORRESU.NEUTB" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU"
+                     Length="__PLACEHOLDER__"/>
+            <ItemDef OID="IT.LB.LBORRESU.NEUT" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU"
+                     Length="__PLACEHOLDER__"/>
+            <ItemDef OID="IT.LB.LBORRESU.MONO" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU"
+                     Length="__PLACEHOLDER__"/>
+            <ItemDef OID="IT.LB.LBORRESU.EOS" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU"
+                     Length="__PLACEHOLDER__"/>
+            <ItemDef OID="IT.LB.LBORRESU.BASO" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU"
+                     Length="__PLACEHOLDER__"/>
+            <ItemDef OID="IT.LB.LBORRESU.PLAT" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU"
+                     Length="__PLACEHOLDER__"/>
+            <ItemDef OID="IT.LB.LBORRESU.ALT" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU"
+                     Length="__PLACEHOLDER__"/>
+            <ItemDef OID="IT.LB.LBORRESU.ALP" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU"
+                     Length="__PLACEHOLDER__"/>
+            <ItemDef OID="IT.LB.LBORRESU.AST" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU"
+                     Length="__PLACEHOLDER__"/>
+            <ItemDef OID="IT.LB.LBORRESU.CREAT" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU"
+                     Length="__PLACEHOLDER__"/>
+            <ItemDef OID="IT.LB.LBORRESU.K" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU"
+                     Length="__PLACEHOLDER__"/>
+            <ItemDef OID="IT.LB.LBORRESU.SODIUM" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU"
+                     Length="__PLACEHOLDER__"/>
+            <ItemDef OID="IT.LB.LBORRESU.UREAN" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU"
+                     Length="__PLACEHOLDER__"/>
+            <ItemDef OID="IT.LB.LBORRESU.BICARB" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU"
+                     Length="__PLACEHOLDER__"/>
+            <ItemDef OID="IT.LB.LBORRESU.CL" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU"
+                     Length="__PLACEHOLDER__"/>
+            <ItemDef OID="IT.LB.LBORRESU.GGT" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU"
+                     Length="__PLACEHOLDER__"/>
+            <ItemDef OID="IT.LB.LBORRESU.URATE" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU"
+                     Length="__PLACEHOLDER__"/>
+            <ItemDef OID="IT.LB.LBORRESU.PHOS" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU"
+                     Length="__PLACEHOLDER__"/>
+            <ItemDef OID="IT.LB.LBORRESU.CA" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU"
+                     Length="__PLACEHOLDER__"/>
+            <ItemDef OID="IT.LB.LBORRESU.CHOL" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU"
+                     Length="__PLACEHOLDER__"/>
+            <ItemDef OID="IT.LB.LBORRESU.T3UP" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU"
+                     Length="__PLACEHOLDER__"/>
+            <ItemDef OID="IT.LB.LBORRESU.T3" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU"
+                     Length="__PLACEHOLDER__"/>
+            <ItemDef OID="IT.LB.LBORRESU.T4FR" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU"
+                     Length="__PLACEHOLDER__"/>
+            <ItemDef OID="IT.LB.LBORRESU.T4FRIDX" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU"
+                     Length="__PLACEHOLDER__"/>
+            <ItemDef OID="IT.LB.LBORRESU.TSH" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU"
+                     Length="__PLACEHOLDER__"/>
+            <ItemDef OID="IT.LB.LBORRESU.VITB9" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU"
+                     Length="__PLACEHOLDER__"/>
+            <ItemDef OID="IT.LB.LBORRESU.VITB12" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU"
+                     Length="__PLACEHOLDER__"/>
+            <ItemDef OID="IT.LB.LBORRESU.UROBIL" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU"
+                     Length="__PLACEHOLDER__"/>
+            <ItemDef OID="IT.LB.LBORRESU.HBA1C" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU"
+                     Length="__PLACEHOLDER__"/>
+            <ItemDef OID="IT.LB.LBORRESU.HBA1CHGB" Name="LBORRESU" DataType="text" SASFieldName="LBORRESU"
+                     Length="__PLACEHOLDER__"/>
+            <ItemDef OID="IT.MB.STUDYID" Name="STUDYID" DataType="text" SASFieldName="STUDYID" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Study Identifier</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.MB.DOMAIN" Name="DOMAIN" DataType="text" SASFieldName="DOMAIN" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.MB.USUBJID" Name="USUBJID" DataType="text" SASFieldName="USUBJID" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.MB.MBSEQ" Name="MBSEQ" DataType="integer" SASFieldName="MBSEQ" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Sequence Number</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.MB.MBTESTCD" Name="MBTESTCD" DataType="text" SASFieldName="MBTESTCD"
+                     Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Microbiology Test or Finding Short Name</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.MBTESTCD"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.MB.MBTEST" Name="MBTEST" DataType="text" SASFieldName="MBTEST" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Microbiology Test or Finding Name</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.MBTEST"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.MB.MBTSTDTL" Name="MBTSTDTL" DataType="text" SASFieldName="MBTSTDTL"
+                     Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Measurement, Test or Examination Detail</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.MBFTSDTL"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.MB.MBORRES" Name="MBORRES" DataType="text" SASFieldName="MBORRES" Length="20">
+                <Description>
+                    <TranslatedText xml:lang="en">Result or Finding in Original Units</TranslatedText>
+                </Description>
+                <def:ValueListRef ValueListOID="VL.MB.MBORRES"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.MB.MBSTRESC" Name="MBSTRESC" DataType="text" SASFieldName="MBSTRESC" Length="20">
+                <Description>
+                    <TranslatedText xml:lang="en">Result or Finding in Standard Format</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.MB.MBSPEC" Name="MBSPEC" DataType="text" SASFieldName="MBSPEC" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Specimen Material Type</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.SPECTYPE"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.MB.MBMETHOD" Name="MBMETHOD" DataType="text" SASFieldName="MBMETHOD"
+                     Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Method of Test or Examination</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.METHOD"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.MB.VISITNUM" Name="VISITNUM" DataType="integer" SASFieldName="VISITNUM"
+                     Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Visit Number</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.MB.MBDTC" Name="MBDTC" DataType="datetime" SASFieldName="MBDTC">
+                <Description>
+                    <TranslatedText xml:lang="en">Date/Time of Collection</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.MB.MBORRES.TPLAB" Name="MBORRES" DataType="text" SASFieldName="MBORRES" Length="20"/>
+            <ItemDef OID="IT.MB.MBORRES.TPADNA" Name="MBORRES" DataType="text" SASFieldName="MBORRES" Length="20"/>
+            <ItemDef OID="IT.EC.STUDYID" Name="STUDYID" DataType="text" SASFieldName="STUDYID" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Study Identifier</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.EC.DOMAIN" Name="DOMAIN" DataType="text" SASFieldName="DOMAIN" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.EC.USUBJID" Name="USUBJID" DataType="text" SASFieldName="USUBJID" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.EC.ECSEQ" Name="ECSEQ" DataType="integer" SASFieldName="ECSEQ" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Sequence Number</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.EC.ECREFID" Name="ECREFID" DataType="text" SASFieldName="ECREFID" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Reference ID</TranslatedText>
+                </Description>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.EC.ECTRT" Name="ECTRT" DataType="text" SASFieldName="ECTRT" Length="200">
+                <Description>
+                    <TranslatedText xml:lang="en">Name of Treatment</TranslatedText>
+                </Description>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.EC.ECDOSE" Name="ECDOSE" DataType="integer" SASFieldName="ECDOSE" Length="20">
+                <Description>
+                    <TranslatedText xml:lang="en">Dose</TranslatedText>
+                </Description>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.EC.ECDOSTXT" Name="ECDOSTXT" DataType="text" SASFieldName="ECDOSTXT" Length="100">
+                <Description>
+                    <TranslatedText xml:lang="en">Dose Description</TranslatedText>
+                </Description>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.EC.ECDOSU" Name="ECDOSU" DataType="text" SASFieldName="ECDOSU" Length="200">
+                <Description>
+                    <TranslatedText xml:lang="en">Dose Units</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.UNIT"/>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.EC.ECDOSFRM" Name="ECDOSFRM" DataType="text" SASFieldName="ECDOSFRM" Length="200">
+                <Description>
+                    <TranslatedText xml:lang="en">Dose Form</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.FRM"/>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.EC.ECDOSFRQ" Name="ECDOSFRQ" DataType="text" SASFieldName="ECDOSFRQ" Length="200">
+                <Description>
+                    <TranslatedText xml:lang="en">Dosing Frequency per Interval</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.FREQ"/>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.EC.ECDOSRGM" Name="ECDOSRGM" DataType="text" SASFieldName="ECDOSRGM"
+                     Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Intended Dose Regimen</TranslatedText>
+                </Description>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.EC.ECROUTE" Name="ECROUTE" DataType="text" SASFieldName="ECROUTE" Length="200">
+                <Description>
+                    <TranslatedText xml:lang="en">Route of Administration</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.ROUTE"/>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.EC.ECLOC" Name="ECLOC" DataType="text" SASFieldName="ECLOC" Length="200">
+                <Description>
+                    <TranslatedText xml:lang="en">Location of Dose Administration</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.LOC"/>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.EC.ECLAT" Name="ECLAT" DataType="text" SASFieldName="ECLAT" Length="200">
+                <Description>
+                    <TranslatedText xml:lang="en">Laterality</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.LAT"/>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.EC.ECDIR" Name="ECDIR" DataType="text" SASFieldName="ECDIR" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Directionality</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.DIR"/>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.EC.ECSTDTC" Name="ECSTDTC" DataType="datetime" SASFieldName="ECSTDTC">
+                <Description>
+                    <TranslatedText xml:lang="en">Start Date/Time of Treatment</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.EC.ECENDTC" Name="ECENDTC" DataType="datetime" SASFieldName="ECENDTC">
+                <Description>
+                    <TranslatedText xml:lang="en">End Date/Time of Treatment</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.AE.STUDYID" Name="STUDYID" DataType="text" SASFieldName="STUDYID" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Study Identifier</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.AE.DOMAIN" Name="DOMAIN" DataType="text" SASFieldName="DOMAIN" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.AE.USUBJID" Name="USUBJID" DataType="text" SASFieldName="USUBJID" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.AE.AESEQ" Name="AESEQ" DataType="integer" SASFieldName="AESEQ" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Sequence Number</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.AE.AETERM" Name="AETERM" DataType="text" SASFieldName="AETERM" Length="200">
+                <Description>
+                    <TranslatedText xml:lang="en">Reported Term for the Adverse Event</TranslatedText>
+                </Description>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.AE.AELLT" Name="AELLT" DataType="text" SASFieldName="AELLT" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Lowest Level Term</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.AE.AELLTCD" Name="AELLTCD" DataType="integer" SASFieldName="AELLTCD"
+                     Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Lowest Level Term Code</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.AE.AEDECOD" Name="AEDECOD" DataType="text" SASFieldName="AEDECOD" Length="200">
+                <Description>
+                    <TranslatedText xml:lang="en">Dictionary-Derived Term</TranslatedText>
+                </Description>
+                <def:Origin Type="Assigned" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.AE.AEPTCD" Name="AEPTCD" DataType="integer" SASFieldName="AEPTCD" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Preferred Term Code</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.AE.AEHLT" Name="AEHLT" DataType="text" SASFieldName="AEHLT" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">High Level Term</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.AE.AEHLTCD" Name="AEHLTCD" DataType="integer" SASFieldName="AEHLTCD"
+                     Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">High Level Term Code</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.AE.AEHLGT" Name="AEHLGT" DataType="text" SASFieldName="AEHLGT" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">High Level Group Term</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.AE.AEHLGTCD" Name="AEHLGTCD" DataType="integer" SASFieldName="AEHLGTCD"
+                     Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">High Level Group Term Code</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.AE.AECAT" Name="AECAT" DataType="text" SASFieldName="AECAT" Length="200">
+                <Description>
+                    <TranslatedText xml:lang="en">Category for Adverse Event</TranslatedText>
+                </Description>
+                <def:Origin Type="Assigned" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.AE.AESCAT" Name="AESCAT" DataType="text" SASFieldName="AESCAT" Length="200">
+                <Description>
+                    <TranslatedText xml:lang="en">Subcategory for Adverse Event</TranslatedText>
+                </Description>
+                <def:Origin Type="Assigned" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.AE.AEPRESP" Name="AEPRESP" DataType="text" SASFieldName="AEPRESP" Length="1">
+                <Description>
+                    <TranslatedText xml:lang="en">Pre-Specified Adverse Event</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.NY"/>
+                <def:Origin Type="Assigned" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.AE.AEBODSYS" Name="AEBODSYS" DataType="text" SASFieldName="AEBODSYS"
+                     Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Body System or Organ Class</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.AE.AEBDSYCD" Name="AEBDSYCD" DataType="integer" SASFieldName="AEBDSYCD"
+                     Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Body System or Organ Class Code</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.AE.AESOC" Name="AESOC" DataType="text" SASFieldName="AESOC" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Primary System Organ Class</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.AE.AESOCCD" Name="AESOCCD" DataType="integer" SASFieldName="AESOCCD"
+                     Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Primary System Organ Class Code</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.AE.AELOC" Name="AELOC" DataType="text" SASFieldName="AELOC" Length="200">
+                <Description>
+                    <TranslatedText xml:lang="en">Location of Event</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.LOC"/>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.AE.AESEV" Name="AESEV" DataType="text" SASFieldName="AESEV" Length="20">
+                <Description>
+                    <TranslatedText xml:lang="en">Severity/Intensity</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.AESEV"/>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.AE.AESER" Name="AESER" DataType="text" SASFieldName="AESER" Length="1">
+                <Description>
+                    <TranslatedText xml:lang="en">Serious Event</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.NY"/>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.AE.AEACN" Name="AEACN" DataType="text" SASFieldName="AEACN" Length="200">
+                <Description>
+                    <TranslatedText xml:lang="en">Action Taken with Study Treatment</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.ACN"/>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.AE.AEACNOTH" Name="AEACNOTH" DataType="text" SASFieldName="AEACNOTH" Length="200">
+                <Description>
+                    <TranslatedText xml:lang="en">Other Action Taken</TranslatedText>
+                </Description>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.AE.AEREL" Name="AEREL" DataType="text" SASFieldName="AEREL" Length="200">
+                <Description>
+                    <TranslatedText xml:lang="en">Causality</TranslatedText>
+                </Description>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.AE.AERELNST" Name="AERELNST" DataType="text" SASFieldName="AERELNST" Length="200">
+                <Description>
+                    <TranslatedText xml:lang="en">Relationship to Non-Study Treatment</TranslatedText>
+                </Description>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.AE.AEPATT" Name="AEPATT" DataType="text" SASFieldName="AEPATT" Length="200">
+                <Description>
+                    <TranslatedText xml:lang="en">Pattern of Adverse Event</TranslatedText>
+                </Description>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.AE.AEOUT" Name="AEOUT" DataType="text" SASFieldName="AEOUT" Length="200">
+                <Description>
+                    <TranslatedText xml:lang="en">Outcome of Adverse Event</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.OUT"/>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.AE.AESCAN" Name="AESCAN" DataType="text" SASFieldName="AESCAN" Length="1">
+                <Description>
+                    <TranslatedText xml:lang="en">Involves Cancer</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.NY"/>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.AE.AESCONG" Name="AESCONG" DataType="text" SASFieldName="AESCONG" Length="1">
+                <Description>
+                    <TranslatedText xml:lang="en">Congenital Anomaly or Birth Defect</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.NY"/>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.AE.AESDISAB" Name="AESDISAB" DataType="text" SASFieldName="AESDISAB" Length="1">
+                <Description>
+                    <TranslatedText xml:lang="en">Persist or Signif Disability/Incapacity</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.NY"/>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.AE.AESDTH" Name="AESDTH" DataType="text" SASFieldName="AESDTH" Length="1">
+                <Description>
+                    <TranslatedText xml:lang="en">Results in Death</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.NY"/>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.AE.AESHOSP" Name="AESHOSP" DataType="text" SASFieldName="AESHOSP" Length="1">
+                <Description>
+                    <TranslatedText xml:lang="en">Requires or Prolongs Hospitalization</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.NY"/>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.AE.AESLIFE" Name="AESLIFE" DataType="text" SASFieldName="AESLIFE" Length="1">
+                <Description>
+                    <TranslatedText xml:lang="en">Is Life Threatening</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.NY"/>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.AE.AESOD" Name="AESOD" DataType="text" SASFieldName="AESOD" Length="1">
+                <Description>
+                    <TranslatedText xml:lang="en">Occurred with Overdose</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.NY"/>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.AE.AESMIE" Name="AESMIE" DataType="text" SASFieldName="AESMIE" Length="1">
+                <Description>
+                    <TranslatedText xml:lang="en">Other Medically Important Serious Event</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.NY"/>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.AE.AECONTRT" Name="AECONTRT" DataType="text" SASFieldName="AECONTRT" Length="1">
+                <Description>
+                    <TranslatedText xml:lang="en">Concomitant or Additional Trtmnt Given</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.NY"/>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.AE.AETOXGR" Name="AETOXGR" DataType="text" SASFieldName="AETOXGR" Length="1">
+                <Description>
+                    <TranslatedText xml:lang="en">Standard Toxicity Grade</TranslatedText>
+                </Description>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.AE.AESTDTC" Name="AESTDTC" DataType="datetime" SASFieldName="AESTDTC">
+                <Description>
+                    <TranslatedText xml:lang="en">Start Date/Time of Adverse Event</TranslatedText>
+                </Description>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.AE.AEENDTC" Name="AEENDTC" DataType="datetime" SASFieldName="AEENDTC">
+                <Description>
+                    <TranslatedText xml:lang="en">End Date/Time of Adverse Event</TranslatedText>
+                </Description>
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.AE.AEENRF" Name="AEENRF" DataType="text" SASFieldName="AEENRF" Length="20">
+                <Description>
+                    <TranslatedText xml:lang="en">End Relative to Reference Period</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.STENRF"/>
+                <def:Origin Type="Assigned" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.AE.AEENRTPT" Name="AEENRTPT" DataType="text" SASFieldName="AEENRTPT" Length="20">
+                <Description>
+                    <TranslatedText xml:lang="en">End Relative to Reference Time Point</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.STENRF"/>
+                <def:Origin Type="Assigned" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.AE.AEENTPT" Name="AEENTPT" DataType="text" SASFieldName="AEENTPT" Length="20">
+                <Description>
+                    <TranslatedText xml:lang="en">End Reference Time Point</TranslatedText>
+                </Description>
+                <def:Origin Type="Assigned" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.TS.STUDYID" Name="STUDYID" DataType="text" SASFieldName="STUDYID" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Study Identifier</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.TS.DOMAIN" Name="DOMAIN" DataType="text" SASFieldName="DOMAIN" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.TS.TSSEQ" Name="TSSEQ" DataType="integer" SASFieldName="TSSEQ" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Sequence Number</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.TS.TSPARMCD" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD"
+                     Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Trial Summary Parameter Short Name</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.TSPARMCD"/>
+                <def:ValueListRef ValueListOID="VL.TS.TSPARMCD"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.TS.TSPARM" Name="TSPARM" DataType="text" SASFieldName="TSPARM" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Trial Summary Parameter</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.TSPARM"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.TS.TSVAL" Name="TSVAL" DataType="text" SASFieldName="TSVAL" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Parameter Value</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.TS.TSVALCD" Name="TSVALCD" DataType="text" SASFieldName="TSVALCD" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Parameter Value Code</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.TS.TSVCDREF" Name="TSVCDREF" DataType="text" SASFieldName="TSVCDREF"
+                     Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Name of the Reference Terminology</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.DICTNAM"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.TS.TSVCDVER" Name="TSVCDVER" DataType="text" SASFieldName="TSVCDVER"
+                     Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Version of the Reference Terminology</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.TS.TSPARMCD.ADAPT" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="1">
+                <CodeListRef CodeListOID="CL.NY"/>
+                <def:Origin Type="Protocol" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.TS.TSPARMCD.AGEMIN" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="200">
+                <def:Origin Type="Protocol" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.TS.TSPARMCD.AGEMAX" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="200">
+                <def:Origin Type="Protocol" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.TS.TSPARMCD.COMPTRT" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="200">
+                <def:Origin Type="Protocol" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.TS.TSPARMCD.CRMDUR" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="200">
+                <def:Origin Type="Protocol" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.TS.TSPARMCD.DOSE" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="200">
+                <def:Origin Type="Protocol" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.TS.TSPARMCD.DOSFRQ" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="200">
+                <def:Origin Type="Protocol" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.TS.TSPARMCD.DOSU" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="200">
+                <def:Origin Type="Protocol" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.TS.TSPARMCD.INDIC" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="200">
+                <def:Origin Type="Protocol" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.TS.TSPARMCD.INTMODEL" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="200">
+                <def:Origin Type="Protocol" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.TS.TSPARMCD.INTTYPE" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="200">
+                <def:Origin Type="Protocol" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.TS.TSPARMCD.NARMS" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="200">
+                <def:Origin Type="Protocol" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.TS.TSPARMCD.OBJPRIM" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="200">
+                <def:Origin Type="Protocol" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.TS.TSPARMCD.OBJSEC" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="200">
+                <def:Origin Type="Protocol" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.TS.TSPARMCD.OUTMSPRI" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="200">
+                <def:Origin Type="Protocol" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.TS.TSPARMCD.OUTMSSEC" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="200">
+                <def:Origin Type="Protocol" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.TS.TSPARMCD.PLANSUB" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="200">
+                <def:Origin Type="Protocol" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.TS.TSPARMCD.PTRTDUR" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="200">
+                <def:Origin Type="Protocol" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.TS.TSPARMCD.ROUTE" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="200">
+                <def:Origin Type="Protocol" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.TS.TSPARMCD.SEXPOP" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="200">
+                <def:Origin Type="Protocol" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.TS.TSPARMCD.SPONSOR" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="200">
+                <def:Origin Type="Protocol" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.TS.TSPARMCD.STYPE" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="200">
+                <def:Origin Type="Protocol" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.TS.TSPARMCD.TBLIND" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="200">
+                <def:Origin Type="Protocol" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.TS.TSPARMCD.THERAREA" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="200">
+                <def:Origin Type="Protocol" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.TS.TSPARMCD.TINDTP" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="200">
+                <def:Origin Type="Protocol" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.TS.TSPARMCD.TITLE" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="200">
+                <def:Origin Type="Protocol" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.TS.TSPARMCD.TPHASE" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="200">
+                <def:Origin Type="Protocol" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.TS.TSPARMCD.TRT" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="200">
+                <def:Origin Type="Protocol" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.TS.TSPARMCD.TTYPE" Name="TSPARMCD" DataType="text" SASFieldName="TSPARMCD" Length="200">
+                <def:Origin Type="Protocol" Source="Sponsor"/>
+            </ItemDef>
+            <ItemDef OID="IT.TA.STUDYID" Name="STUDYID" DataType="text" SASFieldName="STUDYID" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Study Identifier</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.TA.DOMAIN" Name="DOMAIN" DataType="text" SASFieldName="DOMAIN" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.TA.ARMCD" Name="ARMCD" DataType="text" SASFieldName="ARMCD" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Planned Arm Code</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.ARMCD"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.TA.ARM" Name="ARM" DataType="text" SASFieldName="ARM" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Description of Planned Arm</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.ARM"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.TA.TAETORD" Name="TAETORD" DataType="integer" SASFieldName="TAETORD"
+                     Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Planned Order of Element within Arm</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.TA.ETCD" Name="ETCD" DataType="text" SASFieldName="ETCD" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Element Code</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.ETCD"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.TA.ELEMENT" Name="ELEMENT" DataType="text" SASFieldName="ELEMENT" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Description of Element</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.ELEMENT"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.TA.TABRANCH" Name="TABRANCH" DataType="text" SASFieldName="TABRANCH"
+                     Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Branch</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.TA.TATRANS" Name="TATRANS" DataType="text" SASFieldName="TATRANS" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Transition Rule</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.TA.EPOCH" Name="EPOCH" DataType="text" SASFieldName="EPOCH" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Epoch</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.EPOCH"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.TE.STUDYID" Name="STUDYID" DataType="text" SASFieldName="STUDYID" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Study Identifier</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.TE.DOMAIN" Name="DOMAIN" DataType="text" SASFieldName="DOMAIN" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.TE.ETCD" Name="ETCD" DataType="text" SASFieldName="ETCD" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Element Code</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.ETCD"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.TE.ELEMENT" Name="ELEMENT" DataType="text" SASFieldName="ELEMENT" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Description of Element</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.ELEMENT"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.TE.TESTRL" Name="TESTRL" DataType="text" SASFieldName="TESTRL" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Rule for Start of Element</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.TI.STUDYID" Name="STUDYID" DataType="text" SASFieldName="STUDYID" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Study Identifier</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.TI.DOMAIN" Name="DOMAIN" DataType="text" SASFieldName="DOMAIN" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.TI.IETESTCD" Name="IETESTCD" DataType="text" SASFieldName="IETESTCD"
+                     Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Incl/Excl Criterion Short Name</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.IETESTCD"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.TI.IETEST" Name="IETEST" DataType="text" SASFieldName="IETEST" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Inclusion/Exclusion Criterion</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.IETEST"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.TI.IECAT" Name="IECAT" DataType="text" SASFieldName="IECAT" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Inclusion/Exclusion Category</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.IECAT"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.TV.STUDYID" Name="STUDYID" DataType="text" SASFieldName="STUDYID" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Study Identifier</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.TV.DOMAIN" Name="DOMAIN" DataType="text" SASFieldName="DOMAIN" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.TV.VISITNUM" Name="VISITNUM" DataType="integer" SASFieldName="VISITNUM"
+                     Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Visit Number</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.TV.VISIT" Name="VISIT" DataType="text" SASFieldName="VISIT" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Visit Name</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.TV.VISITDY" Name="VISITDY" DataType="integer" SASFieldName="VISITDY"
+                     Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Planned Study Day of Visit</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.TV.ARMCD" Name="ARMCD" DataType="text" SASFieldName="ARMCD" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Planned Arm Code</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.ARMCD"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.TV.ARM" Name="ARM" DataType="text" SASFieldName="ARM" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Description of Planned Arm</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.ARM"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.TV.TVSTRL" Name="TVSTRL" DataType="text" SASFieldName="TVSTRL" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Visit Start Rule</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.TV.TVENRL" Name="TVENRL" DataType="text" SASFieldName="TVENRL" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Visit End Rule</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.SV.STUDYID" Name="STUDYID" DataType="text" SASFieldName="STUDYID" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Study Identifier</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.SV.DOMAIN" Name="DOMAIN" DataType="text" SASFieldName="DOMAIN" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.SV.USUBJID" Name="USUBJID" DataType="text" SASFieldName="USUBJID" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.SV.VISITNUM" Name="VISITNUM" DataType="integer" SASFieldName="VISITNUM"
+                     Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Visit Number</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.SV.VISIT" Name="VISIT" DataType="text" SASFieldName="VISIT" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Visit Name</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.SV.SVPRESP" Name="SVPRESP" DataType="text" SASFieldName="SVPRESP" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Pre-specified</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.NY"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.SV.SVOCCUR" Name="SVOCCUR" DataType="text" SASFieldName="SVOCCUR" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Occurrence</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.NY"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.SV.SVCNTMOD" Name="SVCNTMOD" DataType="text" SASFieldName="SVCNTMOD"
+                     Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Contact Mode</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.CNTMODE"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.SV.SVSTDTC" Name="SVSTDTC" DataType="datetime" SASFieldName="SVSTDTC">
+                <Description>
+                    <TranslatedText xml:lang="en">Start Date/Time of Observation</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.SV.SVENDTC" Name="SVENDTC" DataType="datetime" SASFieldName="SVENDTC">
+                <Description>
+                    <TranslatedText xml:lang="en">End Date/Time of Observation</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.IE.STUDYID" Name="STUDYID" DataType="text" SASFieldName="STUDYID" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Study Identifier</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.IE.DOMAIN" Name="DOMAIN" DataType="text" SASFieldName="DOMAIN" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.IE.USUBJID" Name="USUBJID" DataType="text" SASFieldName="USUBJID" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.IE.IESEQ" Name="IESEQ" DataType="integer" SASFieldName="IESEQ" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Sequence Number</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.IE.IETESTCD" Name="IETESTCD" DataType="text" SASFieldName="IETESTCD"
+                     Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Inclusion/Exclusion Criterion Short Name</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.IETESTCD"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.IE.IETEST" Name="IETEST" DataType="text" SASFieldName="IETEST" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Inclusion/Exclusion Criterion</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.IETEST"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.IE.IECAT" Name="IECAT" DataType="text" SASFieldName="IECAT" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Inclusion/Exclusion Category</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.IECAT"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.IE.IEORRES" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">I/E Criterion Original Result</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.NY"/>
+                <def:ValueListRef ValueListOID="VL.IE.IEORRES"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.IE.IESTRESC" Name="IESTRESC" DataType="text" SASFieldName="IESTRESC"
+                     Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">I/E Criterion Result in Std Format</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.NY"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.IE.IEORRES.IN01" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1">
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.IE.IEORRES.IN02" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1">
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.IE.IEORRES.IN03" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1">
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.IE.IEORRES.IN04" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1">
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.IE.IEORRES.IN05" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1">
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.IE.IEORRES.IN06" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1">
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.IE.IEORRES.IN07" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1">
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.IE.IEORRES.IN08" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1">
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.IE.IEORRES.EX01" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1">
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.IE.IEORRES.EX02" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1">
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.IE.IEORRES.EX03" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1">
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.IE.IEORRES.EX04" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1">
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.IE.IEORRES.EX05" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1">
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.IE.IEORRES.EX06" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1">
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.IE.IEORRES.EX07" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1">
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.IE.IEORRES.EX08" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1">
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.IE.IEORRES.EX09" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1">
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.IE.IEORRES.EX10" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1">
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.IE.IEORRES.EX11" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1">
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.IE.IEORRES.EX12" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1">
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.IE.IEORRES.EX13" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1">
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.IE.IEORRES.EX14" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1">
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.IE.IEORRES.EX15" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1">
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.IE.IEORRES.EX16" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1">
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.IE.IEORRES.EX17" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1">
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.IE.IEORRES.EX18" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1">
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.IE.IEORRES.EX19" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1">
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.IE.IEORRES.EX20" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1">
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.IE.IEORRES.EX21" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1">
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.IE.IEORRES.EX22" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1">
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.IE.IEORRES.EX23" Name="IEORRES" DataType="text" SASFieldName="IEORRES" Length="1">
+                <def:Origin Type="Collected" Source="Investigator">
+                    <def:DocumentRef leafID="LF.acrf">
+                        <def:PDFPageRef PageRefs="__PLACEHOLDER__" Type="PhysicalRef"/>
+                    </def:DocumentRef>
+                </def:Origin>
+            </ItemDef>
+            <ItemDef OID="IT.SE.STUDYID" Name="STUDYID" DataType="text" SASFieldName="STUDYID" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Study Identifier</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.SE.DOMAIN" Name="DOMAIN" DataType="text" SASFieldName="DOMAIN" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.SE.USUBJID" Name="USUBJID" DataType="text" SASFieldName="USUBJID" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.SE.SESEQ" Name="SESEQ" DataType="integer" SASFieldName="SESEQ" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Sequence Number</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.SE.ETCD" Name="ETCD" DataType="text" SASFieldName="ETCD" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Element Code</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.ETCD"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.SE.ELEMENT" Name="ELEMENT" DataType="text" SASFieldName="ELEMENT" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Description of Element</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.ELEMENT"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.SE.EPOCH" Name="EPOCH" DataType="text" SASFieldName="EPOCH" Length="__PLACEHOLDER__">
+                <Description>
+                    <TranslatedText xml:lang="en">Epoch</TranslatedText>
+                </Description>
+                <CodeListRef CodeListOID="CL.EPOCH"/>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.SE.SESTDTC" Name="SESTDTC" DataType="datetime" SASFieldName="SESTDTC">
+                <Description>
+                    <TranslatedText xml:lang="en">Start Date/Time of Element</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <ItemDef OID="IT.SE.SEENDTC" Name="SEENDTC" DataType="datetime" SASFieldName="SEENDTC">
+                <Description>
+                    <TranslatedText xml:lang="en">End Date/Time of Element</TranslatedText>
+                </Description>
+                <def:Origin Type="__PLACEHOLDER__" Source="__PLACEHOLDER__"/>
+            </ItemDef>
+            <CodeList OID="CL.ARMCD" Name="ARM Code" DataType="text" def:IsNonStandard="Yes">
+                <EnumeratedItem CodedValue="Placebo"/>
+                <EnumeratedItem CodedValue="Xanomeline Low Dose"/>
+                <EnumeratedItem CodedValue="Xanomeline High Dose"/>
+            </CodeList>
+            <CodeList OID="CL.ARM" Name="ARM" DataType="text" def:IsNonStandard="Yes">
+                <EnumeratedItem CodedValue="Placebo"/>
+                <EnumeratedItem CodedValue="Xanomeline Low Dose"/>
+                <EnumeratedItem CodedValue="Xanomeline High Dose"/>
+            </CodeList>
+            <CodeList OID="CL.IETEST" Name="Inclusion/Exclusion Test Name" DataType="text" def:IsNonStandard="Yes">
+                <EnumeratedItem CodedValue="Age greater than 50"/>
+                <EnumeratedItem CodedValue="Diagnosis of Alzheimer's"/>
+                <EnumeratedItem CodedValue="MMSE Score"/>
+                <EnumeratedItem CodedValue="Hachinski Ischemic Score"/>
+                <EnumeratedItem CodedValue="CNS imaging comptaible with Alzheimer's"/>
+                <EnumeratedItem CodedValue="Informed consent criteria"/>
+                <EnumeratedItem CodedValue="Geographic proximity criteria"/>
+                <EnumeratedItem CodedValue="Reliable caregiver criteria"/>
+                <EnumeratedItem CodedValue="Previous study criteria"/>
+                <EnumeratedItem CodedValue="Other Alzheimer's therapy criteria"/>
+                <EnumeratedItem CodedValue="Serious illness criteria"/>
+                <EnumeratedItem CodedValue="Serious neurolocal conditions criteria"/>
+                <EnumeratedItem CodedValue="Depression criteria"/>
+                <EnumeratedItem CodedValue="Schizophrenia, Bipolar, Ethanol or psychoactive abuse criteria"/>
+                <EnumeratedItem CodedValue="Syncope criteria"/>
+                <EnumeratedItem CodedValue="ECG Criteria"/>
+                <EnumeratedItem CodedValue="Cardiovascular criteria"/>
+                <EnumeratedItem CodedValue="Gastrointensinal criteria"/>
+                <EnumeratedItem CodedValue="Endocrine criteria"/>
+                <EnumeratedItem CodedValue="Resporatory criteria"/>
+                <EnumeratedItem CodedValue="Genitourinary criteria"/>
+                <EnumeratedItem CodedValue="Rheumatologic criteria"/>
+                <EnumeratedItem CodedValue="HIV criteria"/>
+                <EnumeratedItem CodedValue="Neurosyphilis, Meningitis,Encephalitis criteria"/>
+                <EnumeratedItem CodedValue="Malignant disease criteria"/>
+                <EnumeratedItem CodedValue="Ability to participate in study criteria"/>
+                <EnumeratedItem CodedValue="Laboratory values criteria"/>
+                <EnumeratedItem CodedValue="Central laboratory values criteria"/>
+                <EnumeratedItem CodedValue="Syphilia criteria"/>
+                <EnumeratedItem CodedValue="Hemoglobin criteria"/>
+                <EnumeratedItem CodedValue="Medications Criteria"/>
+            </CodeList>
+            <CodeList OID="CL.IETESTCD" Name="Inclusion/Exclusion Test Code" DataType="text" def:IsNonStandard="Yes">
+                <CodeListItem CodedValue="IN01">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Age greater than 50</TranslatedText>
+                    </Decode>
+                </CodeListItem>
+                <CodeListItem CodedValue="IN02">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Diagnosis of Alzheimer's</TranslatedText>
+                    </Decode>
+                </CodeListItem>
+                <CodeListItem CodedValue="IN03">
+                    <Decode>
+                        <TranslatedText xml:lang="en">MMSE Score</TranslatedText>
+                    </Decode>
+                </CodeListItem>
+                <CodeListItem CodedValue="IN04">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Hachinski Ischemic Score</TranslatedText>
+                    </Decode>
+                </CodeListItem>
+                <CodeListItem CodedValue="IN05">
+                    <Decode>
+                        <TranslatedText xml:lang="en">CNS imaging comptaible with Alzheimer's</TranslatedText>
+                    </Decode>
+                </CodeListItem>
+                <CodeListItem CodedValue="IN06">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Informed consent criteria</TranslatedText>
+                    </Decode>
+                </CodeListItem>
+                <CodeListItem CodedValue="IN07">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Geographic proximity criteria</TranslatedText>
+                    </Decode>
+                </CodeListItem>
+                <CodeListItem CodedValue="IN08">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Reliable caregiver criteria</TranslatedText>
+                    </Decode>
+                </CodeListItem>
+                <CodeListItem CodedValue="EX01">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Previous study criteria</TranslatedText>
+                    </Decode>
+                </CodeListItem>
+                <CodeListItem CodedValue="EX02">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Other Alzheimer's therapy criteria</TranslatedText>
+                    </Decode>
+                </CodeListItem>
+                <CodeListItem CodedValue="EX03">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Serious illness criteria</TranslatedText>
+                    </Decode>
+                </CodeListItem>
+                <CodeListItem CodedValue="EX04">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Serious neurolocal conditions criteria</TranslatedText>
+                    </Decode>
+                </CodeListItem>
+                <CodeListItem CodedValue="EX05">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Depression criteria</TranslatedText>
+                    </Decode>
+                </CodeListItem>
+                <CodeListItem CodedValue="EX06">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Schizophrenia, Bipolar, Ethanol or psychoactive abuse criteria
+                        </TranslatedText>
+                    </Decode>
+                </CodeListItem>
+                <CodeListItem CodedValue="EX07">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Syncope criteria</TranslatedText>
+                    </Decode>
+                </CodeListItem>
+                <CodeListItem CodedValue="EX08">
+                    <Decode>
+                        <TranslatedText xml:lang="en">ECG Criteria</TranslatedText>
+                    </Decode>
+                </CodeListItem>
+                <CodeListItem CodedValue="EX09">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Cardiovascular criteria</TranslatedText>
+                    </Decode>
+                </CodeListItem>
+                <CodeListItem CodedValue="EX10">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Gastrointensinal criteria</TranslatedText>
+                    </Decode>
+                </CodeListItem>
+                <CodeListItem CodedValue="EX11">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Endocrine criteria</TranslatedText>
+                    </Decode>
+                </CodeListItem>
+                <CodeListItem CodedValue="EX12">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Resporatory criteria</TranslatedText>
+                    </Decode>
+                </CodeListItem>
+                <CodeListItem CodedValue="EX13">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Genitourinary criteria</TranslatedText>
+                    </Decode>
+                </CodeListItem>
+                <CodeListItem CodedValue="EX14">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Rheumatologic criteria</TranslatedText>
+                    </Decode>
+                </CodeListItem>
+                <CodeListItem CodedValue="EX15">
+                    <Decode>
+                        <TranslatedText xml:lang="en">HIV criteria</TranslatedText>
+                    </Decode>
+                </CodeListItem>
+                <CodeListItem CodedValue="EX16">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Neurosyphilis, Meningitis,Encephalitis criteria</TranslatedText>
+                    </Decode>
+                </CodeListItem>
+                <CodeListItem CodedValue="EX17">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Malignant disease criteria</TranslatedText>
+                    </Decode>
+                </CodeListItem>
+                <CodeListItem CodedValue="EX18">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Ability to participate in study criteria</TranslatedText>
+                    </Decode>
+                </CodeListItem>
+                <CodeListItem CodedValue="EX19">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Laboratory values criteria</TranslatedText>
+                    </Decode>
+                </CodeListItem>
+                <CodeListItem CodedValue="EX20">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Central laboratory values criteria</TranslatedText>
+                    </Decode>
+                </CodeListItem>
+                <CodeListItem CodedValue="EX21">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Syphilia criteria</TranslatedText>
+                    </Decode>
+                </CodeListItem>
+                <CodeListItem CodedValue="EX22">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Hemoglobin criteria</TranslatedText>
+                    </Decode>
+                </CodeListItem>
+                <CodeListItem CodedValue="EX23">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Medications Criteria</TranslatedText>
+                    </Decode>
+                </CodeListItem>
+            </CodeList>
+            <CodeList OID="CL.ELEMENT" Name="Description of Element" DataType="text" def:IsNonStandard="Yes">
+                <EnumeratedItem CodedValue="Screening"/>
+                <EnumeratedItem CodedValue="Placebo"/>
+                <EnumeratedItem CodedValue="Follow up"/>
+                <EnumeratedItem CodedValue="Low"/>
+                <EnumeratedItem CodedValue="High - Start"/>
+                <EnumeratedItem CodedValue="High - Middle"/>
+                <EnumeratedItem CodedValue="High - End"/>
+            </CodeList>
+            <CodeList OID="CL.ETCD" Name="Element Code" DataType="text" def:IsNonStandard="Yes">
+                <CodeListItem CodedValue="EL1">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Screening</TranslatedText>
+                    </Decode>
+                </CodeListItem>
+                <CodeListItem CodedValue="EL2">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Placebo</TranslatedText>
+                    </Decode>
+                </CodeListItem>
+                <CodeListItem CodedValue="EL7">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Follow up</TranslatedText>
+                    </Decode>
+                </CodeListItem>
+                <CodeListItem CodedValue="EL3">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Low</TranslatedText>
+                    </Decode>
+                </CodeListItem>
+                <CodeListItem CodedValue="EL4">
+                    <Decode>
+                        <TranslatedText xml:lang="en">High - Start</TranslatedText>
+                    </Decode>
+                </CodeListItem>
+                <CodeListItem CodedValue="EL5">
+                    <Decode>
+                        <TranslatedText xml:lang="en">High - Middle</TranslatedText>
+                    </Decode>
+                </CodeListItem>
+                <CodeListItem CodedValue="EL6">
+                    <Decode>
+                        <TranslatedText xml:lang="en">High - End</TranslatedText>
+                    </Decode>
+                </CodeListItem>
+            </CodeList>
+            <CodeList OID="CL.EPOCH" Name="Epoch" DataType="text" def:StandardOID="STD.SDTMCT">
+                <EnumeratedItem CodedValue="Screening">
+                    <Alias Context="nci:ExtCodeID" Name="C202487"/>
+                </EnumeratedItem>
+                <EnumeratedItem CodedValue="Treatment 1">
+                    <Alias Context="nci:ExtCodeID" Name="C101526"/>
+                </EnumeratedItem>
+                <EnumeratedItem CodedValue="Treatment 2">
+                    <Alias Context="nci:ExtCodeID" Name="C101526"/>
+                </EnumeratedItem>
+                <EnumeratedItem CodedValue="Treatment 3">
+                    <Alias Context="nci:ExtCodeID" Name="C101526"/>
+                </EnumeratedItem>
+                <EnumeratedItem CodedValue="Follow-Up">
+                    <Alias Context="nci:ExtCodeID" Name="C202578"/>
+                </EnumeratedItem>
+                <Alias Context="nci:ExtCodeID" Name="C99079"/>
+            </CodeList>
+            <CodeList OID="CL.NCOMPLT" Name="Completion/Reason for Non-Completion" DataType="text"
+                      def:StandardOID="STD.SDTMCT">
+                <CodeListItem CodedValue="__PLACEHOLDER__">
+                    <Decode>
+                        <TranslatedText xml:lang="en">__PLACEHOLDER__</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="__PLACEHOLDER__"/>
+                </CodeListItem>
+                <Alias Context="nci:ExtCodeID" Name="C66727"/>
+            </CodeList>
+            <CodeList OID="CL.DSCAT" Name="Category of Disposition Event" DataType="text" def:StandardOID="STD.SDTMCT">
+                <CodeListItem CodedValue="__PLACEHOLDER__">
+                    <Decode>
+                        <TranslatedText xml:lang="en">__PLACEHOLDER__</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="__PLACEHOLDER__"/>
+                </CodeListItem>
+                <Alias Context="nci:ExtCodeID" Name="C74558"/>
+            </CodeList>
+            <CodeList OID="CL.DSSCAT" Name="Subcategory for Disposition Event" DataType="text"
+                      def:StandardOID="STD.SDTMCT">
+                <CodeListItem CodedValue="__PLACEHOLDER__">
+                    <Decode>
+                        <TranslatedText xml:lang="en">__PLACEHOLDER__</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="__PLACEHOLDER__"/>
+                </CodeListItem>
+                <Alias Context="nci:ExtCodeID" Name="C170443"/>
+            </CodeList>
+            <CodeList OID="CL.NY" Name="No Yes Response" DataType="text" def:StandardOID="STD.SDTMCT">
+                <CodeListItem CodedValue="N">
+                    <Decode>
+                        <TranslatedText xml:lang="en">No</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C49487"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Y">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Yes</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C49488"/>
+                </CodeListItem>
+                <Alias Context="nci:ExtCodeID" Name="C66742"/>
+            </CodeList>
+            <CodeList OID="CL.AGEU" Name="Age Unit" DataType="text" def:StandardOID="STD.SDTMCT">
+                <CodeListItem CodedValue="__PLACEHOLDER__">
+                    <Decode>
+                        <TranslatedText xml:lang="en">__PLACEHOLDER__</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="__PLACEHOLDER__"/>
+                </CodeListItem>
+                <Alias Context="nci:ExtCodeID" Name="C66781"/>
+            </CodeList>
+            <CodeList OID="CL.SEX" Name="Sex" DataType="text" def:StandardOID="STD.SDTMCT">
+                <CodeListItem CodedValue="F">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Female</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C16576"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="M">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Male</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C20197"/>
+                </CodeListItem>
+                <Alias Context="nci:ExtCodeID" Name="C66731"/>
+            </CodeList>
+            <CodeList OID="CL.RACE" Name="Race" DataType="text" def:StandardOID="STD.SDTMCT">
+                <CodeListItem CodedValue="__PLACEHOLDER__">
+                    <Decode>
+                        <TranslatedText xml:lang="en">__PLACEHOLDER__</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="__PLACEHOLDER__"/>
+                </CodeListItem>
+                <Alias Context="nci:ExtCodeID" Name="C74457"/>
+            </CodeList>
+            <CodeList OID="CL.ETHNIC" Name="Ethnic Group" DataType="text" def:StandardOID="STD.SDTMCT">
+                <CodeListItem CodedValue="__PLACEHOLDER__">
+                    <Decode>
+                        <TranslatedText xml:lang="en">__PLACEHOLDER__</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="__PLACEHOLDER__"/>
+                </CodeListItem>
+                <Alias Context="nci:ExtCodeID" Name="C66790"/>
+            </CodeList>
+            <CodeList OID="CL.ARMNULRS" Name="Arm Null Reason" DataType="text" def:StandardOID="STD.SDTMCT">
+                <CodeListItem CodedValue="__PLACEHOLDER__">
+                    <Decode>
+                        <TranslatedText xml:lang="en">__PLACEHOLDER__</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="__PLACEHOLDER__"/>
+                </CodeListItem>
+                <Alias Context="nci:ExtCodeID" Name="C142179"/>
+            </CodeList>
+            <CodeList OID="CL.SCTESTCD" Name="Subject Characteristic Test Code" DataType="text"
+                      def:StandardOID="STD.SDTMCT">
+                <CodeListItem CodedValue="EDULEVEL">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Level of Education Attained</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C17953"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="EDUYRNUM">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Number of Years of Education</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C122393"/>
+                </CodeListItem>
+                <Alias Context="nci:ExtCodeID" Name="C74559"/>
+            </CodeList>
+            <CodeList OID="CL.SCTEST" Name="Subject Characteristic Test Name" DataType="text"
+                      def:StandardOID="STD.SDTMCT">
+                <CodeListItem CodedValue="Level of Education Attained">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Level of Education Attained</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C17953"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Number of Years of Education">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Number of Years of Education</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C122393"/>
+                </CodeListItem>
+                <Alias Context="nci:ExtCodeID" Name="C103330"/>
+            </CodeList>
+            <CodeList OID="CL.UNIT" Name="Unit" DataType="text" def:StandardOID="STD.SDTMCT">
+                <CodeListItem CodedValue="%">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Percentage</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C25613"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="10^12/L">
+                    <Decode>
+                        <TranslatedText xml:lang="en">/pL</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C67308"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="10^6/L">
+                    <Decode>
+                        <TranslatedText xml:lang="en">/mm3</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C67452"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="10^9/L">
+                    <Decode>
+                        <TranslatedText xml:lang="en">/nL</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C67255"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="CIGAR">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Cigar Dosing Unit</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C116244"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="CIGARETTE">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Cigarette Dosing Unit</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C116245"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="DRINK">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Drink Dosing Unit</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C161487"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="EU">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Ehrlich Units</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C96599"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="fmol">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Femtomole</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C68854"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="fraction of 1">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Proportion of 1</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C105484"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="g">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Gram</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C48155"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="g/dL">
+                    <Decode>
+                        <TranslatedText xml:lang="en">g%</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64783"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="g/L">
+                    <Decode>
+                        <TranslatedText xml:lang="en">g/L</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C42576"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="GLASS">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Glass Dosing Unit</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C198391"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="IU/L">
+                    <Decode>
+                        <TranslatedText xml:lang="en">IE/L</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C67376"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="kg/m2">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Kilogram per Square Meter</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C49671"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="L">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Liter</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C48505"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="mEq/dL">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Milliequivalent per Deciliter</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C67473"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="mEq/L">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Milliequivalent Per Liter</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C67474"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="mg">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Milligram</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C28253"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="mg/dL">
+                    <Decode>
+                        <TranslatedText xml:lang="en">mg%</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C67015"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="mg/L">
+                    <Decode>
+                        <TranslatedText xml:lang="en">g/m3</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64572"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="mIU/L">
+                    <Decode>
+                        <TranslatedText xml:lang="en">mcIU/mL</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C67405"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="mL">
+                    <Decode>
+                        <TranslatedText xml:lang="en">cc</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C28254"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="mmol/L">
+                    <Decode>
+                        <TranslatedText xml:lang="en">mcmol/mL</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64387"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="ms">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Millisecond</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C41140"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="mU/L">
+                    <Decode>
+                        <TranslatedText xml:lang="en">uU/mL</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C67408"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="ng/dL">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Nanogram per Deciliter</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C67326"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="ng/L">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Microgram per Cubic Meter</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C67327"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="nkat/L">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Nanokatal per Liter</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C70510"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="nmol/L">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Nanomole per Liter</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C67432"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="oz">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Ounce</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C48519"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="PACK">
+                    <Decode>
+                        <TranslatedText xml:lang="en">PACK</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C62653"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="pg">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Picogram</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64551"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="PIPE">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Pipe Dosing Unit</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C116246"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="pmol/L">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Femtomole per Milliliter</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C67434"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="psi">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Pounds per Square Inch</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C67334"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="s">
+                    <Decode>
+                        <TranslatedText xml:lang="en">sec</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C42535"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="U/L">
+                    <Decode>
+                        <TranslatedText xml:lang="en">mU/mL</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C67456"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="ug/dL">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Microgram per Deciliter</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C67305"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="ug/L">
+                    <Decode>
+                        <TranslatedText xml:lang="en">mcg/L</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C67306"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="ukat/L">
+                    <Decode>
+                        <TranslatedText xml:lang="en">mckat/L</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C67397"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="umol/L">
+                    <Decode>
+                        <TranslatedText xml:lang="en">nmol/mL</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C48508"/>
+                </CodeListItem>
+                <Alias Context="nci:ExtCodeID" Name="C71620"/>
+            </CodeList>
+            <CodeList OID="CL.STENRF" Name="Relation to Reference Period" DataType="text" def:StandardOID="STD.SDTMCT">
+                <CodeListItem CodedValue="__PLACEHOLDER__">
+                    <Decode>
+                        <TranslatedText xml:lang="en">__PLACEHOLDER__</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="__PLACEHOLDER__"/>
+                </CodeListItem>
+                <Alias Context="nci:ExtCodeID" Name="C66728"/>
+            </CodeList>
+            <CodeList OID="CL.FREQ" Name="Frequency" DataType="text" def:StandardOID="STD.SDTMCT">
+                <CodeListItem CodedValue="Q7D">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Every 7 Days</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C139177"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="QD">
+                    <Decode>
+                        <TranslatedText xml:lang="en">/day</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C25473"/>
+                </CodeListItem>
+                <Alias Context="nci:ExtCodeID" Name="C71113"/>
+            </CodeList>
+            <CodeList OID="CL.PROCEDUR" Name="Procedure" DataType="text" def:StandardOID="STD.SDTMCT">
+                <CodeListItem CodedValue="__PLACEHOLDER__">
+                    <Decode>
+                        <TranslatedText xml:lang="en">__PLACEHOLDER__</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="__PLACEHOLDER__"/>
+                </CodeListItem>
+                <Alias Context="nci:ExtCodeID" Name="C101858"/>
+            </CodeList>
+            <CodeList OID="CL.LOC" Name="Anatomical Location" DataType="text" def:StandardOID="STD.SDTMCT">
+                <CodeListItem CodedValue="ARM">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Arm</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C32141"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="AXILLA">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Armpit</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C12674"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="BACK">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Back</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C13062"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="BRACHIAL ARTERY">
+                    <Decode>
+                        <TranslatedText xml:lang="en">BRACHIAL ARTERY</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C12681"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="BUTTOCK">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Buttock</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C89806"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="CAROTID ARTERY">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Common Carotid Artery</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C12687"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="CEREBRAL ARTERY">
+                    <Decode>
+                        <TranslatedText xml:lang="en">CEREBRAL ARTERY</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C12691"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="CHEST">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Chest</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C25389"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="DORSALIS PEDIS ARTERY">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Dorsal Pedal Artery</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C32478"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="EAR">
+                    <Decode>
+                        <TranslatedText xml:lang="en">EAR</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C12394"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="FEMORAL ARTERY">
+                    <Decode>
+                        <TranslatedText xml:lang="en">FEMORAL ARTERY</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C12715"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="FINGER">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Finger</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C32608"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="FOREHEAD">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Forehead</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C89803"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="ORAL CAVITY">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Buccal cavity</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C12421"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="RADIAL ARTERY">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Radial Artery</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C12838"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="RECTUM">
+                    <Decode>
+                        <TranslatedText xml:lang="en">RECTUM</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C12390"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="THIGH">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Thigh</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C33763"/>
+                </CodeListItem>
+                <Alias Context="nci:ExtCodeID" Name="C74456"/>
+            </CodeList>
+            <CodeList OID="CL.VSTESTCD" Name="Vital Signs Test Code" DataType="text" def:StandardOID="STD.SDTMCT">
+                <CodeListItem CodedValue="BMI">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Body Mass Index</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C16358"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="DIABP">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Diastolic Blood Pressure</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C25299"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="HEIGHT">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Height</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C25347"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="HR">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Heart Rate</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C49677"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="PULSE">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Pulse Rate</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C49676"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="RESP">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Respiratory Rate</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C49678"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="SYSBP">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Systolic Blood Pressure</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C25298"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="TEMP">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Body Temperature</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C174446"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="WEIGHT">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Weight</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C25208"/>
+                </CodeListItem>
+                <Alias Context="nci:ExtCodeID" Name="C66741"/>
+            </CodeList>
+            <CodeList OID="CL.VSTEST" Name="Vital Signs Test Name" DataType="text" def:StandardOID="STD.SDTMCT">
+                <CodeListItem CodedValue="Body Mass Index">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Body Mass Index</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C16358"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Diastolic Blood Pressure">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Diastolic Blood Pressure</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C25299"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Heart Rate">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Heart Rate</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C49677"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Height">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Height</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C25347"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Pulse Rate">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Pulse Rate</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C49676"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Respiratory Rate">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Respiratory Rate</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C49678"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Systolic Blood Pressure">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Systolic Blood Pressure</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C25298"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Temperature">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Body Temperature</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C174446"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Weight">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Weight</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C25208"/>
+                </CodeListItem>
+                <Alias Context="nci:ExtCodeID" Name="C67153"/>
+            </CodeList>
+            <CodeList OID="CL.POSITION" Name="Position" DataType="text" def:StandardOID="STD.SDTMCT">
+                <CodeListItem CodedValue="PRONE">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Prone</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C62165"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="SEMI-RECUMBENT">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Semi-Supine</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C111310"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="SITTING">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Sitting</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C62122"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="STANDING">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Orthostatic</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C62166"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="SUPINE">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Supine</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C62167"/>
+                </CodeListItem>
+                <Alias Context="nci:ExtCodeID" Name="C71148"/>
+            </CodeList>
+            <CodeList OID="CL.VSRESU" Name="Units for Vital Signs Results" DataType="text" def:StandardOID="STD.SDTMCT">
+                <CodeListItem CodedValue="C">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Degree Celsius</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C42559"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="cm">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Centimeter</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C49668"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="F">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Degree Fahrenheit</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C44277"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="g">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Gram</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C48155"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="in">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Inch</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C48500"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="K">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Kelvin</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C42537"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="kg">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Kilogram</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C28252"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="LB">
+                    <Decode>
+                        <TranslatedText xml:lang="en">lb</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C48531"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="m">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Meter</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C41139"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="kg/m2">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Kilogram per Square Meter</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C49671"/>
+                </CodeListItem>
+                <Alias Context="nci:ExtCodeID" Name="C66770"/>
+            </CodeList>
+            <CodeList OID="CL.LAT" Name="Laterality" DataType="text" def:StandardOID="STD.SDTMCT">
+                <CodeListItem CodedValue="LEFT">
+                    <Decode>
+                        <TranslatedText xml:lang="en">LEFT</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C25229"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="RIGHT">
+                    <Decode>
+                        <TranslatedText xml:lang="en">RIGHT</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C25228"/>
+                </CodeListItem>
+                <Alias Context="nci:ExtCodeID" Name="C99073"/>
+            </CodeList>
+            <CodeList OID="CL.EGTESTCD" Name="ECG Test Code" DataType="text" def:StandardOID="STD.SDTMCT">
+                <CodeListItem CodedValue="AVCOND">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Atrioventricular Conduction</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C111131"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="AXISVOLT">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Axis and Voltage</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C111132"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="CHYPTENL">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Chamber Hypertrophy or Enlargement</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C111155"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="EGHRMN">
+                    <Decode>
+                        <TranslatedText xml:lang="en">ECG Mean Heart Rate</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C119259"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="INTP">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Interpretation</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C41255"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="IVTIACD">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Intraventricular-Intraatrial Conduction</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C111238"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="PACEMAKR">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Pacemaker</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C111285"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="PRAG">
+                    <Decode>
+                        <TranslatedText xml:lang="en">PQ Interval, Aggregate</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C117773"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="QRS_AXIS">
+                    <Decode>
+                        <TranslatedText xml:lang="en">QRS Axis</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C118165"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="QRSAG">
+                    <Decode>
+                        <TranslatedText xml:lang="en">QRS Duration, Aggregate</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C117779"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="QTAG">
+                    <Decode>
+                        <TranslatedText xml:lang="en">QT Interval, Aggregate</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C117783"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="QTCBAG">
+                    <Decode>
+                        <TranslatedText xml:lang="en">QTcB Interval, Aggregate</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C117784"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="QTCFAG">
+                    <Decode>
+                        <TranslatedText xml:lang="en">QTcF Interval, Aggregate</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C117786"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="RHYNOS">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Rhythm Not Otherwise Specified</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C111307"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="RRAG">
+                    <Decode>
+                        <TranslatedText xml:lang="en">RR Interval, Aggregate</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C117791"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="SNRARRY">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Sinus Node Rhythms and Arrhythmias</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C111312"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="SPRARRY">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Supraventricular Arrhythmias</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C111320"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="SPRTARRY">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Supraventricular Tachyarrhythmias</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C111321"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="TECHQUAL">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Technical Quality</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C117807"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="VTARRY">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Ventricular Arrhythmias</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C111330"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="VTTARRY">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Ventricular Tachyarrhythmias</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C111331"/>
+                </CodeListItem>
+                <Alias Context="nci:ExtCodeID" Name="C71153"/>
+            </CodeList>
+            <CodeList OID="CL.EGTEST" Name="ECG Test Name" DataType="text" def:StandardOID="STD.SDTMCT">
+                <CodeListItem CodedValue="Atrioventricular Conduction">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Atrioventricular Conduction</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C111131"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Axis and Voltage">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Axis and Voltage</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C111132"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Chamber Hypertrophy or Enlargement">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Chamber Hypertrophy or Enlargement</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C111155"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="ECG Mean Heart Rate">
+                    <Decode>
+                        <TranslatedText xml:lang="en">ECG Mean Heart Rate</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C119259"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Interpretation">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Interpretation</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C41255"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Intraventricular-Intraatrial Conduction">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Intraventricular-Intraatrial Conduction</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C111238"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Pacemaker">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Pacemaker</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C111285"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="PR Interval, Aggregate">
+                    <Decode>
+                        <TranslatedText xml:lang="en">PQ Interval, Aggregate</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C117773"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="QRS Axis">
+                    <Decode>
+                        <TranslatedText xml:lang="en">QRS Axis</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C118165"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="QRS Duration, Aggregate">
+                    <Decode>
+                        <TranslatedText xml:lang="en">QRS Duration, Aggregate</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C117779"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="QT Interval, Aggregate">
+                    <Decode>
+                        <TranslatedText xml:lang="en">QT Interval, Aggregate</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C117783"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="QTcB Interval, Aggregate">
+                    <Decode>
+                        <TranslatedText xml:lang="en">QTcB Interval, Aggregate</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C117784"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="QTcF Interval, Aggregate">
+                    <Decode>
+                        <TranslatedText xml:lang="en">QTcF Interval, Aggregate</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C117786"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Rhythm Not Otherwise Specified">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Rhythm Not Otherwise Specified</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C111307"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="RR Interval, Aggregate">
+                    <Decode>
+                        <TranslatedText xml:lang="en">RR Interval, Aggregate</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C117791"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Sinus Node Rhythms and Arrhythmias">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Sinus Node Rhythms and Arrhythmias</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C111312"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Supraventricular Arrhythmias">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Supraventricular Arrhythmias</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C111320"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Supraventricular Tachyarrhythmias">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Supraventricular Tachyarrhythmias</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C111321"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Technical Quality">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Technical Quality</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C117807"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Ventricular Arrhythmias">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Ventricular Arrhythmias</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C111330"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Ventricular Tachyarrhythmias">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Ventricular Tachyarrhythmias</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C111331"/>
+                </CodeListItem>
+                <Alias Context="nci:ExtCodeID" Name="C71152"/>
+            </CodeList>
+            <CodeList OID="CL.EGSTRESC" Name="ECG Result" DataType="text" def:StandardOID="STD.SDTMCT">
+                <CodeListItem CodedValue="__PLACEHOLDER__">
+                    <Decode>
+                        <TranslatedText xml:lang="en">__PLACEHOLDER__</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="__PLACEHOLDER__"/>
+                </CodeListItem>
+                <Alias Context="nci:ExtCodeID" Name="C71150"/>
+            </CodeList>
+            <CodeList OID="CL.EGMETHOD" Name="ECG Test Method" DataType="text" def:StandardOID="STD.SDTMCT">
+                <CodeListItem CodedValue="__PLACEHOLDER__">
+                    <Decode>
+                        <TranslatedText xml:lang="en">__PLACEHOLDER__</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="__PLACEHOLDER__"/>
+                </CodeListItem>
+                <Alias Context="nci:ExtCodeID" Name="C71151"/>
+            </CodeList>
+            <CodeList OID="CL.EVAL" Name="Evaluator" DataType="text" def:StandardOID="STD.SDTMCT">
+                <CodeListItem CodedValue="ADJUDICATION COMMITTEE">
+                    <Decode>
+                        <TranslatedText xml:lang="en">ADJUDICATION COMMITTEE</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C78726"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="INDEPENDENT ASSESSOR">
+                    <Decode>
+                        <TranslatedText xml:lang="en">INDEPENDENT ASSESSOR</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C78720"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="INVESTIGATOR">
+                    <Decode>
+                        <TranslatedText xml:lang="en">INVESTIGATOR</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C25936"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="VENDOR">
+                    <Decode>
+                        <TranslatedText xml:lang="en">VENDOR</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C68608"/>
+                </CodeListItem>
+                <Alias Context="nci:ExtCodeID" Name="C78735"/>
+            </CodeList>
+            <CodeList OID="CL.FRM" Name="Dosage Form" DataType="text" def:StandardOID="STD.SDTMCT">
+                <CodeListItem CodedValue="__PLACEHOLDER__">
+                    <Decode>
+                        <TranslatedText xml:lang="en">__PLACEHOLDER__</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="__PLACEHOLDER__"/>
+                </CodeListItem>
+                <Alias Context="nci:ExtCodeID" Name="C66726"/>
+            </CodeList>
+            <CodeList OID="CL.ROUTE" Name="Route of Administration Response" DataType="text"
+                      def:StandardOID="STD.SDTMCT">
+                <CodeListItem CodedValue="__PLACEHOLDER__">
+                    <Decode>
+                        <TranslatedText xml:lang="en">__PLACEHOLDER__</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="__PLACEHOLDER__"/>
+                </CodeListItem>
+                <Alias Context="nci:ExtCodeID" Name="C66729"/>
+            </CodeList>
+            <CodeList OID="CL.LBTESTCD" Name="Laboratory Test Code" DataType="text" def:StandardOID="STD.SDTMCT">
+                <CodeListItem CodedValue="ALB">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Albumin</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64431"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="ALP">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Alkaline Phosphatase</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64432"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="ALT">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Alanine Aminotransferase</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64433"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="ANISO">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Anisocytes</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C74797"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="AST">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Aspartate Aminotransferase</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64467"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="BASO">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Basophils</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64470"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="BICARB">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Bicarbonate</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C74667"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="BILI">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Bilirubin</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C38037"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="CA">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Calcium</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64488"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="CHOL">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Cholesterol</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C105586"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="CL">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Chloride</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64495"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="COLOR">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Color</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64546"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="CREAT">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Creatinine</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64547"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="EOS">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Eosinophils</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64550"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="GGT">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Gamma Glutamyl Transferase</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64847"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="GLUC">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Glucose</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C105585"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="HBA1C">
+                    <Decode>
+                        <TranslatedText xml:lang="en">HbA1c</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64849"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="HBA1CHGB">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Hemoglobin A1C/Hemoglobin</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C111207"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="HCT">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Erythrocyte Volume Fraction</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64796"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="HGB">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Hemoglobin</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64848"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="K">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Potassium</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64853"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="KETONES">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Ketones</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64854"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="MACROCY">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Macrocytes</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64821"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="MCH">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Ery. Mean Corpuscular Hemoglobin</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64797"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="MCHC">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Ery. Mean Corpuscular HGB Concentration</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64798"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="MCV">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Ery. Mean Corpuscular Volume</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64799"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="MICROCY">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Microcytes</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64822"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="MONO">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Monocytes</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64823"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="NEUT">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Neutrophils</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C63321"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="NEUTB">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Neutrophils Band Form</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64830"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="NEUTSG">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Neutrophils, Segmented</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C81997"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="NITRITE">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Nitrite</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64810"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="OCCBLD">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Occult Blood</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C74686"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="PHOS">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Inorganic Phosphate</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64857"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="PLAT">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Platelets</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C51951"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="POIKILO">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Poikilocytes</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C79602"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="POLYCHR">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Polychromasia</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64803"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="PROT">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Protein</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64858"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="RBC">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Erythrocytes</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C51946"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="SODIUM">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Sodium</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64809"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="SPGRAV">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Specific Gravity</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64832"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="T3">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Total T3</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C74747"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="T3UP">
+                    <Decode>
+                        <TranslatedText xml:lang="en">T3RU</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C74748"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="T4FR">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Free T4</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C74786"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="T4FRIDX">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Thyroxine, Free Index</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C170598"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="TSH">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Thyroid Stimulating Hormone</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64813"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="URATE">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Urate</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64814"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="UREAN">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Urea Nitrogen</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C125949"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="UROBIL">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Urobilinogen</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64816"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="VITB12">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Cobalamin</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64817"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="VITB9">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Folate</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C74676"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="WBC">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Leukocytes</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C51948"/>
+                </CodeListItem>
+                <Alias Context="nci:ExtCodeID" Name="C65047"/>
+            </CodeList>
+            <CodeList OID="CL.LBTEST" Name="Laboratory Test Name" DataType="text" def:StandardOID="STD.SDTMCT">
+                <CodeListItem CodedValue="Alanine Aminotransferase">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Alanine Aminotransferase</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64433"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Albumin">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Albumin</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64431"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Alkaline Phosphatase">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Alkaline Phosphatase</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64432"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Anisocytes">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Anisocytes</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C74797"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Aspartate Aminotransferase">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Aspartate Aminotransferase</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64467"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Basophils">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Basophils</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64470"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Bicarbonate">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Bicarbonate</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C74667"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Bilirubin">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Bilirubin</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C38037"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Calcium">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Calcium</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64488"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Chloride">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Chloride</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64495"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Cholesterol">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Cholesterol</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C105586"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Color">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Color</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64546"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Creatinine">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Creatinine</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64547"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Eosinophils">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Eosinophils</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64550"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Ery. Mean Corpuscular Hemoglobin">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Ery. Mean Corpuscular Hemoglobin</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64797"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Ery. Mean Corpuscular HGB Concentration">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Ery. Mean Corpuscular HGB Concentration</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64798"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Ery. Mean Corpuscular Volume">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Ery. Mean Corpuscular Volume</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64799"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Erythrocytes">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Erythrocytes</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C51946"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Gamma Glutamyl Transferase">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Gamma Glutamyl Transferase</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64847"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Glucose">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Glucose</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C105585"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Hematocrit">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Erythrocyte Volume Fraction</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64796"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Hemoglobin A1C">
+                    <Decode>
+                        <TranslatedText xml:lang="en">HbA1c</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64849"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Hemoglobin A1C/Hemoglobin">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Hemoglobin A1C/Hemoglobin</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C111207"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Hemoglobin">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Hemoglobin</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64848"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Ketones">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Ketones</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64854"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Leukocytes">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Leukocytes</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C51948"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Macrocytes">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Macrocytes</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64821"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Microcytes">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Microcytes</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64822"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Monocytes">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Monocytes</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64823"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Neutrophils Band Form">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Neutrophils Band Form</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64830"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Neutrophils">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Neutrophils</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C63321"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Neutrophils, Segmented">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Neutrophils, Segmented</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C81997"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Nitrite">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Nitrite</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64810"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Occult Blood">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Occult Blood</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C74686"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Phosphate">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Inorganic Phosphate</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64857"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Platelets">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Platelets</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C51951"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Poikilocytes">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Poikilocytes</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C79602"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Polychromasia">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Polychromasia</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64803"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Potassium">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Potassium</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64853"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Protein">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Protein</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64858"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Sodium">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Sodium</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64809"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Specific Gravity">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Specific Gravity</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64832"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Thyrotropin">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Thyroid Stimulating Hormone</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64813"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Thyroxine, Free Index">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Thyroxine, Free Index</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C170598"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Thyroxine, Free">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Free T4</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C74786"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Triiodothyronine Uptake">
+                    <Decode>
+                        <TranslatedText xml:lang="en">T3RU</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C74748"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Triiodothyronine">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Total T3</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C74747"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Urate">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Urate</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64814"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Urea Nitrogen">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Urea Nitrogen</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C125949"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Urobilinogen">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Urobilinogen</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64816"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Vitamin B12">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Cobalamin</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C64817"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Vitamin B9">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Folate</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C74676"/>
+                </CodeListItem>
+                <Alias Context="nci:ExtCodeID" Name="C67154"/>
+            </CodeList>
+            <CodeList OID="CL.LBSTRESC" Name="Laboratory Test Standard Character Result" DataType="text"
+                      def:StandardOID="STD.SDTMCT">
+                <CodeListItem CodedValue="__PLACEHOLDER__">
+                    <Decode>
+                        <TranslatedText xml:lang="en">__PLACEHOLDER__</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="__PLACEHOLDER__"/>
+                </CodeListItem>
+                <Alias Context="nci:ExtCodeID" Name="C102580"/>
+            </CodeList>
+            <CodeList OID="CL.NRIND" Name="Reference Range Indicator" DataType="text" def:StandardOID="STD.SDTMCT">
+                <CodeListItem CodedValue="__PLACEHOLDER__">
+                    <Decode>
+                        <TranslatedText xml:lang="en">__PLACEHOLDER__</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="__PLACEHOLDER__"/>
+                </CodeListItem>
+                <Alias Context="nci:ExtCodeID" Name="C78736"/>
+            </CodeList>
+            <CodeList OID="CL.SPECTYPE" Name="Specimen Type" DataType="text" def:StandardOID="STD.SDTMCT">
+                <CodeListItem CodedValue="BLOOD">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Peripheral Blood</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C12434"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="ERYTHROCYTES">
+                    <Decode>
+                        <TranslatedText xml:lang="en">RBC</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C12521"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="SERUM OR PLASMA">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Ser/Plas</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C105706"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="STOOL">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Feces</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C13234"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="URINE SEDIMENT">
+                    <Decode>
+                        <TranslatedText xml:lang="en">URINE SEDIMENT</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C158282"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="URINE">
+                    <Decode>
+                        <TranslatedText xml:lang="en">URINE</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C13283"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="CEREBROSPINAL FLUID">
+                    <Decode>
+                        <TranslatedText xml:lang="en">CSF</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C12692"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="FLUID">
+                    <Decode>
+                        <TranslatedText xml:lang="en">FLUID</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C13236"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="SERUM">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Sera</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C13325"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="SWABBED MATERIAL">
+                    <Decode>
+                        <TranslatedText xml:lang="en">SWABBED MATERIAL</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C150895"/>
+                </CodeListItem>
+                <Alias Context="nci:ExtCodeID" Name="C78734"/>
+            </CodeList>
+            <CodeList OID="CL.METHOD" Name="Method" DataType="text" def:StandardOID="STD.SDTMCT">
+                <CodeListItem CodedValue="DIPSTICK MEASUREMENT METHOD">
+                    <Decode>
+                        <TranslatedText xml:lang="en">DIPSTICK MEASUREMENT METHOD</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C178142"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="CHEMILUMINESCENT MICROPARTICLE IMMUNOASSAY">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Chemiluminescent Magnetic Microparticle Immunoassay
+                        </TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C172557"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="FLUORESCENT IMMUNOASSAY">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Fluorescent Antibody Assay</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C17370"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="HEMAGGLUTINATION ASSAY">
+                    <Decode>
+                        <TranslatedText xml:lang="en">HEMAGGLUTINATION ASSAY</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C130173"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="IMMUNOBLOT">
+                    <Decode>
+                        <TranslatedText xml:lang="en">IMMUNOBLOT</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C17638"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="LINE PROBE ASSAY">
+                    <Decode>
+                        <TranslatedText xml:lang="en">LiPA</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C102656"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="POLYMERASE CHAIN REACTION">
+                    <Decode>
+                        <TranslatedText xml:lang="en">PCR</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C17003"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="RAPID IMMUNOASSAY">
+                    <Decode>
+                        <TranslatedText xml:lang="en">RAPID IMMUNOASSAY</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C178031"/>
+                </CodeListItem>
+                <Alias Context="nci:ExtCodeID" Name="C85492"/>
+            </CodeList>
+            <CodeList OID="CL.MBTESTCD" Name="Microbiology Test Code" DataType="text" def:StandardOID="STD.SDTMCT">
+                <CodeListItem CodedValue="TPADNA">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Treponema pallidum DNA</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C198341"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="TPLAB">
+                    <Decode>
+                        <TranslatedText xml:lang="en">TPLAB</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="__PLACEHOLDER__"/>
+                </CodeListItem>
+                <Alias Context="nci:ExtCodeID" Name="C120527"/>
+            </CodeList>
+            <CodeList OID="CL.MBTEST" Name="Microbiology Test Name" DataType="text" def:StandardOID="STD.SDTMCT">
+                <CodeListItem CodedValue="Treponema pallidum DNA">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Treponema pallidum DNA</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C198341"/>
+                </CodeListItem>
+                <Alias Context="nci:ExtCodeID" Name="C120528"/>
+            </CodeList>
+            <CodeList OID="CL.MBFTSDTL" Name="Microbiology Findings Test Details" DataType="text"
+                      def:StandardOID="STD.SDTMCT">
+                <CodeListItem CodedValue="DETECTION">
+                    <Decode>
+                        <TranslatedText xml:lang="en">DETECTION</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C174330"/>
+                </CodeListItem>
+                <Alias Context="nci:ExtCodeID" Name="C174225"/>
+            </CodeList>
+            <CodeList OID="CL.DIR" Name="Directionality" DataType="text" def:StandardOID="STD.SDTMCT">
+                <CodeListItem CodedValue="LOWER">
+                    <Decode>
+                        <TranslatedText xml:lang="en">LOWER</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C25309"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="MIDLINE">
+                    <Decode>
+                        <TranslatedText xml:lang="en">MIDLINE</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C81170"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="UPPER">
+                    <Decode>
+                        <TranslatedText xml:lang="en">UPPER</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C25355"/>
+                </CodeListItem>
+                <Alias Context="nci:ExtCodeID" Name="C99074"/>
+            </CodeList>
+            <CodeList OID="CL.AESEV" Name="Severity/Intensity Scale for Adverse Events" DataType="text"
+                      def:StandardOID="STD.SDTMCT">
+                <CodeListItem CodedValue="__PLACEHOLDER__">
+                    <Decode>
+                        <TranslatedText xml:lang="en">__PLACEHOLDER__</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="__PLACEHOLDER__"/>
+                </CodeListItem>
+                <Alias Context="nci:ExtCodeID" Name="C66769"/>
+            </CodeList>
+            <CodeList OID="CL.ACN" Name="Action Taken with Study Treatment" DataType="text"
+                      def:StandardOID="STD.SDTMCT">
+                <CodeListItem CodedValue="__PLACEHOLDER__">
+                    <Decode>
+                        <TranslatedText xml:lang="en">__PLACEHOLDER__</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="__PLACEHOLDER__"/>
+                </CodeListItem>
+                <Alias Context="nci:ExtCodeID" Name="C66767"/>
+            </CodeList>
+            <CodeList OID="CL.OUT" Name="Outcome of Event" DataType="text" def:StandardOID="STD.SDTMCT">
+                <CodeListItem CodedValue="__PLACEHOLDER__">
+                    <Decode>
+                        <TranslatedText xml:lang="en">__PLACEHOLDER__</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="__PLACEHOLDER__"/>
+                </CodeListItem>
+                <Alias Context="nci:ExtCodeID" Name="C66768"/>
+            </CodeList>
+            <CodeList OID="CL.TSPARMCD" Name="Trial Summary Parameter Test Code" DataType="text"
+                      def:StandardOID="STD.SDTMCT">
+                <CodeListItem CodedValue="ADAPT">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Adaptive Design</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C146995"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="AGEMAX">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Planned Maximum Age of Subjects</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C49694"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="AGEMIN">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Planned Minimum Age of Subjects</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C49693"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="COMPTRT">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Comparative Treatment Name</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C68612"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="CRMDUR">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Confirmed Response Minimum Duration</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C98715"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="DOSE">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Dose Level</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C25488"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="DOSFRQ">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Dosing Frequency</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C89081"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="DOSU">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Dose Units</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C73558"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="INDIC">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Indication for Use</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C112038"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="INTMODEL">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Intervention Model</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C98746"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="INTTYPE">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Intervention Type</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C98747"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="NARMS">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Planned Number of Arms</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C98771"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="OBJPRIM">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Study Primary Objective</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C85826"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="OBJSEC">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Study Secondary Objective</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C85827"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="OUTMSPRI">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Primary Outcome Measure</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C98772"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="OUTMSSEC">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Secondary Outcome Measure</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C98781"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="PLANSUB">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Anticipated Enrollment</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C49692"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="PTRTDUR">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Planned Treatment Duration</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C139276"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="ROUTE">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Route of Administration</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C38114"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="SEXPOP">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Sex of Participants</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C49696"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="SPONSOR">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Clinical Study Sponsor</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C70793"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="STYPE">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Study Type</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C142175"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="TBLIND">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Study Blinding Design</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C49658"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="THERAREA">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Therapeutic Area</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C101302"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="TINDTP">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Trial Intent Type</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C49652"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="TITLE">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Official Study Title</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C49802"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="TPHASE">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Trial Phase</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C48281"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="TRT">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Investigational Interventional</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C41161"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="TTYPE">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Trial Scope</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C49660"/>
+                </CodeListItem>
+                <Alias Context="nci:ExtCodeID" Name="C66738"/>
+            </CodeList>
+            <CodeList OID="CL.TSPARM" Name="Trial Summary Parameter Test Name" DataType="text"
+                      def:StandardOID="STD.SDTMCT">
+                <CodeListItem CodedValue="Adaptive Design">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Adaptive Design</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C146995"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Clinical Study Sponsor">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Clinical Study Sponsor</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C70793"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Comparative Treatment Name">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Comparative Treatment Name</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C68612"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Confirmed Response Minimum Duration">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Confirmed Response Minimum Duration</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C98715"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Dose per Administration">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Dose Level</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C25488"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Dose Units">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Dose Units</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C73558"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Dosing Frequency">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Dosing Frequency</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C89081"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Intervention Model">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Intervention Model</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C98746"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Intervention Type">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Intervention Type</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C98747"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Investigational Therapy or Treatment">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Investigational Interventional</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C41161"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Planned Maximum Age of Subjects">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Planned Maximum Age of Subjects</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C49694"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Planned Minimum Age of Subjects">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Planned Minimum Age of Subjects</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C49693"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Planned Number of Arms">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Planned Number of Arms</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C98771"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Planned Number of Subjects">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Anticipated Enrollment</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C49692"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Planned Treatment Duration">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Planned Treatment Duration</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C139276"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Primary Outcome Measure">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Primary Outcome Measure</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C98772"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Route of Administration">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Route of Administration</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C38114"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Secondary Outcome Measure">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Secondary Outcome Measure</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C98781"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Sex of Participants">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Sex of Participants</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C49696"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Study Type">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Study Type</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C142175"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Therapeutic Area">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Therapeutic Area</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C101302"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Trial Blinding Schema">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Study Blinding Design</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C49658"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Trial Disease/Condition Indication">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Indication for Use</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C112038"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Trial Intent Type">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Trial Intent Type</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C49652"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Trial Phase Classification">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Trial Phase</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C48281"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Trial Primary Objective">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Study Primary Objective</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C85826"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Trial Secondary Objective">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Study Secondary Objective</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C85827"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Trial Title">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Official Study Title</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C49802"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="Trial Type">
+                    <Decode>
+                        <TranslatedText xml:lang="en">Trial Scope</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C49660"/>
+                </CodeListItem>
+                <Alias Context="nci:ExtCodeID" Name="C67152"/>
+            </CodeList>
+            <CodeList OID="CL.DICTNAM" Name="Dictionary Name" DataType="text" def:StandardOID="STD.SDTMCT">
+                <CodeListItem CodedValue="__PLACEHOLDER__">
+                    <Decode>
+                        <TranslatedText xml:lang="en">__PLACEHOLDER__</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="__PLACEHOLDER__"/>
+                </CodeListItem>
+                <Alias Context="nci:ExtCodeID" Name="C66788"/>
+            </CodeList>
+            <CodeList OID="CL.IECAT" Name="Category of Inclusion/Exclusion" DataType="text"
+                      def:StandardOID="STD.SDTMCT">
+                <CodeListItem CodedValue="__PLACEHOLDER__">
+                    <Decode>
+                        <TranslatedText xml:lang="en">__PLACEHOLDER__</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="__PLACEHOLDER__"/>
+                </CodeListItem>
+                <Alias Context="nci:ExtCodeID" Name="C66797"/>
+            </CodeList>
+            <CodeList OID="CL.CNTMODE" Name="Mode of Subject Contact" DataType="text" def:StandardOID="STD.SDTMCT">
+                <CodeListItem CodedValue="IN PERSON">
+                    <Decode>
+                        <TranslatedText xml:lang="en">In-Person</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C175574"/>
+                </CodeListItem>
+                <CodeListItem CodedValue="TELEPHONE CALL">
+                    <Decode>
+                        <TranslatedText xml:lang="en">TELEPHONE CALL</TranslatedText>
+                    </Decode>
+                    <Alias Context="nci:ExtCodeID" Name="C171537"/>
+                </CodeListItem>
+                <Alias Context="nci:ExtCodeID" Name="C171445"/>
+            </CodeList>
+            <MethodDef OID="MT.VS.VSORRES.BMI" Name="Derive VSORRES BMI" Type="Computation">
+                <Description>
+                    <TranslatedText xml:lang="en">__PLACEHOLDER__ for derivation of VSORRES BMI</TranslatedText>
+                </Description>
+            </MethodDef>
+            <def:leaf ID="LF.acrf" xlink:href="acrf.pdf">
+                <def:title>Annotated CRF</def:title>
+            </def:leaf>
+        </MetaDataVersion>
+    </Study>
+</ODM>

--- a/src/generators/define/tests/test_itemdef_attributes.py
+++ b/src/generators/define/tests/test_itemdef_attributes.py
@@ -1,0 +1,76 @@
+"""
+Unit tests for Items._add_optional_itemdef_attributes, focused on the
+displayFormat -> SignificantDigits/Length fallback (the issue-78 workaround).
+
+The fallback parses obj['displayFormat'] (e.g. "8.3") into a Length /
+SignificantDigits pair when the study JSON omits them. The hardened version must:
+  * never raise when the format lacks exactly one dot (the old split(".")
+    unpack raised ValueError for "8", "1.2.3", etc.), and
+  * yield ints, matching the type of values that arrive straight from the JSON
+    (the old code left the derived values as strings).
+"""
+import pytest
+
+
+@pytest.fixture
+def add_attrs():
+    import items
+    return items.Items._add_optional_itemdef_attributes
+
+
+class TestExplicitValuesWin:
+    def test_explicit_significant_digits_preserved_as_int(self, add_attrs):
+        # An explicit significantDigits short-circuits the displayFormat fallback.
+        attr = {}
+        add_attrs(attr, {"significantDigits": 2, "dataType": "float", "displayFormat": "8.3"})
+        assert attr["SignificantDigits"] == 2
+        assert isinstance(attr["SignificantDigits"], int)
+
+    def test_explicit_length_not_overridden_by_displayformat(self, add_attrs):
+        attr = {}
+        add_attrs(attr, {"dataType": "float", "length": 10, "displayFormat": "8.3"})
+        assert attr["Length"] == 10            # explicit length wins
+        assert attr["SignificantDigits"] == 3  # sig digits still derived from format
+        assert isinstance(attr["SignificantDigits"], int)
+
+
+class TestDisplayFormatFallback:
+    def test_float_displayformat_yields_int_significant_digits_and_length(self, add_attrs):
+        attr = {}
+        add_attrs(attr, {"dataType": "float", "displayFormat": "8.3"})
+        # Core regression: derived values must be ints, not the strings the old
+        # split(".") branch produced.
+        assert attr["SignificantDigits"] == 3
+        assert isinstance(attr["SignificantDigits"], int)
+        assert attr["Length"] == 8
+        assert isinstance(attr["Length"], int)
+
+    def test_displayformat_without_dot_does_not_raise(self, add_attrs):
+        # "8" has no dot; old split(".") -> single element -> ValueError on unpack.
+        attr = {}
+        add_attrs(attr, {"dataType": "float", "displayFormat": "8"})
+        assert "SignificantDigits" not in attr
+        # The whole-number portion is still recovered into the placeholder slot.
+        assert attr["Length"] == 8
+        assert isinstance(attr["Length"], int)
+
+    def test_displayformat_with_multiple_dots_does_not_raise(self, add_attrs):
+        # "1.2.3" -> old split(".") -> three elements -> ValueError on unpack.
+        attr = {}
+        add_attrs(attr, {"dataType": "float", "displayFormat": "1.2.3"})
+        # "2.3" is not a pure digit string, so no SignificantDigits is derived.
+        assert "SignificantDigits" not in attr
+        assert attr["Length"] == 1
+
+    def test_non_numeric_displayformat_leaves_placeholder(self, add_attrs):
+        attr = {}
+        add_attrs(attr, {"dataType": "float", "displayFormat": "DATE9."})
+        assert "SignificantDigits" not in attr
+        assert attr["Length"] == "__PLACEHOLDER__"  # nothing numeric to recover
+        assert attr["DisplayFormat"] == "DATE9."
+
+    def test_fallback_only_applies_to_float_datatype(self, add_attrs):
+        attr = {}
+        add_attrs(attr, {"dataType": "text", "displayFormat": "8.3"})
+        assert "SignificantDigits" not in attr
+        assert attr["DisplayFormat"] == "8.3"

--- a/src/generators/define/tests/test_itemgroups_subclasses.py
+++ b/src/generators/define/tests/test_itemgroups_subclasses.py
@@ -1,0 +1,314 @@
+"""
+Tests for nested def:SubClass support in itemGroups.ItemGroups.
+
+Define-XML v2.1 represents nested SubClasses as flat siblings under def:Class
+with the ParentClass attribute referencing the parent SubClass's Name. These
+tests verify that the JSON subClasses tree is flattened correctly and that
+nesting is capped at MAX_SUBCLASS_DEPTH levels under Class.
+"""
+import json
+import xml.etree.ElementTree as ET
+
+import pytest
+from odmlib.define_2_1 import model as DEFINE
+
+
+@pytest.fixture
+def item_groups():
+    import itemGroups
+    return itemGroups.ItemGroups()
+
+
+@pytest.fixture
+def fresh_class():
+    return DEFINE.Class(Name="FINDINGS")
+
+
+def _names_and_parents(class_obj):
+    return [(sc.Name, getattr(sc, "ParentClass", None)) for sc in class_obj.SubClass]
+
+
+class TestAppendSubclasses:
+    """Unit tests for the recursive flattener."""
+
+    def test_single_subclass_no_parent(self, item_groups, fresh_class):
+        item_groups._append_subclasses(
+            fresh_class,
+            [{"name": "LABORATORY"}],
+            parent_name=None,
+            depth=1,
+        )
+        assert _names_and_parents(fresh_class) == [("LABORATORY", None)]
+
+    def test_two_level_nesting_assigns_parent(self, item_groups, fresh_class):
+        item_groups._append_subclasses(
+            fresh_class,
+            [{"name": "LAB", "subClasses": [{"name": "CHEM"}]}],
+            parent_name=None,
+            depth=1,
+        )
+        assert _names_and_parents(fresh_class) == [
+            ("LAB", None),
+            ("CHEM", "LAB"),
+        ]
+
+    def test_four_level_chain_fully_emitted(self, item_groups, fresh_class):
+        tree = [
+            {
+                "name": "L1",
+                "subClasses": [
+                    {
+                        "name": "L2",
+                        "subClasses": [
+                            {
+                                "name": "L3",
+                                "subClasses": [{"name": "L4"}],
+                            }
+                        ],
+                    }
+                ],
+            }
+        ]
+        item_groups._append_subclasses(fresh_class, tree, parent_name=None, depth=1)
+        assert _names_and_parents(fresh_class) == [
+            ("L1", None),
+            ("L2", "L1"),
+            ("L3", "L2"),
+            ("L4", "L3"),
+        ]
+
+    def test_fifth_level_is_dropped(self, item_groups, fresh_class):
+        tree = [
+            {
+                "name": "L1",
+                "subClasses": [
+                    {
+                        "name": "L2",
+                        "subClasses": [
+                            {
+                                "name": "L3",
+                                "subClasses": [
+                                    {
+                                        "name": "L4",
+                                        "subClasses": [{"name": "L5_dropped"}],
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            }
+        ]
+        item_groups._append_subclasses(fresh_class, tree, parent_name=None, depth=1)
+        emitted = _names_and_parents(fresh_class)
+        assert ("L5_dropped", "L4") not in emitted
+        assert [name for name, _ in emitted] == ["L1", "L2", "L3", "L4"]
+
+    def test_explicit_parent_overrides_walked_parent(self, item_groups, fresh_class):
+        tree = [
+            {
+                "name": "LAB",
+                "subClasses": [
+                    {"name": "CHEM", "parentClass": "EXPLICIT_PARENT"},
+                ],
+            }
+        ]
+        item_groups._append_subclasses(fresh_class, tree, parent_name=None, depth=1)
+        assert _names_and_parents(fresh_class) == [
+            ("LAB", None),
+            ("CHEM", "EXPLICIT_PARENT"),
+        ]
+
+    def test_empty_and_missing_subclasses_are_safe(self, item_groups, fresh_class):
+        item_groups._append_subclasses(fresh_class, [], parent_name=None, depth=1)
+        assert _names_and_parents(fresh_class) == []
+        item_groups._append_subclasses(
+            fresh_class,
+            [{"name": "ONLY"}, {"name": "NEXT", "subClasses": None}],
+            parent_name=None,
+            depth=1,
+        )
+        assert _names_and_parents(fresh_class) == [("ONLY", None), ("NEXT", None)]
+
+    def test_entry_missing_name_is_skipped(self, item_groups, fresh_class):
+        item_groups._append_subclasses(
+            fresh_class,
+            [{"name": "A"}, {"parentClass": "A"}, {"name": "B"}],
+            parent_name=None,
+            depth=1,
+        )
+        assert _names_and_parents(fresh_class) == [("A", None), ("B", None)]
+
+
+class TestGenerateDatasetIntegration:
+    """Exercise observationClass handling through _generate_dataset."""
+
+    def _make_define_objects(self):
+        return {
+            "ItemGroupDef": [],
+            "ItemDef": [],
+            "ValueListDef": [],
+            "WhereClauseDef": [],
+            "CodeList": [],
+            "MethodDef": [],
+            "CommentDef": [],
+            "leaf": [],
+        }
+
+    def _minimal_dataset(self, observation_class=None):
+        dataset = {
+            "name": "AE",
+            "description": "Adverse Events",
+            "structure": "One record per adverse event per subject",
+            "items": [
+                {
+                    "OID": "IT.AE.STUDYID",
+                    "name": "STUDYID",
+                    "description": "Study Identifier",
+                    "role": "Identifier",
+                    "dataType": "text",
+                    "mandatory": True,
+                }
+            ],
+        }
+        if observation_class is not None:
+            dataset["observationClass"] = observation_class
+        return dataset
+
+    def test_nested_subclasses_emit_flat_siblings(self, item_groups):
+        item_groups.lang = "en"
+        define_objects = self._make_define_objects()
+        dataset = self._minimal_dataset(
+            observation_class={
+                "name": "Findings",
+                "subClasses": [
+                    {
+                        "name": "LAB",
+                        "subClasses": [{"name": "CHEM"}],
+                    }
+                ],
+            }
+        )
+        item_groups._generate_dataset(dataset, define_objects, "en", "LF.acrf")
+        itg = define_objects["ItemGroupDef"][0]
+        assert itg.Class.Name == "FINDINGS"
+        assert _names_and_parents(itg.Class) == [
+            ("LAB", None),
+            ("CHEM", "LAB"),
+        ]
+
+    def test_observation_class_without_subclasses(self, item_groups):
+        item_groups.lang = "en"
+        define_objects = self._make_define_objects()
+        dataset = self._minimal_dataset(observation_class={"name": "Events"})
+        item_groups._generate_dataset(dataset, define_objects, "en", "LF.acrf")
+        itg = define_objects["ItemGroupDef"][0]
+        assert itg.Class.Name == "EVENTS"
+        assert itg.Class.SubClass == []
+
+    def test_no_observation_class_emits_no_class(self, item_groups):
+        item_groups.lang = "en"
+        define_objects = self._make_define_objects()
+        dataset = self._minimal_dataset(observation_class=None)
+        item_groups._generate_dataset(dataset, define_objects, "en", "LF.acrf")
+        itg = define_objects["ItemGroupDef"][0]
+        assert itg.Class is None
+
+
+class TestEndToEndGenerator:
+    """Run the full generator pipeline with nested subClasses in the DDS JSON."""
+
+    def _minimal_dds(self):
+        return {
+            "OID": "MDV.NESTED",
+            "name": "MDV NESTED",
+            "description": "Nested SubClass smoke test",
+            "fileOID": "ODM.NESTED",
+            "creationDateTime": "2026-06-16T00:00:00+00:00",
+            "odmVersion": "1.3.2",
+            "fileType": "Snapshot",
+            "originator": "test",
+            "context": "Other",
+            "defineVersion": "2.1.0",
+            "studyOID": "ODM.NESTED.Study",
+            "studyName": "Nested Study",
+            "studyDescription": "Nested SubClass smoke test",
+            "protocolName": "NESTED",
+            "itemGroups": [
+                {
+                    "OID": "IG.AE",
+                    "name": "AE",
+                    "description": "Adverse Events",
+                    "domain": "AE",
+                    "purpose": "Tabulation",
+                    "structure": "One record per adverse event per subject",
+                    "observationClass": {
+                        "name": "Findings",
+                        "subClasses": [
+                            {
+                                "name": "LAB",
+                                "subClasses": [
+                                    {
+                                        "name": "CHEM",
+                                        "subClasses": [
+                                            {
+                                                "name": "ALK",
+                                                "subClasses": [
+                                                    {
+                                                        "name": "L4",
+                                                        "subClasses": [
+                                                            {"name": "DROPPED"}
+                                                        ],
+                                                    }
+                                                ],
+                                            }
+                                        ],
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                    "items": [
+                        {
+                            "OID": "IT.AE.STUDYID",
+                            "name": "STUDYID",
+                            "description": "Study Identifier",
+                            "role": "Identifier",
+                            "dataType": "text",
+                            "mandatory": True,
+                        }
+                    ],
+                }
+            ],
+        }
+
+    def test_pipeline_emits_flattened_subclasses(self, temp_output_dir):
+        from define_generator import DefineGenerator
+
+        dds_path = temp_output_dir / "nested_subclasses.json"
+        with open(dds_path, "w") as f:
+            json.dump(self._minimal_dds(), f)
+        output_xml = temp_output_dir / "nested_subclasses.xml"
+
+        dg = DefineGenerator(
+            dds_file=str(dds_path),
+            define_file=str(output_xml),
+            log_level="WARNING",
+        )
+        dg.create()
+
+        assert output_xml.exists()
+        tree = ET.parse(output_xml)
+        ns = {"def": "http://www.cdisc.org/ns/def/v2.1"}
+        class_elems = tree.getroot().findall(".//def:Class", ns)
+        assert len(class_elems) == 1
+        class_elem = class_elems[0]
+        assert class_elem.get("Name") == "FINDINGS"
+        sub_elems = class_elem.findall("def:SubClass", ns)
+        assert [(sc.get("Name"), sc.get("ParentClass")) for sc in sub_elems] == [
+            ("LAB", None),
+            ("CHEM", "LAB"),
+            ("ALK", "CHEM"),
+            ("L4", "ALK"),
+        ]
+        assert all(sc.get("Name") != "DROPPED" for sc in sub_elems)

--- a/src/generators/define/tests/test_origin_shapes.py
+++ b/src/generators/define/tests/test_origin_shapes.py
@@ -131,7 +131,8 @@ class TestOriginListShape:
         }
         items_instance._add_origin(item, obj)
         # No predecessor text should have been emitted for the origin.
-        assert item.Origin[0].Description.TranslatedText == []
+        desc = getattr(item.Origin[0], "Description", None)
+        assert desc is None or desc.TranslatedText == []
 
     def test_item_level_pages_not_folded_into_list_shape(self, items_instance):
         item = _new_itemdef()

--- a/src/generators/define/tests/test_origin_shapes.py
+++ b/src/generators/define/tests/test_origin_shapes.py
@@ -1,0 +1,231 @@
+"""
+Tests for ItemDef Origin generation under both the current (dict) and future
+(list-of-dicts) shapes of `origin` in the DDS JSON.
+"""
+import pytest
+
+
+@pytest.fixture
+def items_instance():
+    import items
+    inst = items.Items()
+    inst.lang = "en"
+    inst.acrf = "LF.ACRF"
+    return inst
+
+
+def _new_itemdef():
+    """Mirror the descriptor-bypass pattern used in Items._create_itemdef_object."""
+    from odmlib.define_2_1 import model as DEFINE
+    item = object.__new__(DEFINE.ItemDef)
+    item.__dict__["Origin"] = []
+    return item
+
+
+class TestOriginDictShape:
+    """Today's shape: obj['origin'] is a single dict, predecessor/pages live on obj."""
+
+    def test_single_origin_dict_produces_one_origin(self, items_instance):
+        item = _new_itemdef()
+        obj = {"origin": {"type": "Collected", "source": "Investigator"}}
+        items_instance._add_origin(item, obj)
+        assert len(item.Origin) == 1
+        assert item.Origin[0].Type == "Collected"
+        assert item.Origin[0].Source == "Investigator"
+
+    def test_collected_investigator_attaches_acrf_documentref(self, items_instance):
+        item = _new_itemdef()
+        obj = {"origin": {"type": "Collected", "source": "Investigator"}}
+        items_instance._add_origin(item, obj)
+        assert len(item.Origin[0].DocumentRef) == 1
+        assert item.Origin[0].DocumentRef[0].leafID == "LF.ACRF"
+
+    def test_item_level_predecessor_folded_into_wrapped_origin(self, items_instance):
+        item = _new_itemdef()
+        obj = {
+            "origin": {"type": "Predecessor"},
+            "predecessor": "DM.USUBJID",
+        }
+        items_instance._add_origin(item, obj)
+        assert item.Origin[0].Description.TranslatedText[0]._content == "DM.USUBJID"
+
+    def test_item_level_pages_folded_into_wrapped_origin(self, items_instance):
+        item = _new_itemdef()
+        obj = {
+            "origin": {"type": "Collected", "source": "Investigator"},
+            "pages": "5-7",
+        }
+        items_instance._add_origin(item, obj)
+        page_refs = [
+            pr for dr in item.Origin[0].DocumentRef for pr in dr.PDFPageRef
+            if pr.PageRefs == "5-7"
+        ]
+        assert page_refs
+
+
+class TestOriginDictFolding:
+    """Edge cases in folding item-level predecessor/pages into the single dict shape."""
+
+    def test_predecessor_and_pages_folded_together(self, items_instance):
+        item = _new_itemdef()
+        obj = {
+            "origin": {"type": "Collected", "source": "Investigator"},
+            "predecessor": "DM.USUBJID",
+            "pages": "5-7",
+        }
+        items_instance._add_origin(item, obj)
+        assert item.Origin[0].Description.TranslatedText[0]._content == "DM.USUBJID"
+        page_refs = [
+            pr.PageRefs for dr in item.Origin[0].DocumentRef for pr in dr.PDFPageRef
+        ]
+        assert "5-7" in page_refs
+
+    def test_origin_own_predecessor_wins_over_item_level(self, items_instance):
+        # The wrapped dict already carries a predecessor, so the item-level sibling
+        # must NOT clobber it ("predecessor not in wrapped" guard).
+        item = _new_itemdef()
+        obj = {
+            "origin": {"type": "Predecessor", "predecessor": "ORIGIN.LEVEL"},
+            "predecessor": "ITEM.LEVEL",
+        }
+        items_instance._add_origin(item, obj)
+        assert item.Origin[0].Description.TranslatedText[0]._content == "ORIGIN.LEVEL"
+
+    def test_origin_own_pages_wins_over_item_level(self, items_instance):
+        item = _new_itemdef()
+        obj = {
+            "origin": {"type": "Collected", "source": "Investigator", "pages": "99"},
+            "pages": "5-7",
+        }
+        items_instance._add_origin(item, obj)
+        page_refs = [
+            pr.PageRefs for dr in item.Origin[0].DocumentRef for pr in dr.PDFPageRef
+        ]
+        assert "99" in page_refs
+        assert "5-7" not in page_refs
+
+
+class TestOriginListShape:
+    """Future shape: obj['origin'] is a list of origin dicts, each self-contained."""
+
+    def test_single_element_list_equivalent_to_dict(self, items_instance):
+        item = _new_itemdef()
+        obj = {"origin": [{"type": "Collected", "source": "Investigator"}]}
+        items_instance._add_origin(item, obj)
+        assert len(item.Origin) == 1
+        assert item.Origin[0].Type == "Collected"
+        assert item.Origin[0].Source == "Investigator"
+
+    def test_empty_list_produces_no_origins(self, items_instance):
+        item = _new_itemdef()
+        items_instance._add_origin(item, {"origin": []})
+        assert item.Origin == []
+
+    def test_item_level_predecessor_not_folded_into_list_shape(self, items_instance):
+        # Folding is intentionally dict-shape only. In the list shape each origin is
+        # self-contained, so an item-level predecessor sibling must be ignored.
+        item = _new_itemdef()
+        obj = {
+            "origin": [{"type": "Predecessor"}],
+            "predecessor": "ITEM.LEVEL",
+        }
+        items_instance._add_origin(item, obj)
+        # No predecessor text should have been emitted for the origin.
+        assert item.Origin[0].Description.TranslatedText == []
+
+    def test_item_level_pages_not_folded_into_list_shape(self, items_instance):
+        item = _new_itemdef()
+        obj = {
+            "origin": [{"type": "Predecessor"}],
+            "pages": "5-7",
+        }
+        items_instance._add_origin(item, obj)
+        page_refs = [
+            pr.PageRefs for dr in item.Origin[0].DocumentRef for pr in dr.PDFPageRef
+        ]
+        assert "5-7" not in page_refs
+
+    def test_multiple_origins_produce_multiple_elements(self, items_instance):
+        item = _new_itemdef()
+        obj = {
+            "origin": [
+                {"type": "Derived"},
+                {"type": "Predecessor", "predecessor": "DM.USUBJID"},
+            ]
+        }
+        items_instance._add_origin(item, obj)
+        assert len(item.Origin) == 2
+        assert item.Origin[0].Type == "Derived"
+        assert item.Origin[1].Type == "Predecessor"
+        assert item.Origin[1].Description.TranslatedText[0]._content == "DM.USUBJID"
+
+    def test_per_origin_pages_in_list_shape(self, items_instance):
+        item = _new_itemdef()
+        obj = {
+            "origin": [
+                {"type": "Collected", "source": "Investigator", "pages": "10"},
+                {"type": "Collected", "source": "Investigator", "pages": "20"},
+            ]
+        }
+        items_instance._add_origin(item, obj)
+        # Each origin gets the acrf DocumentRef (Collected/Investigator rule) plus its own pages DocumentRef.
+        page_refs_per_origin = [
+            sorted(pr.PageRefs for dr in o.DocumentRef for pr in dr.PDFPageRef)
+            for o in item.Origin
+        ]
+        assert "10" in page_refs_per_origin[0]
+        assert "20" in page_refs_per_origin[1]
+        assert "10" not in page_refs_per_origin[1]
+
+
+class TestPostProcessingMultiOrigin:
+    """post_processing._add_derived_methods must trigger when ANY origin is Derived."""
+
+    def _build_objects(self, origin_value):
+        from odmlib.define_2_1 import model as DEFINE
+        item = _new_itemdef()
+        item.__dict__["OID"] = "IT.DM.USUBJID"
+
+        items_inst_module = __import__("items")
+        inst = items_inst_module.Items()
+        inst.lang = "en"
+        inst.acrf = "LF.ACRF"
+        inst._add_origin(item, {"origin": origin_value})
+
+        igd = object.__new__(DEFINE.ItemGroupDef)
+        ir = object.__new__(DEFINE.ItemRef)
+        ir.__dict__["ItemOID"] = item.OID
+        ir.__dict__["MethodOID"] = None
+        igd.__dict__["ItemRef"] = [ir]
+
+        return {
+            "ItemDef": [item],
+            "ItemGroupDef": [igd],
+            "ValueListDef": [],
+            "MethodDef": [],
+        }, ir
+
+    def test_derived_in_first_origin_triggers_method(self):
+        import post_processing
+        objects, ir = self._build_objects([{"type": "Derived"}, {"type": "Predecessor"}])
+        post_processing.PostProcessing(objects, is_xpt=False, lang="en").process_define_objects()
+        assert ir.MethodOID is not None
+        assert len(objects["MethodDef"]) == 1
+
+    def test_derived_in_later_origin_still_triggers_method(self):
+        import post_processing
+        objects, ir = self._build_objects(
+            [{"type": "Collected", "source": "Investigator"}, {"type": "Derived"}]
+        )
+        post_processing.PostProcessing(objects, is_xpt=False, lang="en").process_define_objects()
+        assert ir.MethodOID is not None
+        assert len(objects["MethodDef"]) == 1
+
+    def test_no_derived_origin_skips_method(self):
+        import post_processing
+        objects, ir = self._build_objects(
+            [{"type": "Collected", "source": "Investigator"}, {"type": "Predecessor"}]
+        )
+        post_processing.PostProcessing(objects, is_xpt=False, lang="en").process_define_objects()
+        assert ir.MethodOID is None
+        assert objects["MethodDef"] == []


### PR DESCRIPTION
Added minor fixes for issues:
- 100 nested sub-classes
- 98 origins as a list - also opened an issue for DDS to change origin to be a list of dictionaries - generator code now processes both plain dictionaries and a list of dictionaries
- 78 missing significant digits - this requires a USDM file update to point to the latest DSSs - added a workaround in the code for cases where a type=float and displayFormat exists but significant digits is missing, now it will use the displayFormat to create the missing significant digits value 